### PR TITLE
Quote command-line arguments, warn on empty filter

### DIFF
--- a/src/storm-cli-utilities/cli.cpp
+++ b/src/storm-cli-utilities/cli.cpp
@@ -11,6 +11,7 @@
 
 #include <type_traits>
 #include <ctime>
+#include <boost/algorithm/string/replace.hpp>
 
 #include "storm-cli-utilities/model-handling.h"
 
@@ -63,7 +64,27 @@ namespace storm {
             storm::utility::cleanUp();
             return 0;
         }
-        
+
+        std::string shellQuoteSingleIfNecessary(const std::string& arg) {
+            // quote empty argument
+            if (arg.empty()) {
+                return "''";
+            }
+
+            if (arg.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_./=") != std::string::npos) {
+                // contains potentially unsafe character, needs quoting
+                if (arg.find('\'') != std::string::npos) {
+                    // contains ', we have to replace all ' with '\''
+                    std::string escaped(arg);
+                    boost::replace_all(escaped, "'", "'\\''");
+                    return "'" + escaped + "'";
+                } else {
+                    return "'" + arg + "'";
+                }
+            }
+
+            return arg;
+        }
         
         void printHeader(std::string const& name, const int argc, const char** argv) {
             STORM_PRINT(name << " " << storm::utility::StormVersion::shortVersionString() << std::endl << std::endl);
@@ -71,7 +92,7 @@ namespace storm {
             // "Compute" the command line argument string with which storm was invoked.
             std::stringstream commandStream;
             for (int i = 1; i < argc; ++i) {
-                commandStream << argv[i] << " ";
+                commandStream << " " << shellQuoteSingleIfNecessary(argv[i]);
             }
             
             std::string command = commandStream.str();
@@ -79,7 +100,7 @@ namespace storm {
             if (!command.empty()) {
                 std::time_t result = std::time(nullptr);
                 STORM_PRINT("Date: " << std::ctime(&result));
-                STORM_PRINT("Command line arguments: " << commandStream.str() << std::endl);
+                STORM_PRINT("Command line arguments:" << commandStream.str() << std::endl);
                 STORM_PRINT("Current working directory: " << storm::utility::cli::getCurrentWorkingDirectory() << std::endl << std::endl);
             }
         }

--- a/src/storm-cli-utilities/cli.h
+++ b/src/storm-cli-utilities/cli.h
@@ -11,6 +11,13 @@ namespace storm {
          */
         int64_t process(const int argc, const char** argv);
 
+        /*!
+         * For a command-line argument, returns a quoted version
+         * with single quotes if it contains unsafe characters.
+         * Otherwise, just returns the unquoted argument.
+         */
+        std::string shellQuoteSingleIfNecessary(const std::string& arg);
+
         void printHeader(std::string const& name, const int argc, const char** argv);
         
         void printVersion(std::string const& name);

--- a/src/storm/api/properties.cpp
+++ b/src/storm/api/properties.cpp
@@ -78,6 +78,11 @@ namespace storm {
                 std::set<std::string> const& propertyNameSet = propertyFilter.get();
                 std::vector<storm::jani::Property> result;
                 std::set<std::string> reducedPropertyNames;
+
+                if (propertyNameSet.empty()) {
+                    STORM_LOG_WARN("Filtering all properties.");
+                }
+
                 for (auto const& property : properties) {
                     if (propertyNameSet.find(property.getName()) != propertyNameSet.end()) {
                         result.push_back(property);


### PR DESCRIPTION
With our talent of stumbling onto corner cases, we had the situation where due to some bogus scripting `storm` was called with
`--prop properties.props ''`
i.e., an empty filter, resulting in no output for properties, as all of the properties were filtered away. This was quite difficult to debug, as the
`Command line arguments: ...`
line in the log does not quote the arguments, rendering the empty filter quite invisible.

In this PR, we propose:
 - quote the command line arguments in the log if they contain unsafe characters (or are empty)
 - print a warning if the filter is empty and thus all properties are filtered away.
