### PR TITLE
Fix init state enumeration

### DIFF
--- a/resources/examples/testfiles/mdp/enumerate_init.jani
+++ b/resources/examples/testfiles/mdp/enumerate_init.jani
@@ -1,0 +1,304 @@
+{
+    "actions": [],
+    "automata": [
+        {
+            "edges": [
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "x <- -(x)",
+                                    "ref": "x",
+                                    "value": {
+                                        "exp": "x",
+                                        "op": "-"
+                                    }
+                                }
+                            ],
+                            "location": "l4"
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(x < 0)",
+                        "exp": {
+                            "left": "x",
+                            "op": "<",
+                            "right": 0
+                        }
+                    },
+                    "location": "l2"
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "b <- true",
+                                    "ref": "b",
+                                    "value": true
+                                }
+                            ],
+                            "location": "l2",
+                            "probability": {
+                                "comment": "1/2",
+                                "exp": 0.5
+                            }
+                        },
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "b <- false",
+                                    "ref": "b",
+                                    "value": false
+                                }
+                            ],
+                            "location": "l1",
+                            "probability": {
+                                "comment": "1/2",
+                                "exp": 0.5
+                            }
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(x > 0)",
+                        "exp": {
+                            "left": "x",
+                            "op": ">",
+                            "right": 0
+                        }
+                    },
+                    "location": "l1"
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "x <- (x - 1)",
+                                    "ref": "x",
+                                    "value": {
+                                        "left": "x",
+                                        "op": "-",
+                                        "right": 1
+                                    }
+                                }
+                            ],
+                            "location": "l1"
+                        }
+                    ],
+                    "guard": {
+                        "comment": "((b = true) & (x > 0))",
+                        "exp": {
+                            "left": "b",
+                            "op": "∧",
+                            "right": {
+                                "left": "x",
+                                "op": ">",
+                                "right": 0
+                            }
+                        }
+                    },
+                    "location": "l2"
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "x <- 1",
+                                    "ref": "x",
+                                    "value": 1
+                                }
+                            ],
+                            "location": "l3"
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(x = 0)",
+                        "exp": {
+                            "left": "x",
+                            "op": "=",
+                            "right": 0
+                        }
+                    },
+                    "location": "l4"
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "x <- -(x)",
+                                    "ref": "x",
+                                    "value": {
+                                        "exp": "x",
+                                        "op": "-"
+                                    }
+                                }
+                            ],
+                            "location": "l2"
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(x < 0)",
+                        "exp": {
+                            "left": "x",
+                            "op": "<",
+                            "right": 0
+                        }
+                    },
+                    "location": "l1"
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "b <- true",
+                                    "ref": "b",
+                                    "value": true
+                                }
+                            ],
+                            "location": "l2",
+                            "probability": {
+                                "comment": "1/2",
+                                "exp": 0.5
+                            }
+                        },
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "b <- false",
+                                    "ref": "b",
+                                    "value": false
+                                }
+                            ],
+                            "location": "l1",
+                            "probability": {
+                                "comment": "1/2",
+                                "exp": 0.5
+                            }
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(x > 0)",
+                        "exp": {
+                            "left": "x",
+                            "op": ">",
+                            "right": 0
+                        }
+                    },
+                    "location": "l2"
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "x <- (x - 1)",
+                                    "ref": "x",
+                                    "value": {
+                                        "left": "x",
+                                        "op": "-",
+                                        "right": 1
+                                    }
+                                }
+                            ],
+                            "location": "l2"
+                        }
+                    ],
+                    "guard": {
+                        "comment": "((b = true) & (x > 0))",
+                        "exp": {
+                            "left": "b",
+                            "op": "∧",
+                            "right": {
+                                "left": "x",
+                                "op": ">",
+                                "right": 0
+                            }
+                        }
+                    },
+                    "location": "l3"
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "x <- 1",
+                                    "ref": "x",
+                                    "value": 1
+                                }
+                            ],
+                            "location": "l3"
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(x = 0)",
+                        "exp": {
+                            "left": "x",
+                            "op": "=",
+                            "right": 0
+                        }
+                    },
+                    "location": "l4"
+                }
+            ],
+            "initial-locations": [
+                "l2",
+				"l4"
+            ],
+            "locations": [
+                {
+                    "name": "l1"
+                },
+                {
+                    "name": "l2"
+                },
+                {
+                    "name": "l3"
+                },
+                {
+                    "name": "l4"
+                }
+            ],
+            "name": "main",
+            "variables": []
+        }
+    ],
+    "constants": [],
+    "features": [
+        "derived-operators"
+    ],
+    "jani-version": 1,
+    "name": "test",
+    "properties": [],
+    "restrict-initial": {
+        "exp": true
+    },
+    "system": {
+        "elements": [
+            {
+                "automaton": "main"
+            }
+        ]
+    },
+    "type": "mdp",
+    "variables": [
+        {
+            "name": "x",
+            "type": {
+                "base": "int",
+                "kind": "bounded",
+                "lower-bound": -7,
+                "upper-bound": 10
+            }
+        },
+        {
+            "name": "b",
+            "type": "bool"
+        }
+    ]
+}

