### PR TITLE
Fixes related to End Components and Scheduler Extraction

### DIFF
--- a/src/storm/modelchecker/prctl/helper/SparseMdpEndComponentInformation.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpEndComponentInformation.cpp
@@ -380,9 +380,10 @@ namespace storm {
                 }
                 
                 STORM_LOG_ASSERT(notInEcResultIt == fromResult.begin() + this->getNumberOfMaybeStatesNotInEc(), "Mismatching iterators.");
-                // The maybeStates without a choice shall reach maybeStates with a choice with probability 1
-                storm::utility::graph::computeSchedulerProb1E(maybeStates, transitionMatrix, backwardTransitions, maybeStatesWithoutChoice, ~maybeStatesWithoutChoice, scheduler, ecStayChoices);
-
+                // The maybeStates without a choice (i.e. those within an end component for which we do not take an exiting choice) shall reach maybeStates with a choice with probability 1
+                // We have to make sure that choices for non-maybe states are not set
+                auto maybeStatesWithChoice = maybeStates & ~maybeStatesWithoutChoice;
+                storm::utility::graph::computeSchedulerProb1E(maybeStates, transitionMatrix, backwardTransitions, maybeStatesWithoutChoice, maybeStatesWithChoice, scheduler, ecStayChoices);
             }
             
             template class SparseMdpEndComponentInformation<double>;

--- a/src/storm/storage/MaximalEndComponentDecomposition.cpp
+++ b/src/storm/storage/MaximalEndComponentDecomposition.cpp
@@ -83,13 +83,13 @@ namespace storm {
             storm::storage::BitVector includedChoices;
             if (choices) {
                 includedChoices = *choices;
-            } else if (states) {
-                includedChoices = storm::storage::BitVector(transitionMatrix.getRowCount());
-                for (auto state : *states) {
-                    for (uint_fast64_t choice = nondeterministicChoiceIndices[state]; choice < nondeterministicChoiceIndices[state + 1]; ++choice) {
-                        includedChoices.set(choice, true);
-                    }
+                if (states) {
+                    // Exclude choices that originate from or lead to states that are not considered.
+                    includedChoices &= transitionMatrix.getRowFilter(*states, *states);
                 }
+            } else if (states) {
+                // Exclude choices that originate from or lead to states that are not considered.
+                includedChoices = transitionMatrix.getRowFilter(*states, *states);
             } else {
                 includedChoices = storm::storage::BitVector(transitionMatrix.getRowCount(), true);
             }


### PR DESCRIPTION
- Fixed an issue with subsystem MEC decomposition (fixes #167)
The issue happened when there is a choice within the subsystem that leads outside of the subsystem. In the old version, such a choice could contribute to an End Component (simply ignoring transitions that lead to non-subsystem states)
Issue #167 was triggered by the fact that two ECs were considered as one single EC.


- Fixed setting arbitrary scheduler choices for non-MaybeStates