### PR TITLE
Simplify check whether argument of --prop is a file/property

### DIFF
--- a/src/storm/api/properties.cpp
+++ b/src/storm/api/properties.cpp
@@ -24,10 +24,9 @@ namespace storm {
         }
 
         std::vector<storm::jani::Property> parseProperties(storm::parser::FormulaParser& formulaParser, std::string const& inputString, boost::optional<std::set<std::string>> const& propertyFilter) {
-            // If the given property looks like a file (containing a dot and there exists a file with that name),
-            // we try to parse it as a file, otherwise we assume it's a property.
+            // If the given property is a file, we parse it as a file, otherwise we assume it's a property.
             std::vector<storm::jani::Property> properties;
-            if (inputString.find(".") != std::string::npos && std::ifstream(inputString).good()) {
+            if (std::ifstream(inputString).good()) {
                 properties = formulaParser.parseFromFile(inputString);
             } else {
                 properties = formulaParser.parseFromString(inputString);

--- a/src/storm/api/properties.cpp
+++ b/src/storm/api/properties.cpp
@@ -27,6 +27,7 @@ namespace storm {
             // If the given property is a file, we parse it as a file, otherwise we assume it's a property.
             std::vector<storm::jani::Property> properties;
             if (std::ifstream(inputString).good()) {
+                STORM_LOG_INFO("Loading properties from file: " << inputString << std::endl);
                 properties = formulaParser.parseFromFile(inputString);
             } else {
                 properties = formulaParser.parseFromString(inputString);


### PR DESCRIPTION
Before, the argument to `--prop` was only treated as a file if (a) it exits and (b) contains a dot.

We remove the requirement for a dot and always treat the argument as a file if it exists.

Fixes #25.