--- a/resources/examples/testfiles/mdp/enumerate_init.prism
+++ b/resources/examples/testfiles/mdp/enumerate_init.prism
@@ -1,0 +1,15 @@
+mdp
+
+module main
+	x : [-7..10];
+	b : bool;
+	
+	[] x < 0 -> 1: (x' = -x);
+	[] x > 0 -> 0.5 : (b' = true) + 0.5 : (b'=false);
+	[] b=true & x > 0 -> 1: (x'= x-1);
+	[] x=0 -> 1 : (x'=1);
+endmodule
+
+init
+true
+endinit

--- a/src/storm/generator/CompressedState.cpp
+++ b/src/storm/generator/CompressedState.cpp
@@ -26,7 +26,7 @@ namespace storm {
                 evaluator.setBooleanValue(booleanVariable.variable, state.get(booleanVariable.bitOffset));
             }
             for (auto const& integerVariable : variableInformation.integerVariables) {
-                evaluator.setIntegerValue(integerVariable.variable, state.getAsInt(integerVariable.bitOffset, integerVariable.bitWidth) + integerVariable.lowerBound);
+                evaluator.setIntegerValue(integerVariable.variable, static_cast<int_fast64_t>(state.getAsInt(integerVariable.bitOffset, integerVariable.bitWidth)) + integerVariable.lowerBound);
             }
         }
         
@@ -43,7 +43,7 @@ namespace storm {
                 result.setBooleanValue(booleanVariable.variable, state.get(booleanVariable.bitOffset));
             }
             for (auto const& integerVariable : variableInformation.integerVariables) {
-                result.setIntegerValue(integerVariable.variable, state.getAsInt(integerVariable.bitOffset, integerVariable.bitWidth) + integerVariable.lowerBound);
+                result.setIntegerValue(integerVariable.variable, static_cast<int_fast64_t>(state.getAsInt(integerVariable.bitOffset, integerVariable.bitWidth)) + integerVariable.lowerBound);
             }
             return result;
         }
@@ -79,7 +79,7 @@ namespace storm {
                 booleanValues.push_back(state.get(booleanVariable.bitOffset));
             }
             for (auto const& integerVariable : variableInformation.integerVariables) {
-                integerValues.push_back(state.getAsInt(integerVariable.bitOffset, integerVariable.bitWidth) + integerVariable.lowerBound);
+                integerValues.push_back(static_cast<int_fast64_t>(state.getAsInt(integerVariable.bitOffset, integerVariable.bitWidth)) + integerVariable.lowerBound);
             }
         }
         
@@ -97,7 +97,7 @@ namespace storm {
                 }
             }
             for (auto const& integerVariable : variableInformation.integerVariables) {
-                assignments.push_back(integerVariable.variable.getName() + "=" + std::to_string(state.getAsInt(integerVariable.bitOffset, integerVariable.bitWidth) + integerVariable.lowerBound));
+                assignments.push_back(integerVariable.variable.getName() + "=" + std::to_string(static_cast<int_fast64_t>(state.getAsInt(integerVariable.bitOffset, integerVariable.bitWidth)) + integerVariable.lowerBound));
             }
             return boost::join(assignments, " & ");
         }

