### PR TITLE
Fix for CUDD

### DIFF
--- a/resources/3rdparty/include_cudd.cmake
+++ b/resources/3rdparty/include_cudd.cmake
@@ -36,7 +36,7 @@ endif()
 
 set(CUDD_CXX_COMPILER "${CMAKE_CXX_COMPILER}")
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-	if (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 12.0.0.12000032)
+	if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0.12000032)
 		if (CMAKE_HOST_SYSTEM_VERSION VERSION_GREATER_EQUAL 20.1.0)
 			message(WARNING "There are some known issues compiling CUDD on some setups. We implemented a workaround that mostly works, but if you still have problems compiling CUDD, especially if you do not use the default compiler of your system, please contact the Storm developers.")
 			# The issue is known to occur using the Command Line Tools for XCode 12.2. Apparently, it is fixed in the beta for XCode 12.3. 


### PR DESCRIPTION
After updating the XCode CLT, the problem described in issue moves-rwth#104 occurs again as the shipped AppleClang version (12.0.5.12050022) does not fix the underlying issue. Changing the condition from "equal" to "greater or equal" reestablishes the fix.