### PR TITLE
Fix broken model building when reordering is active

### DIFF
--- a/src/storm/storage/dd/DdManager.cpp
+++ b/src/storm/storage/dd/DdManager.cpp
@@ -431,7 +431,12 @@ namespace storm {
         void DdManager<LibraryType>::triggerReordering() {
             internalDdManager.triggerReordering();
         }
-        
+
+        template<DdType LibraryType>
+        std::unique_ptr<typename DdManager<LibraryType>::DynamicReorderingInhibitor> DdManager<LibraryType>::getDynamicReorderingInhibitor() {
+             return internalDdManager.getDynamicReorderingInhibitor();
+        }
+      
         template<DdType LibraryType>
         std::set<storm::expressions::Variable> DdManager<LibraryType>::getAllMetaVariables() const {
             std::set<storm::expressions::Variable> result;

--- a/src/storm/storage/dd/DdManager.h
+++ b/src/storm/storage/dd/DdManager.h
@@ -30,7 +30,9 @@ namespace storm {
 
             template<DdType LibraryTypePrime, typename ValueType>
             friend class AddIterator;
-            
+
+            typedef typename InternalDdManager<LibraryType>::DynamicReorderingInhibitor DynamicReorderingInhibitor;
+
             /*!
              * Creates an empty manager without any meta variables.
              */
@@ -271,6 +273,12 @@ namespace storm {
             void triggerReordering();
             
             /*!
+             * Requests an object that inhibits dynamic reordering as long as it is
+             * in scope.
+             */
+            std::unique_ptr<DynamicReorderingInhibitor> getDynamicReorderingInhibitor();
+            
+            /*!
              * Retrieves the meta variable with the given name if it exists.
              *
              * @param variable The expression variable associated with the meta variable.
@@ -385,7 +393,7 @@ namespace storm {
             
             // The manager responsible for the variables.
             std::shared_ptr<storm::expressions::ExpressionManager> manager;
-        };
+	};
     }
 }
 

--- a/src/storm/storage/dd/cudd/InternalCuddDdManager.h
+++ b/src/storm/storage/dd/cudd/InternalCuddDdManager.h
@@ -177,12 +177,9 @@ namespace storm {
             cudd::Cudd const& getCuddManager() const;
 
         private:
-            // Helper function to create the BDD whose encodings are below a given bound.
-            DdNodePtr getBddEncodingLessOrEqualThanRec(uint64_t minimalValue, uint64_t maximalValue, uint64_t bound, DdNodePtr cube, uint64_t remainingDdVariables) const;
-
             // Communicate to CUDD whether currently dynamic reordering is allowed.
             void setDynamicReorderingState();
-            
+
             // The manager responsible for the DDs created/modified with this DdManager.
             cudd::Cudd cuddManager;
             

--- a/src/storm/storage/dd/sylvan/InternalSylvanDdManager.cpp
+++ b/src/storm/storage/dd/sylvan/InternalSylvanDdManager.cpp
@@ -242,16 +242,24 @@ namespace storm {
             return false;
         }
         
-        void InternalDdManager<DdType::Sylvan>::allowDynamicReordering(bool) {
-            STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Operation is not supported by sylvan.");
+        void InternalDdManager<DdType::Sylvan>::allowDynamicReordering(bool value) {
+            if (value)
+                STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Dynamic reordering is not supported by sylvan.");
+            // nothing to do for 'false', as reordering is not supported
+            return;
         }
         
         bool InternalDdManager<DdType::Sylvan>::isDynamicReorderingAllowed() const {
-            STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Operation is not supported by sylvan.");
+            return false;
         }
         
         void InternalDdManager<DdType::Sylvan>::triggerReordering() {
-            STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Operation is not supported by sylvan.");
+            STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Reordering is not supported by sylvan.");
+        }
+
+        std::unique_ptr<InternalDdManager<DdType::Sylvan>::DynamicReorderingInhibitor> InternalDdManager<DdType::Sylvan>::getDynamicReorderingInhibitor() const {
+            // return the no-op inhibitor
+            return std::make_unique<DynamicReorderingInhibitor>();
         }
         
         void InternalDdManager<DdType::Sylvan>::debugCheck() const {

--- a/src/storm/storage/dd/sylvan/InternalSylvanDdManager.h
+++ b/src/storm/storage/dd/sylvan/InternalSylvanDdManager.h
@@ -27,7 +27,12 @@ namespace storm {
             
             template<DdType LibraryType, typename ValueType>
             friend class InternalAdd;
-            
+
+            // helper class to inhibit dynamic reordering as long as the object is in scope
+            class DynamicReorderingInhibitor {
+                // empty, nothing to do (no reordering in sylvan at the moment)
+            };
+	    
             /*!
              * Creates a new internal manager for Sylvan DDs.
              */
@@ -126,6 +131,8 @@ namespace storm {
              * Triggers a reordering of the DDs managed by this manager.
              */
             void triggerReordering();
+
+            std::unique_ptr<DynamicReorderingInhibitor> getDynamicReorderingInhibitor() const;
             
             /*!
              * Performs a debug check if available.


### PR DESCRIPTION
This PR fixes an issue with model building, when `--dynreordering` is active.

Consider the following PRISM model (designed to induce variable reordering).
```
dtmc

module m
   s0 : [0..10] init 0;
   s1 : [0..10] init 0;
   s2 : [0..10] init 0;
   s3 : [0..10] init 0;
   s4 : [0..20] init 0;
   tick : [0..1] init 0;

   [] tick=0 & s0<10 -> 1:(tick'=1)&(s0'=s0+1);
   [] tick=0 & s1<10 -> 1:(tick'=1)&(s1'=s1+1);
   [] tick=0 & s2<10 -> 1:(tick'=1)&(s2'=s2+1);
   [] tick=0 & s3<10 -> 1:(tick'=1)&(s3'=s3+1);
   [] tick=1 -> 1:(s4'=mod(s0+s1+s2+s3, 20))&(tick'=0);
endmodule
```

When running with reordering
```
$ bin/storm --prism test-reorder.prism --prop 'P=?[ F s4=6 ]' --engine dd --ddlib cudd --dynreorder
...
--------------------------------------------------------------
Model type:     DTMC (symbolic)
States:         466 (196 nodes)
Transitions:    797 (848 nodes)
Reward Models:  none
Variables:      rows: 6 meta variables (22 DD variables), columns: 6 meta variables (22 DD variables)
Labels:         2
   * deadlock -> 47 state(s) (41 nodes)
   * init -> 48 state(s) (30 nodes)
--------------------------------------------------------------

Model checking property "1": P=? [F (s4 = 6)] ...
Result (for initial states): [0, 1] (range)
Time for model checking: 0.005s.
```
notice the additional, unexpected initial states, leading to a result range of `[0,1]` instead of the normal result `1` (that's also the result without reordering).

This is due to [getBddEncodingLessOrEqualThanRec() in InternalCuddDdManager.cpp](https://github.com/moves-rwth/storm/blob/6fcebed10eafa1c15a3b12f16949d164b36a3d56/src/storm/storage/dd/cudd/InternalCuddDdManager.cpp#L64), which is not compatible with reordering. This leads to the `getRange()` calls for the variables to return bogus results.

This PR contains
 * infrastructure for inhibiting dynamic reordering in certain scopes
 * a variant of `getBddEncodingLessOrEqualThan` that is able to handle reordered DDs

I did some testing and looked at some DOTs for the generated DDs, but having a second pair of eyes on the changes would be good. Especially as there are no test cases for reordering, right?

Design decision: The code now always does some preprocessing to recover the "DD variable index/level to bit in the encoding" before the recursion, even though that is straightforward in the case where no reordering has occurred. From running the tests, it didn't look like it introduces significant overhead, but it could be the case that it's worthwhile to have a special case for that?


Output with PR applied:

```
$ bin/storm --prism test-reorder.prism --prop 'P=?[ F s4=6 ]' --engine dd --ddlib cudd --dynreorder
...
--------------------------------------------------------------
Model type:     DTMC (symbolic)
States:         419 (176 nodes)
Transitions:    797 (848 nodes)
Reward Models:  none
Variables:      rows: 6 meta variables (22 DD variables), columns: 6 meta variables (22 DD variables)
Labels:         2
   * deadlock -> 0 state(s) (1 nodes)
   * init -> 1 state(s) (23 nodes)
--------------------------------------------------------------

Model checking property "1": P=? [F (s4 = 6)] ...
Result (for initial states): 1
Time for model checking: 0.004s.
```