### PR TITLE
Implement manually triggered github actions CI

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -102,7 +102,6 @@ jobs:
         run: sudo docker exec storm bash -c "mkdir /opt/carl/build; cd /opt/carl/build; cmake .. ${CARL_CMAKE_ARGS}"
       - name: Build carl
         run: sudo docker exec storm bash -c "cd /opt/carl/build; make lib_carl -j ${NR_JOBS}"
-        # dummy step for now
       - name: Deploy carl
         run: |
           sudo docker commit storm movesrwth/carl:ci-${{ matrix.debugOrRelease }}
@@ -132,7 +131,6 @@ jobs:
       - name: Run unit tests
         run: sudo docker exec storm bash -c "cd /opt/storm/build; ctest test --output-on-failure"
 
-        # dummy step for now
       - name: Deploy storm
         run: |
           sudo docker commit storm movesrwth/storm:ci-${{ matrix.debugOrRelease }}

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,47 @@
+name: Doxygen
+# Builds and deploys storms doxygen documentation
+
+on:
+  # needed to trigger the workflow manually
+  workflow_dispatch:
+
+env:
+  BASE_IMG: "movesrwth/carl:ci-release"
+  STORM_GIT_URL: "${{ github.server_url }}/${{ github.repository }}.git"
+  STORM_BRANCH: "master"
+  # github runners currently have two cores
+  NR_JOBS: "2"
+
+
+jobs:
+
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Init Docker
+        run: sudo docker run -d -it --name storm --privileged ${BASE_IMG}
+
+        # We should not do partial updates :/
+        # but we need to install some dependencies
+        # Surely we can find a better way to do this at some point
+      - name: Update base system
+        run: |
+          sudo docker exec storm apt-get update
+          sudo docker exec storm apt-get upgrade -qqy
+      - name: install dependencies
+        run: sudo docker exec storm apt-get install -qq -y doxygen graphviz
+      - name: Git clone storm
+        run: sudo docker exec storm git clone --depth 1 --branch $STORM_BRANCH $STORM_GIT_URL /opt/storm
+      - name: Run cmake
+        run: sudo docker exec storm bash -c "mkdir /opt/storm/build; cd /opt/storm/build; cmake .."
+      - name: Build doxygen
+        run: sudo docker exec storm bash -c "cd /opt/storm/build; make doc -j ${NR_JOBS}"
+      - name: Copy doxygen
+        run: sudo docker cp storm:/opt/storm/build/doc/html .
+      - name: Deploy doxygen
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.DOC_DEPLOY_KEY }}
+          publish_dir: ./html
+          external_repository: moves-rwth/storm-doc
+          publish_branch: master


### PR DESCRIPTION
This workflow needs the secret `DOC_DEPLOY_KEY` (an ssh key, like in the documatation of [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages)) to function correctly.
Its needed to push the documentation to an external repo.

This pull request also fixes a typo in buildtest.yml.

The workflow is meant to run on every push, that would be

```
on:
  push:
    branches:
      - master
```