### PR TITLE
Added model export in .json.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version 1.6.x
 ## Version 1.6.4 (20xx/xx)
 - Added support for PRISM models that use unbounded integer variables.
 - Added an export of check results to json. Use `--exportresult` in the command line interface.
+- Added model export in .json using `--exportjson` which can be used to debug and explore the model.
 - Added computation of steady state probabilities for DTMC/CTMC in the sparse engine. Use `--steadystate` in the command line interface.
 - Implemented parsing and model building of Stochastic multiplayer games (SMGs) in the PRISM language. No model checking implemented, for now.
 - API: Simulation of prism-models 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Version 1.6.x
 ## Version 1.6.4 (20xx/xx)
 - Added support for PRISM models that use unbounded integer variables.
 - Added an export of check results to json. Use `--exportresult` in the command line interface.
-- Added model export in .json using `--exportjson` which can be used to debug and explore the model.
+- Added `--exportbuilt` option that exports the built model in various formats. Deprecates `--io:exportexplicit`, `--io:exportdd` and `--io:exportdot`
+- Added export of built model in .json. which can be used to debug and explore the model.
 - Added computation of steady state probabilities for DTMC/CTMC in the sparse engine. Use `--steadystate` in the command line interface.
 - Implemented parsing and model building of Stochastic multiplayer games (SMGs) in the PRISM language. No model checking implemented, for now.
 - API: Simulation of prism-models 

