### PR TITLE
Remove effectless instantiation after specialization in ConstantsComparator.cpp

### DIFF
--- a/src/storm/utility/ConstantsComparator.cpp
+++ b/src/storm/utility/ConstantsComparator.cpp
@@ -14,17 +14,17 @@ namespace storm {
         bool ConstantsComparator<ValueType>::isOne(ValueType const& value) const {
             return storm::utility::isOne(value);
         }
-        
+
         template<typename ValueType>
         bool ConstantsComparator<ValueType>::isZero(ValueType const& value) const {
             return storm::utility::isZero(value);
         }
-        
+
         template<typename ValueType>
         bool ConstantsComparator<ValueType>::isEqual(ValueType const& value1, ValueType const& value2) const {
             return value1 == value2;
         }
-        
+
         template<typename ValueType>
         bool ConstantsComparator<ValueType>::isConstant(ValueType const& value) const {
             return storm::utility::isConstant(value);
@@ -34,64 +34,64 @@ namespace storm {
         bool ConstantsComparator<ValueType>::isInfinity(ValueType const&) const {
             return false;
         }
-        
+
         template<typename ValueType>
         bool ConstantsComparator<ValueType>::isLess(ValueType const& value1, ValueType const& value2) const {
             return value1 < value2;
         }
-        
+
         ConstantsComparator<float>::ConstantsComparator() : precision(static_cast<float>(storm::settings::getModule<storm::settings::modules::GeneralSettings>().getPrecision())) {
             // Intentionally left empty.
         }
-        
+
         ConstantsComparator<float>::ConstantsComparator(float precision) : precision(precision) {
             // Intentionally left empty.
         }
-        
+
         bool ConstantsComparator<float>::isOne(float const& value) const {
             return std::abs(value - one<float>()) <= precision;
         }
-        
+
         bool ConstantsComparator<float>::isZero(float const& value) const {
             return std::abs(value) <= precision;
         }
-        
+
         bool ConstantsComparator<float>::isEqual(float const& value1, float const& value2) const {
             return std::abs(value1 - value2) <= precision;
         }
-        
+
         bool ConstantsComparator<float>::isConstant(float const&) const {
             return true;
         }
-        
+
         bool ConstantsComparator<float>::isInfinity(float const& value) const {
             return value == storm::utility::infinity<float>();
         }
-        
+
         bool ConstantsComparator<float>::isLess(float const& value1, float const& value2) const {
             return std::abs(value1 - value2) < precision;
         }
-        
+
         ConstantsComparator<double>::ConstantsComparator() : precision(storm::settings::getModule<storm::settings::modules::GeneralSettings>().getPrecision()), relative(false) {
             // Intentionally left empty.
         }
-        
+
         ConstantsComparator<double>::ConstantsComparator(double precision, bool relative) : precision(precision), relative(relative) {
             // Intentionally left empty.
         }
-        
+
         bool ConstantsComparator<double>::isOne(double const& value) const {
             return std::abs(value - one<double>()) <= precision;
         }
-        
+
         bool ConstantsComparator<double>::isZero(double const& value) const {
             return std::abs(value) <= precision;
         }
-        
+
         bool ConstantsComparator<double>::isInfinity(double const& value) const {
             return value == infinity<double>();
         }
-        
+
         bool ConstantsComparator<double>::isEqual(double const& value1, double const& value2) const {
             if (relative) {
                 return value1 == value2 || std::abs(value1 - value2)/std::abs(value1 + value2) <= precision;
@@ -99,61 +99,61 @@ namespace storm {
                 return std::abs(value1 - value2) <= precision;
             }
         }
-        
+
         bool ConstantsComparator<double>::isConstant(double const&) const {
             return true;
         }
-        
+
         bool ConstantsComparator<double>::isLess(double const& value1, double const& value2) const {
             return value1 < value2 - precision;
         }
-        
+
         ConstantsComparator<storm::RationalNumber>::ConstantsComparator() : precision(storm::utility::zero<storm::RationalNumber>()), relative(false) {
             // Intentionally left empty.
         }
-        
+
         ConstantsComparator<storm::RationalNumber>::ConstantsComparator(storm::RationalNumber precision, bool relative) : precision(precision), relative(relative) {
             // Intentionally left empty.
         }
-        
+
         bool ConstantsComparator<storm::RationalNumber>::isOne(storm::RationalNumber const& value) const {
             if (storm::utility::isZero(precision)) {
                 return storm::utility::isOne(value);
             }
             return storm::utility::abs(storm::RationalNumber(value - one<storm::RationalNumber>())) <= precision;
         }
-        
+
         bool ConstantsComparator<storm::RationalNumber>::isZero(storm::RationalNumber const& value) const {
             if (storm::utility::isZero(precision)) {
                 return storm::utility::isZero(value);
             }
             return storm::utility::abs(value) <= precision;
         }
-        
+
         bool ConstantsComparator<storm::RationalNumber>::isEqual(storm::RationalNumber const& value1, storm::RationalNumber const& value2) const {
             if (storm::utility::isZero(precision)) {
                 return value1 == value2;
             }
-            
+
             if (relative) {
                 return value1 == value2 || storm::utility::abs(storm::RationalNumber(value1 - value2))/storm::utility::abs(storm::RationalNumber(value1 + value2)) <= precision;
             } else {
                 return storm::utility::abs(storm::RationalNumber(value1 - value2)) <= precision;
             }
         }
-        
+
         bool ConstantsComparator<storm::RationalNumber>::isConstant(storm::RationalNumber const&) const {
             return true;
         }
-        
+
         bool ConstantsComparator<storm::RationalNumber>::isInfinity(storm::RationalNumber const&) const {
             return false;
         }
-        
+
         bool ConstantsComparator<storm::RationalNumber>::isLess(storm::RationalNumber const& value1, storm::RationalNumber const& value2) const {
             return value1 < value2 - precision;
         }
-        
+
         // Explicit instantiations.
         template class ConstantsComparator<int>;
         template class ConstantsComparator<storm::storage::sparse::state_type>;
@@ -162,11 +162,11 @@ namespace storm {
 #if defined(STORM_HAVE_CLN)
         template class ConstantsComparator<ClnRationalNumber>;
 #endif
-        
+
 #if defined(STORM_HAVE_GMP)
         template class ConstantsComparator<GmpRationalNumber>;
 #endif
-        
+
         template class ConstantsComparator<RationalFunction>;
         template class ConstantsComparator<Polynomial>;
         template class ConstantsComparator<Interval>;

--- a/src/storm/utility/ConstantsComparator.cpp
+++ b/src/storm/utility/ConstantsComparator.cpp
@@ -159,11 +159,11 @@ namespace storm {
         template class ConstantsComparator<storm::storage::sparse::state_type>;
 
 #ifdef STORM_HAVE_CARL
-#if defined(STORM_HAVE_CLN)
+#if defined(STORM_HAVE_CLN) && !defined(STORM_USE_CLN_EA)
         template class ConstantsComparator<ClnRationalNumber>;
 #endif
 
-#if defined(STORM_HAVE_GMP)
+#if defined(STORM_HAVE_GMP) && defined(STORM_USE_CLN_EA)
         template class ConstantsComparator<GmpRationalNumber>;
 #endif
 

--- a/src/storm/utility/ConstantsComparator.h
+++ b/src/storm/utility/ConstantsComparator.h
@@ -11,93 +11,93 @@ namespace storm {
         public:
             // This needs to be in here, otherwise the template specializations are not used properly.
             ConstantsComparator() = default;
-            
+
             bool isOne(ValueType const& value) const;
-            
+
             bool isZero(ValueType const& value) const;
-            
+
             bool isEqual(ValueType const& value1, ValueType const& value2) const;
-            
+
             bool isConstant(ValueType const& value) const;
-            
+
             bool isInfinity(ValueType const& value) const;
-            
+
             bool isLess(ValueType const& value1, ValueType const& value2) const;
         };
-        
+
         // For floats we specialize this class and consider the comparison modulo some predefined precision.
         template<>
         class ConstantsComparator<float> {
         public:
             ConstantsComparator();
-            
+
             ConstantsComparator(float precision);
-            
+
             bool isOne(float const& value) const;
-            
+
             bool isZero(float const& value) const;
-            
+
             bool isEqual(float const& value1, float const& value2) const;
-            
+
             bool isConstant(float const& value) const;
-            
+
             bool isInfinity(float const& value) const;
 
             bool isLess(float const& value1, float const& value2) const;
-            
+
         private:
             // The precision used for comparisons.
             float precision;
         };
-        
+
         // For doubles we specialize this class and consider the comparison modulo some predefined precision.
         template<>
         class ConstantsComparator<double> {
         public:
             ConstantsComparator();
-            
+
             ConstantsComparator(double precision, bool relative = false);
-            
+
             bool isOne(double const& value) const;
-            
+
             bool isZero(double const& value) const;
-            
+
             bool isInfinity(double const& value) const;
-            
+
             bool isEqual(double const& value1, double const& value2) const;
-            
+
             bool isConstant(double const& value) const;
-            
+
             bool isLess(double const& value1, double const& value2) const;
-            
+
         private:
             // The precision used for comparisons.
             double precision;
-            
+
             // Whether to use relative comparison for equality.
             bool relative;
         };
-        
+
         // For rational numbers we specialize this class and consider the comparison modulo some predefined precision.
         template<>
         class ConstantsComparator<storm::RationalNumber> {
         public:
             ConstantsComparator();
-            
+
             ConstantsComparator(storm::RationalNumber precision, bool relative);
-            
+
             bool isOne(storm::RationalNumber const& value) const;
-            
+
             bool isZero(storm::RationalNumber const& value) const;
-            
+
             bool isEqual(storm::RationalNumber const& value1, storm::RationalNumber const& value2) const;
-            
+
             bool isConstant(storm::RationalNumber const& value) const;
-            
+
             bool isInfinity(storm::RationalNumber const& value) const;
-            
+
             bool isLess(storm::RationalNumber const& value1, storm::RationalNumber const& value2) const;
-            
+
         private:
             storm::RationalNumber precision;
             bool relative;


### PR DESCRIPTION
Currently, we instantiate the ConstantComparator with ClnRationalNumber and GmpRationalNumber if we have them. Curiously one of them can be equal to storm::RationalNumber for which we have an explicit specialization.

This pull request proposes to just explicitly instantiate  the ConstantComparator for types that are not storm::RationalNumber.

I suspect that there is a bug hidden in there currently as if one has STORM_HAVE_CLN and also not STORM_USE_CLN_EA then there is an instantiation of ConstantsComparator<ClnRationalNumber> which does not use the explicit specialization as one would expect for a rational.