--- a/src/storm/generator/PrismNextStateGenerator.cpp
+++ b/src/storm/generator/PrismNextStateGenerator.cpp
@@ -13,6 +13,7 @@
 #include "storm/solver/SmtSolver.h"
 
 #include "storm/utility/constants.h"
+#include "storm/utility/combinatorics.h"
 #include "storm/utility/macros.h"
 #include "storm/exceptions/InvalidArgumentException.h"
 #include "storm/exceptions/WrongFormatException.h"
@@ -159,58 +160,47 @@ namespace storm {
 
             // If all states are initial, we can simplify the enumeration substantially.
             if (program.hasInitialConstruct() && program.getInitialConstruct().getInitialStatesExpression().isTrue()) {
+                
+                // Create vectors holding all possible values
+                std::vector<std::vector<uint64_t>> allValues;
+                for (auto const& intVar : this->variableInformation.integerVariables) {
+                    STORM_LOG_ASSERT(intVar.lowerBound <= intVar.upperBound, "Expecting variable with non-empty set of possible values.");
+                    // The value of integer variables is shifted so that 0 is always the smallest possible value
+                    allValues.push_back(storm::utility::vector::buildVectorForRange<uint64_t>(static_cast<uint64_t>(0), intVar.upperBound + 1 - intVar.lowerBound));
+                }
+                uint64_t intEndIndex = allValues.size();
+                // For boolean variables we consider the values 0 and 1.
+                allValues.resize(allValues.size() + this->variableInformation.booleanVariables.size(), std::vector<uint64_t>({static_cast<uint64_t>(0), static_cast<uint64_t>(1)}));
+                
+                std::vector<std::vector<uint64_t>::const_iterator> its;
+                std::vector<std::vector<uint64_t>::const_iterator> ites;
+                for (auto const& valVec : allValues) {
+                    its.push_back(valVec.cbegin());
+                    ites.push_back(valVec.cend());
+                }
+                
+                // Now create an initial state for each combination of values
                 CompressedState initialState(this->variableInformation.getTotalBitOffset(true));
-
-                std::vector<int_fast64_t> currentIntegerValues;
-                currentIntegerValues.reserve(this->variableInformation.integerVariables.size());
-                for (auto const& variable : this->variableInformation.integerVariables) {
-                    STORM_LOG_THROW(variable.lowerBound <= variable.upperBound, storm::exceptions::InvalidArgumentException, "Expecting variable with non-empty set of possible values.");
-                    currentIntegerValues.emplace_back(0);
-                    initialState.setFromInt(variable.bitOffset, variable.bitWidth, 0);
-                }
-
-                initialStateIndices.emplace_back(stateToIdCallback(initialState));
-
-                bool done = false;
-                while (!done) {
-                    bool changedBooleanVariable = false;
-                    for (auto const& booleanVariable : this->variableInformation.booleanVariables) {
-                        if (initialState.get(booleanVariable.bitOffset)) {
-                            initialState.set(booleanVariable.bitOffset);
-                            changedBooleanVariable = true;
-                            break;
+                storm::utility::combinatorics::forEach(its, ites,
+                    [this, &initialState, &intEndIndex] (uint64_t index, uint64_t value) {
+                        // Set the value for the variable corresponding to the given index
+                        if (index < intEndIndex) {
+                            // Integer variable
+                            auto const& intVar = this->variableInformation.integerVariables[index];
+                            initialState.setFromInt(intVar.bitOffset, intVar.bitWidth, value);
                         } else {
-                            initialState.set(booleanVariable.bitOffset, false);
+                            // Boolean variable
+                            STORM_LOG_ASSERT(index - intEndIndex < this->variableInformation.booleanVariables.size(), "Unexpected index");
+                            auto const& boolVar = this->variableInformation.booleanVariables[index - intEndIndex];
+                            STORM_LOG_ASSERT(value <= 1u, "Unexpected value for boolean variable.");
+                            initialState.set(boolVar.bitOffset, static_cast<bool>(value));
                         }
-                    }
-
-                    bool changedIntegerVariable = false;
-                    if (changedBooleanVariable) {
-                        initialStateIndices.emplace_back(stateToIdCallback(initialState));
-                    } else {
-                        for (uint64_t integerVariableIndex = 0; integerVariableIndex < this->variableInformation.integerVariables.size(); ++integerVariableIndex) {
-                            auto const& integerVariable = this->variableInformation.integerVariables[integerVariableIndex];
-                            if (currentIntegerValues[integerVariableIndex] < integerVariable.upperBound - integerVariable.lowerBound) {
-                                ++currentIntegerValues[integerVariableIndex];
-                                changedIntegerVariable = true;
-                            } else {
-                                currentIntegerValues[integerVariableIndex] = integerVariable.lowerBound;
-                            }
-                            initialState.setFromInt(integerVariable.bitOffset, integerVariable.bitWidth, currentIntegerValues[integerVariableIndex]);
-
-                            if (changedIntegerVariable) {
-                                break;
-                            }
-                        }
-                    }
-
-                    if (changedIntegerVariable) {
-                        initialStateIndices.emplace_back(stateToIdCallback(initialState));
-                    }
-
-                    done = !changedBooleanVariable && !changedIntegerVariable;
-                }
-
+                    }, [&stateToIdCallback,&initialStateIndices,&initialState] () {
+                        // Register initial state.
+                        StateType id = stateToIdCallback(initialState);
+                        initialStateIndices.push_back(id);
+                        return true; // Keep on exploring
+                    });
                 STORM_LOG_DEBUG("Enumerated " << initialStateIndices.size() << " initial states using brute force enumeration.");
             } else {
                 // Prepare an SMT solver to enumerate all initial states.

--- a/src/storm/utility/combinatorics.h
+++ b/src/storm/utility/combinatorics.h
@@ -57,7 +57,7 @@ namespace storm {
                         break;
                     } else {
                         for (uint64_t j = 0; j <= index; ++j) {
-                            setValueCallback(j, *currentIterators[index]);
+                            setValueCallback(j, *currentIterators[j]);
                         }
                     }
                 }

--- a/src/test/storm/builder/ExplicitJaniModelBuilderTest.cpp
+++ b/src/test/storm/builder/ExplicitJaniModelBuilderTest.cpp
@@ -198,3 +198,11 @@ TEST(ExplicitJaniModelBuilderTest, unassignedVariables) {
     EXPECT_EQ(25ul, model->getNumberOfStates());
     EXPECT_EQ(81ul, model->getNumberOfTransitions());
 }
+
+TEST(ExplicitJaniModelBuilderTest, enumerateInitial) {
+    storm::jani::Model janiModel = storm::api::parseJaniModel(STORM_TEST_RESOURCES_DIR "/mdp/enumerate_init.jani").first;
+    std::shared_ptr<storm::models::sparse::Model<double>> model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
+    EXPECT_EQ(94ul, model->getNumberOfStates());
+    EXPECT_EQ(145ul, model->getNumberOfTransitions());
+    EXPECT_EQ(72ul, model->getInitialStates().getNumberOfSetBits());
+}

--- a/src/test/storm/builder/ExplicitPrismModelBuilderTest.cpp
+++ b/src/test/storm/builder/ExplicitPrismModelBuilderTest.cpp
@@ -101,6 +101,12 @@ TEST(ExplicitPrismModelBuilderTest, Mdp) {
     model = storm::builder::ExplicitModelBuilder<double>(program).build();
     EXPECT_EQ(9ul, model->getNumberOfStates());
     EXPECT_EQ(9ul, model->getNumberOfTransitions());
+ 
+    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/enumerate_init.prism");
+    model = storm::builder::ExplicitModelBuilder<double>(program).build();
+    EXPECT_EQ(36ul, model->getNumberOfStates());
+    EXPECT_EQ(66ul, model->getNumberOfTransitions());
+    EXPECT_EQ(36ul, model->getInitialStates().getNumberOfSetBits());
 }
 
 TEST(ExplicitPrismModelBuilderTest, Ma) {


### PR DESCRIPTION
 Revises enumeration of initial states in Prism and Jani NextStateGenerators.

FYI: The brute-force enumeration of all initial states is triggered whenever every (valid) variable valuation is initial, i.e., if no (non-transient) variable has an initial value and all initial restrictions are `true`.

Apparently, this enumeration was quite broken.

This PR fixes issues with models that contain

- boolean variables, 
- integer variables, where the lower bound is not zero, and
- initial locations other than 0.

There was also an issue with converting `CompressedState`s with negative integer assignments to a string.