--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -601,7 +601,7 @@ namespace storm {
             }
 
             if (ioSettings.isExportDdSet()) {
-                storm::api::exportSparseModelAsDrdd(model, ioSettings.getExportDdFilename());
+                storm::api::exportSymbolicModelAsDrdd(model, ioSettings.getExportDdFilename());
             }
 
             if (ioSettings.isExportDotSet()) {

--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -586,6 +586,10 @@ namespace storm {
             if (ioSettings.isExportDotSet()) {
                 storm::api::exportSparseModelAsDot(model, ioSettings.getExportDotFilename(), ioSettings.getExportDotMaxWidth());
             }
+            
+            if (ioSettings.isExportJsonSet()) {
+                storm::api::exportSparseModelAsJson(model, ioSettings.getExportJsonFilename());
+            }
         }
         
         template <storm::dd::DdType DdType, typename ValueType>

--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -575,6 +575,24 @@ namespace storm {
         void exportSparseModel(std::shared_ptr<storm::models::sparse::Model<ValueType>> const& model, SymbolicInput const& input) {
             auto ioSettings = storm::settings::getModule<storm::settings::modules::IOSettings>();
             
+            if (ioSettings.isExportBuildSet()) {
+                switch(ioSettings.getExportBuildFormat()) {
+                    case storm::exporter::ModelExportFormat::Dot:
+                        storm::api::exportSparseModelAsDot(model, ioSettings.getExportBuildFilename(), ioSettings.getExportDotMaxWidth());
+                        break;
+                    case storm::exporter::ModelExportFormat::Drn:
+                        storm::api::exportSparseModelAsDrn(model, ioSettings.getExportBuildFilename(),  input.model ? input.model.get().getParameterNames() : std::vector<std::string>(), !ioSettings.isExplicitExportPlaceholdersDisabled());
+                        break;
+                    case storm::exporter::ModelExportFormat::Json:
+                        storm::api::exportSparseModelAsJson(model, ioSettings.getExportBuildFilename());
+                        break;
+                    default:
+                        STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Exporting sparse models in " << storm::exporter::toString(ioSettings.getExportBuildFormat()) << " format is not supported.");
+                }
+            }
+            
+            // TODO: The following options are depreciated and shall be removed at some point:
+            
             if (ioSettings.isExportExplicitSet()) {
                 storm::api::exportSparseModelAsDrn(model, ioSettings.getExportExplicitFilename(), input.model ? input.model.get().getParameterNames() : std::vector<std::string>(), !ioSettings.isExplicitExportPlaceholdersDisabled());
             }
@@ -586,15 +604,26 @@ namespace storm {
             if (ioSettings.isExportDotSet()) {
                 storm::api::exportSparseModelAsDot(model, ioSettings.getExportDotFilename(), ioSettings.getExportDotMaxWidth());
             }
-            
-            if (ioSettings.isExportJsonSet()) {
-                storm::api::exportSparseModelAsJson(model, ioSettings.getExportJsonFilename());
-            }
         }
         
         template <storm::dd::DdType DdType, typename ValueType>
         void exportDdModel(std::shared_ptr<storm::models::symbolic::Model<DdType, ValueType>> const& model, SymbolicInput const& input) {
             auto ioSettings = storm::settings::getModule<storm::settings::modules::IOSettings>();
+            
+            if (ioSettings.isExportBuildSet()) {
+                switch(ioSettings.getExportBuildFormat()) {
+                    case storm::exporter::ModelExportFormat::Dot:
+                        storm::api::exportSymbolicModelAsDot(model, ioSettings.getExportBuildFilename());
+                        break;
+                    case storm::exporter::ModelExportFormat::Drdd:
+                        storm::api::exportSymbolicModelAsDrdd(model, ioSettings.getExportBuildFilename());
+                        break;
+                    default:
+                        STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Exporting symbolic models in " << storm::exporter::toString(ioSettings.getExportBuildFormat()) << " format is not supported.");
+                }
+            }
+
+            // TODO: The following options are depreciated and shall be removed at some point:
 
             if (ioSettings.isExportExplicitSet()) {
                 STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Exporting in drn format is only supported for sparse models.");

--- a/src/storm/api/export.h
+++ b/src/storm/api/export.h
@@ -44,7 +44,15 @@ namespace storm {
             model->writeDotToStream(stream, maxWidth);
             storm::utility::closeFile(stream);
         }
-
+        
+        template <typename ValueType>
+        void exportSparseModelAsJson(std::shared_ptr<storm::models::sparse::Model<ValueType>> const& model, std::string const& filename) {
+            std::ofstream stream;
+            storm::utility::openFile(filename, stream);
+            model->writeJsonToStream(stream);
+            storm::utility::closeFile(stream);
+        }
+        
         template<storm::dd::DdType Type, typename ValueType>
         void exportSymbolicModelAsDot(std::shared_ptr<storm::models::symbolic::Model<Type,ValueType>> const& model, std::string const& filename) {
             model->writeDotToFile(filename);

--- a/src/storm/api/export.h
+++ b/src/storm/api/export.h
@@ -33,7 +33,7 @@ namespace storm {
         }
 
         template<storm::dd::DdType Type, typename ValueType>
-        void exportSparseModelAsDrdd(std::shared_ptr<storm::models::symbolic::Model<Type,ValueType>> const& model, std::string const& filename) {
+        void exportSymbolicModelAsDrdd(std::shared_ptr<storm::models::symbolic::Model<Type,ValueType>> const& model, std::string const& filename) {
             storm::exporter::explicitExportSymbolicModel(filename, model);
         }
         

--- a/src/storm/io/ModelExportFormat.cpp
+++ b/src/storm/io/ModelExportFormat.cpp
@@ -1,0 +1,39 @@
+#include "ModelExportFormat.h"
+
+#include "storm/utility/macros.h"
+#include "storm/exceptions/InvalidArgumentException.h"
+
+namespace storm {
+namespace exporter {
+
+    ModelExportFormat getModelExportFormatFromString(std::string const& input) {
+        if (input == "dot") {
+            return ModelExportFormat::Dot;
+        } else if (input == "drdd") {
+            return ModelExportFormat::Drdd;
+        } else if (input == "drn") {
+            return ModelExportFormat::Drn;
+        } else if (input == "json") {
+            return ModelExportFormat::Json;
+        }
+        STORM_LOG_THROW(false, storm::exceptions::InvalidArgumentException, "The model export format '" << input << "' does not match any known format.");
+    }
+    
+    std::string toString(ModelExportFormat const& input) {
+        switch(input) {
+            case ModelExportFormat::Dot: return "dot";
+            case ModelExportFormat::Drdd: return "drdd";
+            case ModelExportFormat::Drn: return "drn";
+            case ModelExportFormat::Json: return "json";
+        }
+    }
+    
+    ModelExportFormat getModelExportFormatFromFileExtension(std::string const& filename) {
+        auto pos = filename.find_last_of('.');
+        STORM_LOG_THROW(pos != std::string::npos, storm::exceptions::InvalidArgumentException, "Couldn't detect a file extension from input filename '" << filename << "'.");
+        ++pos;
+        return getModelExportFormatFromString(filename.substr(pos));
+    }
+    
+}
+}

--- a/src/storm/io/ModelExportFormat.h
+++ b/src/storm/io/ModelExportFormat.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <string>
+
+namespace storm {
+namespace exporter {
+
+    enum class ModelExportFormat {
+        Dot,
+        Drdd,
+        Drn,
+        Json
+    };
+    
+    /*!
+     * @return The ModelExportFormat whose string representation matches the given input
+     * @throws InvalidArgumentException if the input doesn't match any known format
+     */
+    ModelExportFormat getModelExportFormatFromString(std::string const& input);
+    
+    /*!
+     * @return The string representation of the given input
+     */
+    std::string toString(ModelExportFormat const& input);
+    
+    /*!
+     * @return The ModelExportFormat whose string representation matches the extension of the given file
+     * @throws InvalidArgumentException if there is no file extension or if it doesn't match any known format.
+     */
+    ModelExportFormat getModelExportFormatFromFileExtension(std::string const& filename);
+}
+}

--- a/src/storm/models/sparse/Model.cpp
+++ b/src/storm/models/sparse/Model.cpp
@@ -473,7 +473,10 @@ namespace storm {
                     storm::json<JsonValueType> stateRewardsJson;
                     for (auto const& rm : rewardModels) {
                         if (rm.second.hasStateRewards()) {
-                            stateRewardsJson[rm.first] = storm::utility::to_string(rm.second.getStateReward(state));
+                            auto r = rm.second.getStateReward(state);
+                            if (!storm::utility::isZero(r)) {
+                                stateRewardsJson[rm.first] = storm::utility::to_string(r);
+                            }
                         }
                     }
                     if (!stateRewardsJson.empty()) {
@@ -502,18 +505,21 @@ namespace storm {
                         if (hasChoiceLabeling()) {
                             auto choiceLabels = getChoiceLabeling().getLabelsOfChoice(choiceIndex);
                             if (!choiceLabels.empty()) {
-                                choiceJson["labels"] = choiceLabels;
+                                choiceJson["lab"] = choiceLabels;
                             }
                         }
-                        choiceJson["index"] = choiceIndex;
+                        choiceJson["id"] = choiceIndex;
                         storm::json<JsonValueType> choiceRewardsJson;
                         for (auto const& rm : rewardModels) {
                             if (rm.second.hasStateActionRewards()) {
-                                choiceRewardsJson[rm.first] = storm::utility::to_string(rm.second.getStateActionReward(choiceIndex));
+                                auto r = rm.second.getStateActionReward(choiceIndex);
+                                if (!storm::utility::isZero(r)) {
+                                    choiceRewardsJson[rm.first] = storm::utility::to_string(r);
+                                }
                             }
                         }
                         if (!choiceRewardsJson.empty()) {
-                            choiceRewardsJson["rewards"] = std::move(choiceRewardsJson);
+                            choiceRewardsJson["rew"] = std::move(choiceRewardsJson);
                         }
                         storm::json<JsonValueType> successors;
                         for (auto const& entry : transitionMatrix.getRow(choiceIndex)) {
@@ -522,7 +528,7 @@ namespace storm {
                             successor["prob"] = storm::utility::to_string<ValueType>(entry.getValue() / rate);
                             successors.push_back(successor);
                         }
-                        choiceJson["successors"] = std::move(successors);
+                        choiceJson["succ"] = std::move(successors);
                         choicesJson.push_back(choiceJson);
                     }
                 stateChoicesJson["c"] = std::move(choicesJson);

--- a/src/storm/models/sparse/Model.cpp
+++ b/src/storm/models/sparse/Model.cpp
@@ -467,9 +467,7 @@ namespace storm {
                         stateChoicesJson["s"] = getStateValuations().template toJson<JsonValueType>(state);
                     }
                     auto labels = getLabelsOfState(state);
-                    if (!labels.empty()) {
-                        stateChoicesJson["lab"] = labels;
-                    }
+                    stateChoicesJson["lab"] = labels;
                     storm::json<JsonValueType> stateRewardsJson;
                     for (auto const& rm : rewardModels) {
                         if (rm.second.hasStateRewards()) {

--- a/src/storm/models/sparse/Model.cpp
+++ b/src/storm/models/sparse/Model.cpp
@@ -11,7 +11,9 @@
 #include "storm/utility/vector.h"
 #include "storm/io/export.h"
 #include "storm/utility/NumberTraits.h"
+#include "storm/adapters/JsonAdapter.h"
 
+#include "storm/exceptions/NotImplementedException.h"
 
 namespace storm {
     namespace models {
@@ -453,7 +455,92 @@ namespace storm {
                     outStream << "}" << std::endl;
                 }
             }
+            
+            template<typename ValueType, typename RewardModelType>
+            void Model<ValueType, RewardModelType>::writeJsonToStream(std::ostream& outStream) const {
+                using JsonValueType = storm::RationalNumber;
+                storm::json<JsonValueType> output;
+                for (uint64_t state = 0; state < getNumberOfStates(); ++state) {
+                    storm::json<JsonValueType> stateChoicesJson;
+                    stateChoicesJson["id"] = state;
+                    if (hasStateValuations()) {
+                        stateChoicesJson["s"] = getStateValuations().template toJson<JsonValueType>(state);
+                    }
+                    auto labels = getLabelsOfState(state);
+                    if (!labels.empty()) {
+                        stateChoicesJson["lab"] = labels;
+                    }
+                    storm::json<JsonValueType> stateRewardsJson;
+                    for (auto const& rm : rewardModels) {
+                        if (rm.second.hasStateRewards()) {
+                            stateRewardsJson[rm.first] = storm::utility::to_string(rm.second.getStateReward(state));
+                        }
+                    }
+                    if (!stateRewardsJson.empty()) {
+                        stateChoicesJson["rew"] = std::move(stateRewardsJson);
+                    }
+                    
+                    auto rate = storm::utility::one<ValueType>();
+                    if (this->isOfType(storm::models::ModelType::Ctmc)) {
+                        auto const& ctmc = this->template as<storm::models::sparse::Ctmc<ValueType, RewardModelType>>();
+                        rate = ctmc->getExitRateVector()[state];
+                        stateChoicesJson["rate"] = storm::utility::to_string(rate);
+                    } else if (this->isOfType(storm::models::ModelType::MarkovAutomaton)) {
+                        auto const& ma = this->template as<storm::models::sparse::MarkovAutomaton<ValueType, RewardModelType>>();
+                        if (ma->isMarkovianState(state)) {
+                            rate = ma->getExitRate(state);
+                            stateChoicesJson["rate"] = storm::utility::to_string(rate); // Only export rate for Markovian states
+                        }
+                    }
+                    
+                    storm::json<JsonValueType> choicesJson;
+                    for (uint64_t choiceIndex = getTransitionMatrix().getRowGroupIndices()[state]; choiceIndex < getTransitionMatrix().getRowGroupIndices()[state + 1]; ++choiceIndex) {
+                        storm::json<JsonValueType> choiceJson;
+                        if (hasChoiceOrigins() && getChoiceOrigins()->getIdentifier(choiceIndex) != getChoiceOrigins()->getIdentifierForChoicesWithNoOrigin()) {
+                            choiceJson["origin"] = getChoiceOrigins()->getChoiceAsJson(choiceIndex);
+                        }
+                        if (hasChoiceLabeling()) {
+                            auto choiceLabels = getChoiceLabeling().getLabelsOfChoice(choiceIndex);
+                            if (!choiceLabels.empty()) {
+                                choiceJson["labels"] = choiceLabels;
+                            }
+                        }
+                        choiceJson["index"] = choiceIndex;
+                        storm::json<JsonValueType> choiceRewardsJson;
+                        for (auto const& rm : rewardModels) {
+                            if (rm.second.hasStateActionRewards()) {
+                                choiceRewardsJson[rm.first] = storm::utility::to_string(rm.second.getStateActionReward(choiceIndex));
+                            }
+                        }
+                        if (!choiceRewardsJson.empty()) {
+                            choiceRewardsJson["rewards"] = std::move(choiceRewardsJson);
+                        }
+                        storm::json<JsonValueType> successors;
+                        for (auto const& entry : transitionMatrix.getRow(choiceIndex)) {
+                            storm::json<JsonValueType> successor;
+                            successor["id"] = entry.getColumn();
+                            successor["prob"] = storm::utility::to_string<ValueType>(entry.getValue() / rate);
+                            successors.push_back(successor);
+                        }
+                        choiceJson["successors"] = std::move(successors);
+                        choicesJson.push_back(choiceJson);
+                    }
+                stateChoicesJson["c"] = std::move(choicesJson);
+                output.push_back(std::move(stateChoicesJson));
+                }
+                outStream << output.dump(4);
+            }
 
+            template<>
+            void Model<double, storm::models::sparse::StandardRewardModel<storm::Interval>>::writeJsonToStream(std::ostream& outStream) const {
+                STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "Json export not implemented for this model type.");
+            }
+            
+            template<>
+            void Model<float>::writeJsonToStream(std::ostream& outStream) const {
+                STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "Json export not implemented for this model type.");
+            }
+            
             template<typename ValueType, typename RewardModelType>
             std::string Model<ValueType, RewardModelType>::additionalDotStateInfo(uint64_t state) const {
                 return "";

--- a/src/storm/models/sparse/Model.cpp
+++ b/src/storm/models/sparse/Model.cpp
@@ -458,6 +458,7 @@ namespace storm {
             
             template<typename ValueType, typename RewardModelType>
             void Model<ValueType, RewardModelType>::writeJsonToStream(std::ostream& outStream) const {
+                STORM_LOG_WARN_COND(this->getNumberOfStates() < 10000 && this->getNumberOfTransitions() < 100000, "Exporting a large model to json. This might take some time and will result in a very large file.");
                 using JsonValueType = storm::RationalNumber;
                 storm::json<JsonValueType> output;
                 for (uint64_t state = 0; state < getNumberOfStates(); ++state) {

--- a/src/storm/models/sparse/Model.h
+++ b/src/storm/models/sparse/Model.h
@@ -352,6 +352,11 @@ namespace storm {
                 virtual void writeDotToStream(std::ostream& outStream, size_t maxWidthLabel = 30, bool includeLabeling = true, storm::storage::BitVector const* subsystem = nullptr, std::vector<ValueType> const* firstValue = nullptr, std::vector<ValueType> const* secondValue = nullptr, std::vector<uint64_t> const* stateColoring = nullptr, std::vector<std::string> const* colors = nullptr, std::vector<uint_fast64_t>* scheduler = nullptr, bool finalizeOutput = true) const;
 
                 /*!
+                 * Writes a JSON representation of the model to the given stream
+                 */
+                virtual void writeJsonToStream(std::ostream& outStream) const;
+                
+                /*!
                  * Retrieves the set of labels attached to the given state.
                  *
                  * @param state The state whose labels to retrieve.

--- a/src/storm/settings/modules/IOSettings.cpp
+++ b/src/storm/settings/modules/IOSettings.cpp
@@ -19,6 +19,7 @@ namespace storm {
             const std::string IOSettings::moduleName = "io";
             const std::string IOSettings::exportDotOptionName = "exportdot";
             const std::string IOSettings::exportDotMaxWidthOptionName = "dot-maxwidth";
+            const std::string IOSettings::exportJsonOptionName = "exportjson";
             const std::string IOSettings::exportExplicitOptionName = "exportexplicit";
             const std::string IOSettings::exportDdOptionName = "exportdd";
             const std::string IOSettings::exportJaniDotOptionName = "exportjanidot";
@@ -60,6 +61,8 @@ namespace storm {
                                 .addArgument(storm::settings::ArgumentBuilder::createStringArgument("filename", "The name of the file to which the model is to be written.").build()).build());
                 this->addOption(storm::settings::OptionBuilder(moduleName, exportDotMaxWidthOptionName, false, "The maximal width for labels in the dot format. For longer lines a linebreak is inserted. Value 0 represents no linebreaks.").setIsAdvanced()
                                 .addArgument(storm::settings::ArgumentBuilder::createUnsignedIntegerArgument("width", "The maximal line width for the dot format. Default is 0 meaning no linebreaks.").setDefaultValueUnsignedInteger(0).build()).build());
+                this->addOption(storm::settings::OptionBuilder(moduleName, exportJsonOptionName, false, "If given, the loaded model will be written to the specified file in json format.").setIsAdvanced()
+                                .addArgument(storm::settings::ArgumentBuilder::createStringArgument("filename", "The name of the file to which the model is to be written.").build()).build());
                 this->addOption(storm::settings::OptionBuilder(moduleName, exportJaniDotOptionName, false, "If given, the loaded jani model will be written to the specified file in the dot format.").setIsAdvanced()
                                         .addArgument(storm::settings::ArgumentBuilder::createStringArgument("filename", "The name of the file to which the model is to be written.").build()).build());
                 this->addOption(storm::settings::OptionBuilder(moduleName, exportCdfOptionName, false, "Exports the cumulative density function for reward bounded properties into a .csv file.").setIsAdvanced().setShortName(exportCdfOptionShortName).addArgument(storm::settings::ArgumentBuilder::createStringArgument("directory", "A path to an existing directory where the cdf files will be stored.").build()).build());
@@ -128,6 +131,14 @@ namespace storm {
 
             size_t IOSettings::getExportDotMaxWidth() const {
                 return this->getOption(exportDotMaxWidthOptionName).getArgumentByName("width").getValueAsUnsignedInteger();
+            }
+            
+            bool IOSettings::isExportJsonSet() const {
+                return this->getOption(exportJsonOptionName).getHasOptionBeenSet();
+            }
+
+            std::string IOSettings::getExportJsonFilename() const {
+                return this->getOption(exportJsonOptionName).getArgumentByName("filename").getValueAsString();
             }
 
             bool IOSettings::isExportJaniDotSet() const {

--- a/src/storm/settings/modules/IOSettings.h
+++ b/src/storm/settings/modules/IOSettings.h
@@ -5,7 +5,7 @@
 
 #include "storm-config.h"
 #include "storm/settings/modules/ModuleSettings.h"
-
+#include "storm/io/ModelExportFormat.h"
 #include "storm/builder/ExplorationOrder.h"
 
 namespace storm {
@@ -45,14 +45,19 @@ namespace storm {
                 size_t getExportDotMaxWidth() const;
 
                 /*!
-                 * Retrieves whether the export-to-json option was set.
+                 * Retrieves whether the exportbuild option was set.
                  */
-                bool isExportJsonSet() const;
+                bool isExportBuildSet() const;
 
                 /*!
                  * Retrieves the name in which to write the model in json format, if export-to-json option was set.
                  */
-                std::string getExportJsonFilename() const;
+                std::string getExportBuildFilename() const;
+                
+                /*!
+                 * Retrieves the specified export format for the exportbuild option
+                 */
+                 storm::exporter::ModelExportFormat getExportBuildFormat() const;
                 
                 /*!
                  * Retrieves whether the export-to-dot option for jani was set.
@@ -369,7 +374,7 @@ namespace storm {
                 // Define the string names of the options as constants.
                 static const std::string exportDotOptionName;
                 static const std::string exportDotMaxWidthOptionName;
-                static const std::string exportJsonOptionName;
+                static const std::string exportBuildOptionName;
                 static const std::string exportJaniDotOptionName;
                 static const std::string exportExplicitOptionName;
                 static const std::string exportDdOptionName;

--- a/src/storm/settings/modules/IOSettings.h
+++ b/src/storm/settings/modules/IOSettings.h
@@ -45,6 +45,16 @@ namespace storm {
                 size_t getExportDotMaxWidth() const;
 
                 /*!
+                 * Retrieves whether the export-to-json option was set.
+                 */
+                bool isExportJsonSet() const;
+
+                /*!
+                 * Retrieves the name in which to write the model in json format, if export-to-json option was set.
+                 */
+                std::string getExportJsonFilename() const;
+                
+                /*!
                  * Retrieves whether the export-to-dot option for jani was set.
                  *
                  * @return True if the export-to-jani-dot option was set.
@@ -359,6 +369,7 @@ namespace storm {
                 // Define the string names of the options as constants.
                 static const std::string exportDotOptionName;
                 static const std::string exportDotMaxWidthOptionName;
+                static const std::string exportJsonOptionName;
                 static const std::string exportJaniDotOptionName;
                 static const std::string exportExplicitOptionName;
                 static const std::string exportDdOptionName;


### PR DESCRIPTION
New option `--exportbuild` exports the state space of the model in various formats: `.ddrd`, `.drn`, `.dot`, and a new `.json` format.
The json export includes transition probabilities, labels, rewards, exit rates, as well as (if included during model building) state valuations, choice labels, and choice origins.
For example, `storm -qvbs stream 0 ""  --exportjson test.json --buildstateval --buildchoiceorig --buildfull --build-all-labels --exact` yields

```json
[
    {
        "c": [
            {
                "id": 0,
                "origin": {
                    "action-label": "buffer",
                    "transitions": [
                        {
                            "action": "buffer",
                            "automaton": "streamingclient",
                            "destinations": [
                                {
                                    "assignments": [
                                        {
                                            "comment": "s <- 1",
                                            "ref": "s",
                                            "value": 1
                                        }
                                    ],
                                    "location": "l"
                                }
                            ],
                            "guard": {
                                "comment": "(((s = 0) & (n < 10)) & (k = n))",
                                "exp": {
                                    "left": {
                                        "left": {
                                            "left": "s",
                                            "op": "=",
                                            "right": 0
                                        },
                                        "op": "∧",
                                        "right": {
                                            "left": "n",
                                            "op": "<",
                                            "right": 10
                                        }
                                    },
                                    "op": "∧",
                                    "right": {
                                        "left": "k",
                                        "op": "=",
                                        "right": "n"
                                    }
                                }
                            },
                            "location": "l"
                        }
                    ]
                },
                "succ": [
                    {
                        "id": 1,
                        "prob": "1"
                    }
                ]
            }
        ],
        "id": 0,
        "lab": [
            "init"
        ],
        "s": {
            "_loc_streamingclient": 0,
            "buffering": 0,
            "done": false,
            "k": 0,
            "n": 0,
            "numrestarts": 0,
            "running": false,
            "s": 0,
            "underrun": false
        }
    },
    {
        "c": [
            {
                "id": 1,
                "origin": {
```