### PR TITLE
Computation of the expected number of times each state in a DTMC/CTMC is visited (sparse engine)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Version 1.6.x
 - Added `--exportbuilt` option that exports the built model in various formats. Deprecates `--io:exportexplicit`, `--io:exportdd` and `--io:exportdot`
 - Added export of built model in .json. which can be used to debug and explore the model.
 - Added computation of steady state probabilities for DTMC/CTMC in the sparse engine. Use `--steadystate` in the command line interface.
+- Added computation of the expected number of times each state in a DTMC/CTMC is visited (sparse engine). Use `--expvisittimes` in the command line interface.
 - Implemented parsing and model building of Stochastic multiplayer games (SMGs) in the PRISM language. No model checking implemented (yet).
 - API: Simulation of prism-models 
 - API: Model-builder takes a callback function to prevent extension of particular actions, prism-to-explicit mapping can be exported

--- a/resources/3rdparty/modernjson/src/json.hpp
+++ b/resources/3rdparty/modernjson/src/json.hpp
@@ -1571,7 +1571,7 @@ Format](http://rfc7159.net/rfc7159)
                 m_type = value_t::string;
                 m_value = string_t("inf");
             }
-            else if (storm::utility::isInfinity(-val))
+            else if (storm::utility::isInfinity<number_float_t>(-val))
             {
                 m_type = value_t::string;
                 m_value = string_t("-inf");

--- a/resources/3rdparty/modernjson/src/json.hpp
+++ b/resources/3rdparty/modernjson/src/json.hpp
@@ -1549,7 +1549,7 @@ Format](http://rfc7159.net/rfc7159)
     disallows NaN values:
     > Numeric values that cannot be represented in the grammar below (such as
     > Infinity and NaN) are not permitted.
-    In case the parameter @a val is not a number, a JSON null value is created
+    In case the parameter @a val is +inf, -inf, or nan, the corresponding string literal is created
     instead.
 
     @complexity Constant.
@@ -1565,11 +1565,21 @@ Format](http://rfc7159.net/rfc7159)
         basic_json(const number_float_t val) noexcept
                 : m_type(value_t::number_float), m_value(val)
         {
-            // replace infinity and NAN by null
+            // replace infinity and NAN by string literals
             if (storm::utility::isInfinity(val))
             {
-                m_type = value_t::null;
-                m_value = json_value();
+                m_type = value_t::string;
+                m_value = string_t("inf");
+            }
+            else if (storm::utility::isInfinity(-val))
+            {
+                m_type = value_t::string;
+                m_value = string_t("-inf");
+            }
+            else if (storm::utility::isNan(val))
+            {
+                m_type = value_t::string;
+                m_value = string_t("nan");
             }
 
             assert_invariant();

--- a/resources/examples/testfiles/ctmc/expvisittimes.jani
+++ b/resources/examples/testfiles/ctmc/expvisittimes.jani
@@ -1,0 +1,860 @@
+{
+    "actions": [],
+    "automata": [
+        {
+            "edges": [
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 1",
+                                    "ref": "s",
+                                    "value": 1
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "((s + 1) / ((s + 1) + (s + 2)))",
+                                "exp": {
+                                    "left": {
+                                        "left": "s",
+                                        "op": "+",
+                                        "right": 1
+                                    },
+                                    "op": "/",
+                                    "right": {
+                                        "left": {
+                                            "left": "s",
+                                            "op": "+",
+                                            "right": 1
+                                        },
+                                        "op": "+",
+                                        "right": {
+                                            "left": 2,
+                                            "op": "+",
+                                            "right": "s"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 2",
+                                    "ref": "s",
+                                    "value": 2
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "((s + 2) / ((s + 1) + (s + 2)))",
+                                "exp": {
+                                    "left": {
+                                        "left": "s",
+                                        "op": "+",
+                                        "right": 2
+                                    },
+                                    "op": "/",
+                                    "right": {
+                                        "left": {
+                                            "left": "s",
+                                            "op": "+",
+                                            "right": 1
+                                        },
+                                        "op": "+",
+                                        "right": {
+                                            "left": 2,
+                                            "op": "+",
+                                            "right": "s"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(s = 0)",
+                        "exp": {
+                            "left": "s",
+                            "op": "=",
+                            "right": 0
+                        }
+                    },
+                    "location": "l",
+                    "rate": {
+                        "comment": "((s + 1) + (s + 2))",
+                        "exp": {
+                            "left": {
+                                "left": "s",
+                                "op": "+",
+                                "right": 1
+                            },
+                            "op": "+",
+                            "right": {
+                                "left": 2,
+                                "op": "+",
+                                "right": "s"
+                            }
+                        }
+                    }
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 0",
+                                    "ref": "s",
+                                    "value": 0
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "((s + 3) / (((s + 3) + (s + 33/10)) + 18/5))",
+                                "exp": {
+                                    "left": {
+                                        "left": "s",
+                                        "op": "+",
+                                        "right": 3
+                                    },
+                                    "op": "/",
+                                    "right": {
+                                        "left": {
+                                            "left": {
+                                                "left": 3.6,
+                                                "op": "+",
+                                                "right": 3
+                                            },
+                                            "op": "+",
+                                            "right": 3.3
+                                        },
+                                        "op": "+",
+                                        "right": {
+                                            "left": "s",
+                                            "op": "+",
+                                            "right": "s"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 1",
+                                    "ref": "s",
+                                    "value": 1
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "((s + 33/10) / (((s + 3) + (s + 33/10)) + 18/5))",
+                                "exp": {
+                                    "left": {
+                                        "left": "s",
+                                        "op": "+",
+                                        "right": 3.3
+                                    },
+                                    "op": "/",
+                                    "right": {
+                                        "left": {
+                                            "left": {
+                                                "left": 3.6,
+                                                "op": "+",
+                                                "right": 3
+                                            },
+                                            "op": "+",
+                                            "right": 3.3
+                                        },
+                                        "op": "+",
+                                        "right": {
+                                            "left": "s",
+                                            "op": "+",
+                                            "right": "s"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 3",
+                                    "ref": "s",
+                                    "value": 3
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "(18/5 / (((s + 3) + (s + 33/10)) + 18/5))",
+                                "exp": {
+                                    "left": 3.6,
+                                    "op": "/",
+                                    "right": {
+                                        "left": {
+                                            "left": {
+                                                "left": 3.6,
+                                                "op": "+",
+                                                "right": 3
+                                            },
+                                            "op": "+",
+                                            "right": 3.3
+                                        },
+                                        "op": "+",
+                                        "right": {
+                                            "left": "s",
+                                            "op": "+",
+                                            "right": "s"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(s = 1)",
+                        "exp": {
+                            "left": "s",
+                            "op": "=",
+                            "right": 1
+                        }
+                    },
+                    "location": "l",
+                    "rate": {
+                        "comment": "(((s + 3) + (s + 33/10)) + 18/5)",
+                        "exp": {
+                            "left": {
+                                "left": {
+                                    "left": 3.6,
+                                    "op": "+",
+                                    "right": 3
+                                },
+                                "op": "+",
+                                "right": 3.3
+                            },
+                            "op": "+",
+                            "right": {
+                                "left": "s",
+                                "op": "+",
+                                "right": "s"
+                            }
+                        }
+                    }
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 2",
+                                    "ref": "s",
+                                    "value": 2
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "(s / (s + (s + 1)))",
+                                "exp": {
+                                    "left": "s",
+                                    "op": "/",
+                                    "right": {
+                                        "left": "s",
+                                        "op": "+",
+                                        "right": {
+                                            "left": "s",
+                                            "op": "+",
+                                            "right": 1
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 4",
+                                    "ref": "s",
+                                    "value": 4
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "((s + 1) / (s + (s + 1)))",
+                                "exp": {
+                                    "left": {
+                                        "left": "s",
+                                        "op": "+",
+                                        "right": 1
+                                    },
+                                    "op": "/",
+                                    "right": {
+                                        "left": "s",
+                                        "op": "+",
+                                        "right": {
+                                            "left": "s",
+                                            "op": "+",
+                                            "right": 1
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(s = 2)",
+                        "exp": {
+                            "left": "s",
+                            "op": "=",
+                            "right": 2
+                        }
+                    },
+                    "location": "l",
+                    "rate": {
+                        "comment": "(s + (s + 1))",
+                        "exp": {
+                            "left": "s",
+                            "op": "+",
+                            "right": {
+                                "left": "s",
+                                "op": "+",
+                                "right": 1
+                            }
+                        }
+                    }
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 2",
+                                    "ref": "s",
+                                    "value": 2
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "(s / ((s + (s + 2)) + (s - 2)))",
+                                "exp": {
+                                    "left": "s",
+                                    "op": "/",
+                                    "right": {
+                                        "left": {
+                                            "left": {
+                                                "left": "s",
+                                                "op": "-",
+                                                "right": 2
+                                            },
+                                            "op": "+",
+                                            "right": 2
+                                        },
+                                        "op": "+",
+                                        "right": {
+                                            "left": "s",
+                                            "op": "+",
+                                            "right": "s"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 4",
+                                    "ref": "s",
+                                    "value": 4
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "((s + 2) / ((s + (s + 2)) + (s - 2)))",
+                                "exp": {
+                                    "left": {
+                                        "left": "s",
+                                        "op": "+",
+                                        "right": 2
+                                    },
+                                    "op": "/",
+                                    "right": {
+                                        "left": {
+                                            "left": {
+                                                "left": "s",
+                                                "op": "-",
+                                                "right": 2
+                                            },
+                                            "op": "+",
+                                            "right": 2
+                                        },
+                                        "op": "+",
+                                        "right": {
+                                            "left": "s",
+                                            "op": "+",
+                                            "right": "s"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 5",
+                                    "ref": "s",
+                                    "value": 5
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "((s - 2) / ((s + (s + 2)) + (s - 2)))",
+                                "exp": {
+                                    "left": {
+                                        "left": "s",
+                                        "op": "-",
+                                        "right": 2
+                                    },
+                                    "op": "/",
+                                    "right": {
+                                        "left": {
+                                            "left": {
+                                                "left": "s",
+                                                "op": "-",
+                                                "right": 2
+                                            },
+                                            "op": "+",
+                                            "right": 2
+                                        },
+                                        "op": "+",
+                                        "right": {
+                                            "left": "s",
+                                            "op": "+",
+                                            "right": "s"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(s = 3)",
+                        "exp": {
+                            "left": "s",
+                            "op": "=",
+                            "right": 3
+                        }
+                    },
+                    "location": "l",
+                    "rate": {
+                        "comment": "((s + (s + 2)) + (s - 2))",
+                        "exp": {
+                            "left": {
+                                "left": {
+                                    "left": "s",
+                                    "op": "-",
+                                    "right": 2
+                                },
+                                "op": "+",
+                                "right": 2
+                            },
+                            "op": "+",
+                            "right": {
+                                "left": "s",
+                                "op": "+",
+                                "right": "s"
+                            }
+                        }
+                    }
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 6",
+                                    "ref": "s",
+                                    "value": 6
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "(s / s)",
+                                "exp": {
+                                    "left": "s",
+                                    "op": "/",
+                                    "right": "s"
+                                }
+                            }
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(s = 4)",
+                        "exp": {
+                            "left": "s",
+                            "op": "=",
+                            "right": 4
+                        }
+                    },
+                    "location": "l",
+                    "rate": {
+                        "comment": "s",
+                        "exp": "s"
+                    }
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 1",
+                                    "ref": "s",
+                                    "value": 1
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "(s / (s + (s / 2)))",
+                                "exp": {
+                                    "left": "s",
+                                    "op": "/",
+                                    "right": {
+                                        "left": "s",
+                                        "op": "+",
+                                        "right": {
+                                            "left": "s",
+                                            "op": "/",
+                                            "right": 2
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 7",
+                                    "ref": "s",
+                                    "value": 7
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "((s / 2) / (s + (s / 2)))",
+                                "exp": {
+                                    "left": {
+                                        "left": "s",
+                                        "op": "/",
+                                        "right": 2
+                                    },
+                                    "op": "/",
+                                    "right": {
+                                        "left": "s",
+                                        "op": "+",
+                                        "right": {
+                                            "left": "s",
+                                            "op": "/",
+                                            "right": 2
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(s = 5)",
+                        "exp": {
+                            "left": "s",
+                            "op": "=",
+                            "right": 5
+                        }
+                    },
+                    "location": "l",
+                    "rate": {
+                        "comment": "(s + (s / 2))",
+                        "exp": {
+                            "left": "s",
+                            "op": "+",
+                            "right": {
+                                "left": "s",
+                                "op": "/",
+                                "right": 2
+                            }
+                        }
+                    }
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 8",
+                                    "ref": "s",
+                                    "value": 8
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "(s / s)",
+                                "exp": {
+                                    "left": "s",
+                                    "op": "/",
+                                    "right": "s"
+                                }
+                            }
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(s = 6)",
+                        "exp": {
+                            "left": "s",
+                            "op": "=",
+                            "right": 6
+                        }
+                    },
+                    "location": "l",
+                    "rate": {
+                        "comment": "s",
+                        "exp": "s"
+                    }
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 7",
+                                    "ref": "s",
+                                    "value": 7
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "(s / s)",
+                                "exp": {
+                                    "left": "s",
+                                    "op": "/",
+                                    "right": "s"
+                                }
+                            }
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(s = 7)",
+                        "exp": {
+                            "left": "s",
+                            "op": "=",
+                            "right": 7
+                        }
+                    },
+                    "location": "l",
+                    "rate": {
+                        "comment": "s",
+                        "exp": "s"
+                    }
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 9",
+                                    "ref": "s",
+                                    "value": 9
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "(s / s)",
+                                "exp": {
+                                    "left": "s",
+                                    "op": "/",
+                                    "right": "s"
+                                }
+                            }
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(s = 8)",
+                        "exp": {
+                            "left": "s",
+                            "op": "=",
+                            "right": 8
+                        }
+                    },
+                    "location": "l",
+                    "rate": {
+                        "comment": "s",
+                        "exp": "s"
+                    }
+                },
+                {
+                    "destinations": [
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 6",
+                                    "ref": "s",
+                                    "value": 6
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "(s / ((s + (s - 2)) + 1))",
+                                "exp": {
+                                    "left": "s",
+                                    "op": "/",
+                                    "right": {
+                                        "left": {
+                                            "left": "s",
+                                            "op": "+",
+                                            "right": {
+                                                "left": "s",
+                                                "op": "-",
+                                                "right": 2
+                                            }
+                                        },
+                                        "op": "+",
+                                        "right": 1
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 8",
+                                    "ref": "s",
+                                    "value": 8
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "((s - 2) / ((s + (s - 2)) + 1))",
+                                "exp": {
+                                    "left": {
+                                        "left": "s",
+                                        "op": "-",
+                                        "right": 2
+                                    },
+                                    "op": "/",
+                                    "right": {
+                                        "left": {
+                                            "left": "s",
+                                            "op": "+",
+                                            "right": {
+                                                "left": "s",
+                                                "op": "-",
+                                                "right": 2
+                                            }
+                                        },
+                                        "op": "+",
+                                        "right": 1
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "assignments": [
+                                {
+                                    "comment": "s <- 9",
+                                    "ref": "s",
+                                    "value": 9
+                                }
+                            ],
+                            "location": "l",
+                            "probability": {
+                                "comment": "(1 / ((s + (s - 2)) + 1))",
+                                "exp": {
+                                    "left": 1,
+                                    "op": "/",
+                                    "right": {
+                                        "left": {
+                                            "left": "s",
+                                            "op": "+",
+                                            "right": {
+                                                "left": "s",
+                                                "op": "-",
+                                                "right": 2
+                                            }
+                                        },
+                                        "op": "+",
+                                        "right": 1
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "guard": {
+                        "comment": "(s = 9)",
+                        "exp": {
+                            "left": "s",
+                            "op": "=",
+                            "right": 9
+                        }
+                    },
+                    "location": "l",
+                    "rate": {
+                        "comment": "((s + (s - 2)) + 1)",
+                        "exp": {
+                            "left": {
+                                "left": "s",
+                                "op": "+",
+                                "right": {
+                                    "left": "s",
+                                    "op": "-",
+                                    "right": 2
+                                }
+                            },
+                            "op": "+",
+                            "right": 1
+                        }
+                    }
+                }
+            ],
+            "initial-locations": [
+                "l"
+            ],
+            "locations": [
+                {
+                    "name": "l"
+                }
+            ],
+            "name": "main",
+            "variables": []
+        }
+    ],
+    "constants": [],
+    "features": [
+        "derived-operators"
+    ],
+    "jani-version": 1,
+    "name": "expvisittimes",
+    "properties": [],
+    "restrict-initial": {
+        "exp": {
+            "left": "s",
+            "op": "<",
+            "right": 3
+        }
+    },
+    "system": {
+        "elements": [
+            {
+                "automaton": "main"
+            }
+        ]
+    },
+    "type": "ctmc",
+    "variables": [
+        {
+            "name": "s",
+            "type": {
+                "base": "int",
+                "kind": "bounded",
+                "lower-bound": 0,
+                "upper-bound": 9
+            }
+        }
+    ]
+}

--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -1089,6 +1089,19 @@ namespace storm {
                 STORM_PRINT((storm::utility::resources::isTerminate() ? "Result till abort: " : "Result: ") << *result << std::endl);
                 STORM_PRINT("Time for model checking: " << watch << "." << std::endl);
             }
+            if (ioSettings.isComputeExpectedVisitingTimesSet()) {
+                storm::utility::Stopwatch watch(true);
+                std::unique_ptr<storm::modelchecker::CheckResult> result;
+                try {
+                    result = storm::api::computeExpectedVisitingTimesWithSparseEngine<ValueType>(mpi.env, sparseModel);
+                } catch (storm::exceptions::BaseException const& ex) {
+                    STORM_LOG_WARN("Cannot compute expected visiting times: " << ex.what());
+                }
+                watch.stop();
+                postprocessingCallback(result);
+                STORM_PRINT((storm::utility::resources::isTerminate() ? "Result till abort: " : "Result: ") << *result << std::endl);
+                STORM_PRINT("Time for model checking: " << watch << "." << std::endl);
+            }
         }
         
         template <storm::dd::DdType DdType, typename ValueType>

--- a/src/storm/api/export.h
+++ b/src/storm/api/export.h
@@ -76,10 +76,10 @@ namespace storm {
             std::ofstream stream;
             storm::utility::openFile(filename, stream);
             if (checkResult->isExplicitQualitativeCheckResult()) {
-                stream << checkResult->asExplicitQualitativeCheckResult().toJson(model->getOptionalStateValuations()).dump(4);
+                stream << checkResult->asExplicitQualitativeCheckResult().toJson(model->getOptionalStateValuations(), model->getStateLabeling()).dump(4);
             } else {
                 STORM_LOG_THROW(checkResult->isExplicitQuantitativeCheckResult(), storm::exceptions::NotSupportedException, "Export of check results is only supported for explicit check results (e.g. in the sparse engine)");
-                stream << checkResult->template asExplicitQuantitativeCheckResult<ValueType>().toJson(model->getOptionalStateValuations()).dump(4);
+                stream << checkResult->template asExplicitQuantitativeCheckResult<ValueType>().toJson(model->getOptionalStateValuations(), model->getStateLabeling()).dump(4);
             }
             storm::utility::closeFile(stream);
         }

--- a/src/storm/api/verification.h
+++ b/src/storm/api/verification.h
@@ -327,6 +327,33 @@ namespace storm {
             return result;
         }
         
+        template<typename ValueType>
+        std::unique_ptr<storm::modelchecker::CheckResult> computeExpectedVisitingTimesWithSparseEngine(storm::Environment const& env, std::shared_ptr<storm::models::sparse::Dtmc<ValueType>> const& dtmc) {
+            std::unique_ptr<storm::modelchecker::CheckResult> result;
+            storm::modelchecker::SparseDtmcPrctlModelChecker<storm::models::sparse::Dtmc<ValueType>> modelchecker(*dtmc);
+            return modelchecker.computeExpectedVisitingTimes(env);
+        }
+
+        template<typename ValueType>
+        std::unique_ptr<storm::modelchecker::CheckResult> computeExpectedVisitingTimesWithSparseEngine(storm::Environment const& env, std::shared_ptr<storm::models::sparse::Ctmc<ValueType>> const& ctmc) {
+            std::unique_ptr<storm::modelchecker::CheckResult> result;
+            storm::modelchecker::SparseCtmcCslModelChecker<storm::models::sparse::Ctmc<ValueType>> modelchecker(*ctmc);
+            return modelchecker.computeExpectedVisitingTimes(env);
+        }
+
+        template<typename ValueType>
+        std::unique_ptr<storm::modelchecker::CheckResult> computeExpectedVisitingTimesWithSparseEngine(storm::Environment const& env, std::shared_ptr<storm::models::sparse::Model<ValueType>> const& model) {
+            std::unique_ptr<storm::modelchecker::CheckResult> result;
+            if (model->getType() == storm::models::ModelType::Dtmc) {
+                result = computeExpectedVisitingTimesWithSparseEngine(env, model->template as<storm::models::sparse::Dtmc<ValueType>>());
+            } else if (model->getType() == storm::models::ModelType::Ctmc) {
+                result = computeExpectedVisitingTimesWithSparseEngine(env, model->template as<storm::models::sparse::Ctmc<ValueType>>());
+            } else {
+                STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Computing expected visiting times for the model type " << model->getType() << " is not supported.");
+            }
+            return result;
+        }
+        
         //
         // Verifying with Hybrid engine
         //

--- a/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.h
+++ b/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.h
@@ -52,7 +52,12 @@ namespace storm {
              * Assumes a uniform distribution over initial states.
              */
             std::unique_ptr<CheckResult> computeSteadyStateDistribution(Environment const& env);
-
+            
+            /*!
+             * Computes for each state the expected number of times we visit that state.
+             * Assumes a uniform distribution over initial states.
+             */
+            std::unique_ptr<CheckResult> computeExpectedVisitingTimes(Environment const& env);
         };
         
     } // namespace modelchecker

--- a/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.cpp
+++ b/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.cpp
@@ -1,0 +1,276 @@
+#include "SparseDeterministicVisitingTimesHelper.h"
+
+#include <algorithm>
+
+#include "storm/environment/solver/SolverEnvironment.h"
+#include "storm/environment/solver/TopologicalSolverEnvironment.h"
+#include "storm/solver/LinearEquationSolver.h"
+
+#include "storm/utility/ProgressMeasurement.h"
+#include "storm/utility/SignalHandler.h"
+#include "storm/utility/constants.h"
+#include "storm/utility/macros.h"
+#include "storm/utility/vector.h"
+
+#include "storm/exceptions/UnmetRequirementException.h"
+
+namespace storm {
+namespace modelchecker {
+namespace helper {
+template<typename ValueType>
+SparseDeterministicVisitingTimesHelper<ValueType>::SparseDeterministicVisitingTimesHelper(storm::storage::SparseMatrix<ValueType> const& transitionMatrix)
+    : _transitionMatrix(transitionMatrix), _exitRates(nullptr), _backwardTransitions(nullptr), _sccDecomposition(nullptr) {
+    // Intentionally left empty
+}
+
+template<typename ValueType>
+SparseDeterministicVisitingTimesHelper<ValueType>::SparseDeterministicVisitingTimesHelper(storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+                                                                                          std::vector<ValueType> const& exitRates)
+    : _transitionMatrix(transitionMatrix), _exitRates(&exitRates), _backwardTransitions(nullptr), _sccDecomposition(nullptr) {
+    // For the CTMC case we assert that the caller actually provided the probabilistic transitions
+    STORM_LOG_ASSERT(this->_transitionMatrix.isProbabilistic(), "Non-probabilistic transitions");
+}
+
+template<typename ValueType>
+void SparseDeterministicVisitingTimesHelper<ValueType>::provideBackwardTransitions(storm::storage::SparseMatrix<ValueType> const& backwardTransitions) {
+    STORM_LOG_WARN_COND(_backwardTransitions == nullptr, "Backward transition matrix was provided but it was already computed or provided before.");
+    _backwardTransitions = &backwardTransitions;
+}
+
+template<typename ValueType>
+void SparseDeterministicVisitingTimesHelper<ValueType>::provideSCCDecomposition(
+    storm::storage::StronglyConnectedComponentDecomposition<ValueType> const& decomposition) {
+    STORM_LOG_WARN_COND(_sccDecomposition == nullptr, "SCC Decomposition was provided but it was already computed or provided before.");
+    _sccDecomposition = &decomposition;
+}
+
+template<typename ValueType>
+std::vector<ValueType> SparseDeterministicVisitingTimesHelper<ValueType>::computeExpectedVisitingTimes(Environment const& env,
+                                                                                                       storm::storage::BitVector const& initialStates) {
+    STORM_LOG_ASSERT(!initialStates.empty(), "provided an empty set of initial states.");
+    STORM_LOG_ASSERT(initialStates.size() == _transitionMatrix.getRowCount(), "Dimension mismatch.");
+    ValueType const p = storm::utility::one<ValueType>() / storm::utility::convertNumber<ValueType, uint64_t>(initialStates.getNumberOfSetBits());
+    std::vector<ValueType> result(_transitionMatrix.getRowCount(), storm::utility::zero<ValueType>());
+    storm::utility::vector::setVectorValues(result, initialStates, p);
+    computeExpectedVisitingTimes(env, result);
+    return result;
+}
+
+template<typename ValueType>
+std::vector<ValueType> SparseDeterministicVisitingTimesHelper<ValueType>::computeExpectedVisitingTimes(Environment const& env, uint64_t initialState) {
+    STORM_LOG_ASSERT(initialState < _transitionMatrix.getRowCount(), "Invalid initial state index.");
+    std::vector<ValueType> result(_transitionMatrix.getRowCount(), storm::utility::zero<ValueType>());
+    result[initialState] = storm::utility::one<ValueType>();
+    computeExpectedVisitingTimes(env, result);
+    return result;
+}
+
+template<typename ValueType>
+std::vector<ValueType> SparseDeterministicVisitingTimesHelper<ValueType>::computeExpectedVisitingTimes(Environment const& env,
+                                                                                                       ValueGetter const& initialStateValueGetter) {
+    std::vector<ValueType> result;
+    result.reserve(_transitionMatrix.getRowCount());
+    for (uint64_t s = 0; s != _transitionMatrix.getRowCount(); ++s) {
+        result.push_back(initialStateValueGetter(s));
+    }
+    computeExpectedVisitingTimes(env, result);
+    return result;
+}
+
+template<typename ValueType>
+void SparseDeterministicVisitingTimesHelper<ValueType>::computeExpectedVisitingTimes(Environment const& env, std::vector<ValueType>& stateValues) {
+    STORM_LOG_ASSERT(stateValues.size() == _transitionMatrix.getRowCount(), "Dimension missmatch.");
+    createBackwardTransitions();
+    createDecomposition(env);
+    auto sccEnv = getEnvironmentForSccSolver(env);
+
+    // Create auxiliary data and lambdas
+    storm::storage::BitVector sccAsBitVector(stateValues.size(), false);
+    auto isLeavingTransition = [&sccAsBitVector](auto const& e) { return !sccAsBitVector.get(e.getColumn()); };
+    auto isExitState = [this, &isLeavingTransition](uint64_t state) {
+        auto row = this->_transitionMatrix.getRow(state);
+        return std::any_of(row.begin(), row.end(), isLeavingTransition);
+    };
+    auto isLeavingTransitionWithNonZeroValue = [&isLeavingTransition, &stateValues](auto const& e) {
+        return isLeavingTransition(e) && !storm::utility::isZero(stateValues[e.getColumn()]);
+    };
+    auto isReachableInState = [this, &isLeavingTransitionWithNonZeroValue, &stateValues](uint64_t state) {
+        if (!storm::utility::isZero(stateValues[state])) {
+            return true;
+        }
+        auto row = this->_backwardTransitions->getRow(state);
+        return std::any_of(row.begin(), row.end(), isLeavingTransitionWithNonZeroValue);
+    };
+
+    // We solve each SCC individually in *forward* topological order
+    storm::utility::ProgressMeasurement progress("sccs");
+    progress.setMaxCount(_sccDecomposition->size());
+    progress.startNewMeasurement(0);
+    uint64_t sccIndex = 0;
+    auto sccIte = std::make_reverse_iterator(_sccDecomposition->begin());
+    for (auto sccIt = std::make_reverse_iterator(_sccDecomposition->end()); sccIt != sccIte; ++sccIt) {
+        auto const& scc = *sccIt;
+        if (scc.size() == 1) {
+            processSingletonScc(*scc.begin(), stateValues);
+        } else {
+            sccAsBitVector.set(scc.begin(), scc.end(), true);
+            if (std::any_of(sccAsBitVector.begin(), sccAsBitVector.end(), isExitState)) {
+                // This is not a BSCC
+                auto sccResult = computeValueForNonTrivialScc(sccEnv, sccAsBitVector, stateValues);
+                storm::utility::vector::setVectorValues(stateValues, sccAsBitVector, sccResult);
+            } else {
+                // This is a BSCC
+                if (std::any_of(sccAsBitVector.begin(), sccAsBitVector.end(), isReachableInState)) {
+                    storm::utility::vector::setVectorValues(stateValues, sccAsBitVector, storm::utility::infinity<ValueType>());
+                } else {
+                    storm::utility::vector::setVectorValues(stateValues, sccAsBitVector, storm::utility::zero<ValueType>());
+                }
+            }
+            sccAsBitVector.clear();
+        }
+        ++sccIndex;
+        progress.updateProgress(sccIndex);
+        if (storm::utility::resources::isTerminate()) {
+            STORM_LOG_WARN("Visiting times computation aborted after analyzing " << sccIndex << "/" << this->_computedSccDecomposition->size() << " SCCs.");
+            break;
+        }
+    }
+
+    if (isContinuousTime()) {
+        // Divide with the exit rates
+        // Since storm::utility::infinity<storm::RationalNumber>() is just set to some big number, we have to treat the infinity-case explicitly.
+        storm::utility::vector::applyPointwise(stateValues, *_exitRates, stateValues, [](ValueType const& xi, ValueType const& yi) -> ValueType {
+            return storm::utility::isInfinity(xi) ? xi : xi / yi;
+        });
+    }
+}
+
+template<typename ValueType>
+bool SparseDeterministicVisitingTimesHelper<ValueType>::isContinuousTime() const {
+    return _exitRates != nullptr;
+}
+
+template<typename ValueType>
+void SparseDeterministicVisitingTimesHelper<ValueType>::createBackwardTransitions() {
+    if (this->_backwardTransitions == nullptr) {
+        this->_computedBackwardTransitions = std::make_unique<storm::storage::SparseMatrix<ValueType>>(_transitionMatrix.transpose());  // will drop zeroes
+        this->_backwardTransitions = this->_computedBackwardTransitions.get();
+    }
+}
+
+template<typename ValueType>
+void SparseDeterministicVisitingTimesHelper<ValueType>::createDecomposition(Environment const& env) {
+    if (this->_sccDecomposition && !this->_sccDecomposition->hasSccDepth() && env.solver().isForceSoundness()) {
+        // We are missing SCCDepths in the given decomposition.
+        STORM_LOG_WARN("Recomputing SCC Decomposition because the currently available  decomposition is computed without SCCDepths.");
+        this->_computedSccDecomposition.reset();
+        this->_sccDecomposition = nullptr;
+    }
+
+    if (this->_sccDecomposition == nullptr) {
+        // The decomposition has not been provided or computed, yet.
+        auto options =
+            storm::storage::StronglyConnectedComponentDecompositionOptions().forceTopologicalSort().computeSccDepths(env.solver().isForceSoundness());
+        this->_computedSccDecomposition =
+            std::make_unique<storm::storage::StronglyConnectedComponentDecomposition<ValueType>>(this->_transitionMatrix, options);
+        this->_sccDecomposition = this->_computedSccDecomposition.get();
+    }
+}
+
+template<typename ValueType>
+storm::Environment SparseDeterministicVisitingTimesHelper<ValueType>::getEnvironmentForSccSolver(storm::Environment const& env) const {
+    storm::Environment subEnv(env);
+    if (env.solver().getLinearEquationSolverType() == storm::solver::EquationSolverType::Topological) {
+        subEnv.solver().setLinearEquationSolverType(env.solver().topological().getUnderlyingEquationSolverType(),
+                                                    env.solver().topological().isUnderlyingEquationSolverTypeSetFromDefault());
+    }
+    if (env.solver().isForceSoundness()) {
+        STORM_LOG_ASSERT(_sccDecomposition->hasSccDepth(), "Did not compute the longest SCC chain size although it is needed.");
+        auto subEnvPrec = subEnv.solver().getPrecisionOfLinearEquationSolver(subEnv.solver().getLinearEquationSolverType());
+        subEnv.solver().setLinearEquationSolverPrecision(static_cast<storm::RationalNumber>(
+            subEnvPrec.first.get() / storm::utility::convertNumber<storm::RationalNumber>(_sccDecomposition->getMaxSccDepth())));
+    }
+    return subEnv;
+}
+
+template<typename ValueType>
+void SparseDeterministicVisitingTimesHelper<ValueType>::processSingletonScc(uint64_t sccState, std::vector<ValueType>& stateValues) const {
+    auto& stateVal = stateValues[sccState];
+    auto forwardRow = _transitionMatrix.getRow(sccState);
+    auto backwardRow = _backwardTransitions->getRow(sccState);
+    if (forwardRow.getNumberOfEntries() == 1 && forwardRow.begin()->getColumn() == sccState) {
+        // This is a BSCC. We only have to check if there is some non-zero "input"
+        if (!storm::utility::isZero(stateVal) || std::any_of(backwardRow.begin(), backwardRow.end(),
+                                                             [&stateValues](auto const& e) { return !storm::utility::isZero(stateValues[e.getColumn()]); })) {
+            stateVal = storm::utility::infinity<ValueType>();
+        }  // else stateVal = 0 (already implied by !(if-condition))
+    } else {
+        // This is not a BSCC. Compute the state value
+        ValueType divisor = storm::utility::one<ValueType>();
+        for (auto const& entry : backwardRow) {
+            if (entry.getColumn() == sccState) {
+                STORM_LOG_ASSERT(!storm::utility::isOne(entry.getValue()), "found a self-loop state. This is not expected");
+                divisor -= entry.getValue();
+            } else {
+                stateVal += entry.getValue() * stateValues[entry.getColumn()];
+            }
+        }
+        stateVal /= divisor;
+    }
+}
+
+template<typename ValueType>
+std::vector<ValueType> SparseDeterministicVisitingTimesHelper<ValueType>::computeValueForNonTrivialScc(storm::Environment const& env,
+                                                                                                       storm::storage::BitVector const& sccAsBitVector,
+                                                                                                       std::vector<ValueType> const& stateValues) const {
+    // Here we assume that the SCC is not a BSCC
+    // Let P be the SCC matrix. We solve the equation system
+    //       x * P + b = x
+    // <=> P^T * x + b = x   <- fixpoint system
+    // <=> (1-P^T) * x = b   <- equation system
+
+    // We need to check if our sound methods like SVI work on this kind of equation system. Most likely not.
+    STORM_LOG_WARN_COND(!env.solver().isForceSoundness(),
+                        "Sound computations are not properly implemented for this computation. You might get incorrect results.");
+    storm::solver::GeneralLinearEquationSolverFactory<ValueType> linearEquationSolverFactory;
+    bool isFixpointFormat = linearEquationSolverFactory.getEquationProblemFormat(env) == storm::solver::LinearEquationSolverProblemFormat::FixedPointSystem;
+
+    // Get the matrix for the equation system
+    auto sccMatrix = _backwardTransitions->getSubmatrix(false, sccAsBitVector, sccAsBitVector, !isFixpointFormat);
+    if (!isFixpointFormat) {
+        sccMatrix.convertToEquationSystem();
+    }
+
+    // Get the vector for the equation system
+    auto sccVector = storm::utility::vector::filterVector(stateValues, sccAsBitVector);
+    auto valIt = sccVector.begin();
+    for (auto sccState : sccAsBitVector) {
+        for (auto const& entry : _backwardTransitions->getRow(sccState)) {
+            if (!sccAsBitVector.get(entry.getColumn())) {
+                (*valIt) += entry.getValue() * stateValues[entry.getColumn()];
+            }
+        }
+        ++valIt;
+    }
+    
+    // Get the solver object and satisfy requirements
+    auto solver = linearEquationSolverFactory.create(env, std::move(sccMatrix));
+    solver->setLowerBound(storm::utility::zero<ValueType>());
+    auto req = solver->getRequirements(env);
+    req.clearLowerBounds();
+    // We could compute upper bounds at this point using techniques from Baier et al. [CAV'17] (https://doi.org/10.1007/978-3-319-63387-9_8)
+    // However, all relevant solvers for this kind of equation system do not require upper bounds.
+    STORM_LOG_THROW(!req.hasEnabledCriticalRequirement(), storm::exceptions::UnmetRequirementException,
+                    "Solver requirements " + req.getEnabledRequirementsAsString() + " not checked.");
+    std::vector<ValueType> eqSysValues(sccVector.size());
+    solver->solveEquations(env, eqSysValues, sccVector);
+    return eqSysValues;
+}
+
+template class SparseDeterministicVisitingTimesHelper<double>;
+template class SparseDeterministicVisitingTimesHelper<storm::RationalNumber>;
+template class SparseDeterministicVisitingTimesHelper<storm::RationalFunction>;
+
+}  // namespace helper
+}  // namespace modelchecker
+}  // namespace storm

--- a/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.cpp
+++ b/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.cpp
@@ -231,7 +231,7 @@ std::vector<ValueType> SparseDeterministicVisitingTimesHelper<ValueType>::comput
 
     // We need to check if our sound methods like SVI work on this kind of equation system. Most likely not.
     STORM_LOG_WARN_COND(!env.solver().isForceSoundness(),
-                        "Sound computations are not properly implemented for this computation. You might get incorrect results.");
+                        "Sound computations are not properly implemented for the computation of expected number of visits in non-trival SCCs. You might get incorrect results.");
     storm::solver::GeneralLinearEquationSolverFactory<ValueType> linearEquationSolverFactory;
     bool isFixpointFormat = linearEquationSolverFactory.getEquationProblemFormat(env) == storm::solver::LinearEquationSolverProblemFormat::FixedPointSystem;
 

--- a/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.cpp
+++ b/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.cpp
@@ -153,7 +153,7 @@ bool SparseDeterministicVisitingTimesHelper<ValueType>::isContinuousTime() const
 template<typename ValueType>
 void SparseDeterministicVisitingTimesHelper<ValueType>::createBackwardTransitions() {
     if (this->_backwardTransitions == nullptr) {
-        this->_computedBackwardTransitions = std::make_unique<storm::storage::SparseMatrix<ValueType>>(_transitionMatrix.transpose());  // will drop zeroes
+        this->_computedBackwardTransitions = std::make_unique<storm::storage::SparseMatrix<ValueType>>(_transitionMatrix.transpose(true, false));  // will drop zeroes
         this->_backwardTransitions = this->_computedBackwardTransitions.get();
     }
 }

--- a/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.h
+++ b/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.h
@@ -111,7 +111,7 @@ class SparseDeterministicVisitingTimesHelper : public SingleValueModelCheckerHel
 
     /*!
      * Solves the equation system for non-trivial SCCs (i.e. non-bottom SCCs with more than 1 state).
-     * @return
+     * @return for each state of the given SCC the expected number of times that state is visited.
      */
     std::vector<ValueType> computeValueForNonTrivialScc(storm::Environment const& env, storm::storage::BitVector const& sccAsBitVector,
                                                         std::vector<ValueType> const& stateValues) const;

--- a/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.h
+++ b/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.h
@@ -1,0 +1,132 @@
+#pragma once
+#include <vector>
+
+#include "storm/modelchecker/helper/SingleValueModelCheckerHelper.h"
+#include "storm/storage/BitVector.h"
+#include "storm/storage/SparseMatrix.h"
+#include "storm/storage/StronglyConnectedComponentDecomposition.h"
+
+namespace storm {
+class Environment;
+
+namespace modelchecker {
+namespace helper {
+
+/*!
+ * Helper class for computing for each state the expected number of times to visit that state assuming a given initial distribution.
+ * @tparam ValueType the type a value can have
+ */
+template<typename ValueType>
+class SparseDeterministicVisitingTimesHelper : public SingleValueModelCheckerHelper<ValueType, storm::models::ModelRepresentation::Sparse> {
+   public:
+    /*!
+     * Function mapping from indices to values
+     */
+    typedef std::function<ValueType(uint64_t)> ValueGetter;
+
+    /*!
+     * Initializes the helper for a DTMC
+     */
+    SparseDeterministicVisitingTimesHelper(storm::storage::SparseMatrix<ValueType> const& transitionMatrix);
+
+    /*!
+     * Initializes the helper for a CTMC
+     */
+    SparseDeterministicVisitingTimesHelper(storm::storage::SparseMatrix<ValueType> const& transitionMatrix, std::vector<ValueType> const& exitRates);
+
+    /*!
+     * Provides the backward transitions that can be used during the computation.
+     * Providing the backward transitions is optional. If they are not provided, they will be computed internally.
+     * Be aware that this class does not take ownership, i.e. the caller has to make sure that the reference to the given matrix remains valid.
+     */
+    void provideBackwardTransitions(storm::storage::SparseMatrix<ValueType> const& backwardTransitions);
+
+    /*!
+     * Provides the decomposition into SCCs that can be used during the computation.
+     * Providing the decomposition is optional. If it is not provided, they will be computed internally.
+     * Be aware that this class does not take ownership, i.e. the caller has to make sure that the reference to the decomposition remains valid.
+     * The given decomposition shall
+     * * include naive SCCs,
+     * * be topologically sorted, and
+     * * (if sound model checking is requested) shall contain sccDepths
+     */
+    void provideSCCDecomposition(storm::storage::StronglyConnectedComponentDecomposition<ValueType> const& decomposition);
+
+    /*!
+     * Computes for each state the expected number of times we are visiting that state assuming the given initial state(s).
+     *
+     * @note In contrast to most other queries, this method assumes a uniform distribution over the provided initial state.
+     *
+     * @return a value for each state
+     */
+    std::vector<ValueType> computeExpectedVisitingTimes(Environment const& env, storm::storage::BitVector const& initialStates);
+
+    /*!
+     * Computes for each state the expected number of times we are visiting that state assuming the given initial state.
+     *
+     * @return a value for each state
+     */
+    std::vector<ValueType> computeExpectedVisitingTimes(Environment const& env, uint64_t initialState);
+
+    /*!
+     * Computes for each state the expected number of times we are visiting that state assuming the given initial state probabilities
+     * @param initialStateValueGetter function that returns for each state the initial value (probability) for that state.
+     * The values can actually sum up to something different than 1 but should be non-negative.
+     */
+    std::vector<ValueType> computeExpectedVisitingTimes(Environment const& env, ValueGetter const& initialStateValueGetter);
+
+    /*!
+     * Computes for each state the expected number of times we are visiting that state assuming the given initial state(s).
+     * @pre parameter stateValues vector contains for each state the initial value (probability) for that state.
+     * The values can actually sum up to something different than 1 but should be non-negative.
+     * @post parameter stateValues contains the desired values
+     */
+    void computeExpectedVisitingTimes(Environment const& env, std::vector<ValueType>& stateValues);
+
+   private:
+    /*!
+     * @return true iff this is a computation on a continuous time model (i.e. CTMC, MA)
+     */
+    bool isContinuousTime() const;
+
+    /*!
+     * @post _backwardTransitions points to the backward transitions
+     */
+    void createBackwardTransitions();
+
+    /*!
+     * @post _sccDecomposition points to an SCC decomposition
+     */
+    void createDecomposition(Environment const& env);
+
+    /*!
+     * @return the environment used when solving non-trivial SCCs.
+     */
+    storm::Environment getEnvironmentForSccSolver(storm::Environment const& env) const;
+
+    /*!
+     * Processes (bottom or non-bottom SCCs consisting of a single state). The resulting value is directly inserted into stateValues
+     */
+    void processSingletonScc(uint64_t sccState, std::vector<ValueType>& stateValues) const;
+
+    /*!
+     * Solves the equation system for non-trivial SCCs (i.e. non-bottom SCCs with more than 1 state).
+     * @return
+     */
+    std::vector<ValueType> computeValueForNonTrivialScc(storm::Environment const& env, storm::storage::BitVector const& sccAsBitVector,
+                                                        std::vector<ValueType> const& stateValues) const;
+
+    storm::storage::SparseMatrix<ValueType> const& _transitionMatrix;
+    std::vector<ValueType> const* _exitRates;
+
+    storm::storage::SparseMatrix<ValueType> const* _backwardTransitions;
+    std::unique_ptr<storm::storage::SparseMatrix<ValueType>> _computedBackwardTransitions;
+
+    storm::storage::StronglyConnectedComponentDecomposition<ValueType> const* _sccDecomposition;
+    std::unique_ptr<storm::storage::StronglyConnectedComponentDecomposition<ValueType>> _computedSccDecomposition;
+};
+
+
+}  // namespace helper
+}  // namespace modelchecker
+}  // namespace storm

--- a/src/storm/modelchecker/helper/infinitehorizon/SparseDeterministicInfiniteHorizonHelper.cpp
+++ b/src/storm/modelchecker/helper/infinitehorizon/SparseDeterministicInfiniteHorizonHelper.cpp
@@ -2,6 +2,7 @@
 
 #include "storm/modelchecker/helper/infinitehorizon/internal/ComponentUtility.h"
 #include "storm/modelchecker/helper/infinitehorizon/internal/LraViHelper.h"
+#include "storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.h"
 #include "storm/modelchecker/prctl/helper/BaierUpperRewardBoundsComputer.h"
 
 #include "storm/storage/SparseMatrix.h"
@@ -507,62 +508,25 @@ namespace storm {
                 if (numBSCCs == 1) {
                     bsccReachProbs.front() = storm::utility::one<ValueType>();
                 } else {
-                    // Compute mapping from state indices to their BSCC and
-                    // the set of states that do not lie in a BSCC
-                    std::vector<uint64_t> stateToBsccMap(this->_transitionMatrix.getRowGroupCount(), std::numeric_limits<uint64_t>::max());
-                    storm::storage::BitVector statesNotInComponent(this->_transitionMatrix.getRowGroupCount(), true);
+                    // First get the expected number of times we visit each non-BSCC state
+                    auto visittimesHelper = this->isContinuousTime() ? SparseDeterministicVisitingTimesHelper<ValueType>(this->_transitionMatrix, *this->_exitRates) : SparseDeterministicVisitingTimesHelper<ValueType>(this->_transitionMatrix);
+                    this->createBackwardTransitions();
+                    visittimesHelper.provideBackwardTransitions(*this->_backwardTransitions);
+                    auto expVisitTimes = visittimesHelper.computeExpectedVisitingTimes(env, initialDistributionGetter);
+                    
+                    // Then use the expected visiting times to compute BSCC reachability probabilities
                     for (uint64_t currentComponentIndex = 0; currentComponentIndex < this->_longRunComponentDecomposition->size(); ++currentComponentIndex) {
+                        auto& bsccVal = bsccReachProbs[currentComponentIndex];
                         for (auto const& element : (*this->_longRunComponentDecomposition)[currentComponentIndex]) {
                             uint64_t state = internal::getComponentElementState(element);
-                            statesNotInComponent.set(state, false);
-                            stateToBsccMap[state] = currentComponentIndex;
-                        }
-                    }
-                    // For each non-BSCC state, compute the expected number of times we visit that state by solving an equation system
-                    // The equation system basically considers an equation `init(s) + sum_s' P(s',s) * x_s' = x_s` for each state s.
-                    storm::solver::GeneralLinearEquationSolverFactory<ValueType> linearEquationSolverFactory;
-                    bool isEqSysFormat = linearEquationSolverFactory.getEquationProblemFormat(env) == storm::solver::LinearEquationSolverProblemFormat::EquationSystem;
-                    auto eqSysMatrix = this->_transitionMatrix.getSubmatrix(false, statesNotInComponent, statesNotInComponent, isEqSysFormat);
-                    boost::optional<std::vector<ValueType>> upperBounds;
-                    // Check solver requirements
-                    auto requirements = linearEquationSolverFactory.getRequirements(env);
-                    requirements.clearLowerBounds();
-                    if (requirements.upperBounds()) {
-                        auto toBsccProbabilities = this->_transitionMatrix.getConstrainedRowSumVector(statesNotInComponent, ~statesNotInComponent);
-                        upperBounds = computeUpperBoundsForExpectedVisitingTimes(eqSysMatrix, toBsccProbabilities);
-                        requirements.clearUpperBounds();
-                    }
-                    STORM_LOG_THROW(!requirements.hasEnabledCriticalRequirement(), storm::exceptions::UnmetRequirementException, "Solver requirements " + requirements.getEnabledRequirementsAsString() + " not checked.");
-                    eqSysMatrix = eqSysMatrix.transpose(false, true); // Transpose so that each row considers the predecessors
-                    if (isEqSysFormat) {
-                        eqSysMatrix.convertToEquationSystem();
-                    }
-                    std::unique_ptr<storm::solver::LinearEquationSolver<ValueType>> solver = linearEquationSolverFactory.create(env, eqSysMatrix);
-                    solver->setLowerBound(storm::utility::zero<ValueType>());
-                    if (upperBounds) {
-                        solver->setUpperBounds(std::move(upperBounds.get()));
-                    }
-                    std::vector<ValueType> eqSysRhs;
-                    eqSysRhs.reserve(eqSysMatrix.getRowCount());
-                    for (auto state : statesNotInComponent) {
-                        eqSysRhs.push_back(initialDistributionGetter(state));
-                    }
-                    std::vector<ValueType> eqSysValues(eqSysMatrix.getRowCount());
-                    solver->solveEquations(env, eqSysValues, eqSysRhs);
-                    
-                    // Now that we have the expected number of times we visit each non-BSCC state, we can compute the probabilities to reach each bscc.
-                    // Run over all transitions that enter a BSCC
-                    uint64_t eqSysStateIndex = 0;
-                    for (auto state : statesNotInComponent) {
-                        for (auto const& entry : this->_transitionMatrix.getRow(state)) {
-                            if (!statesNotInComponent.get(entry.getColumn())) {
-                                // Add the probability that the BSCC is reached from this state.
-                                bsccReachProbs[stateToBsccMap[entry.getColumn()]] += entry.getValue() * eqSysValues[eqSysStateIndex];
+                            bsccVal += initialDistributionGetter(state);
+                            for (auto const& pred : this->_backwardTransitions->getRow(state)) {
+                                bsccVal += pred.getValue() * expVisitTimes[pred.getColumn()];
                             }
                         }
-                        ++eqSysStateIndex;
                     }
                 }
+                
                 // As a last step, we normalize these values to counter numerical inaccuracies a bit.
                 // This is only reasonable in non-exact mode.
                 if (!env.solver().isForceExact()) {

--- a/src/storm/modelchecker/helper/infinitehorizon/SparseInfiniteHorizonHelper.cpp
+++ b/src/storm/modelchecker/helper/infinitehorizon/SparseInfiniteHorizonHelper.cpp
@@ -159,6 +159,14 @@ namespace storm {
                 return _exitRates != nullptr;
             }
             
+            template <typename ValueType, bool Nondeterministic>
+            void SparseInfiniteHorizonHelper<ValueType, Nondeterministic>::createBackwardTransitions() {
+                if (this->_backwardTransitions == nullptr) {
+                    this->_computedBackwardTransitions = std::make_unique<storm::storage::SparseMatrix<ValueType>>(this->_transitionMatrix.transpose(true, false)); // will drop zeroes
+                    this->_backwardTransitions = this->_computedBackwardTransitions.get();
+                }
+            }
+            
             template class SparseInfiniteHorizonHelper<double, true>;
             template class SparseInfiniteHorizonHelper<storm::RationalNumber, true>;
             

--- a/src/storm/modelchecker/helper/infinitehorizon/SparseInfiniteHorizonHelper.h
+++ b/src/storm/modelchecker/helper/infinitehorizon/SparseInfiniteHorizonHelper.h
@@ -111,6 +111,11 @@ namespace storm {
                 bool isContinuousTime() const;
                 
                 /*!
+                 * @post _backwardTransitions points to backward transitions.
+                 */
+                void createBackwardTransitions();
+                
+                /*!
                  * @post _longRunComponentDecomposition points to a decomposition of the long run components (MECs, BSCCs)
                  */
                 virtual void createDecomposition() = 0;

--- a/src/storm/modelchecker/helper/infinitehorizon/SparseNondeterministicInfiniteHorizonHelper.cpp
+++ b/src/storm/modelchecker/helper/infinitehorizon/SparseNondeterministicInfiniteHorizonHelper.cpp
@@ -61,10 +61,7 @@ namespace storm {
             void SparseNondeterministicInfiniteHorizonHelper<ValueType>::createDecomposition() {
                 if (this->_longRunComponentDecomposition == nullptr) {
                     // The decomposition has not been provided or computed, yet.
-                    if (this->_backwardTransitions == nullptr) {
-                        this->_computedBackwardTransitions = std::make_unique<storm::storage::SparseMatrix<ValueType>>(this->_transitionMatrix.transpose(true));
-                        this->_backwardTransitions = this->_computedBackwardTransitions.get();
-                    }
+                    this->createBackwardTransitions();
                     this->_computedLongRunComponentDecomposition = std::make_unique<storm::storage::MaximalEndComponentDecomposition<ValueType>>(this->_transitionMatrix, *this->_backwardTransitions);
                     this->_longRunComponentDecomposition = this->_computedLongRunComponentDecomposition.get();
                 }
@@ -358,10 +355,7 @@ namespace storm {
                             }
                         }
                         // Ensure that backwards transitions are available
-                        if (this->_backwardTransitions == nullptr) {
-                            this->_computedBackwardTransitions = std::make_unique<storm::storage::SparseMatrix<ValueType>>(this->_transitionMatrix.transpose(true));
-                            this->_backwardTransitions = this->_computedBackwardTransitions.get();
-                        }
+                        this->createBackwardTransitions();
                         // Now start a backwards DFS
                         std::vector<uint64_t> stack = {originalStateChoice.first};
                         while (!stack.empty()) {

--- a/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.h
+++ b/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.h
@@ -46,6 +46,12 @@ namespace storm {
              * Assumes a uniform distribution over initial states.
              */
             std::unique_ptr<CheckResult> computeSteadyStateDistribution(Environment const& env);
+            
+            /*!
+             * Computes for each state the expected number of times we visit that state.
+             * Assumes a uniform distribution over initial states.
+             */
+            std::unique_ptr<CheckResult> computeExpectedVisitingTimes(Environment const& env);
 
         };
         

--- a/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.cpp
@@ -236,7 +236,7 @@ namespace storm {
         }
         
         template<typename JsonRationalType>
-        void insertJsonEntry(storm::json<JsonRationalType>& json, uint64_t const& id, bool value, boost::optional<storm::storage::sparse::StateValuations> const& stateValuations = boost::none) {
+        void insertJsonEntry(storm::json<JsonRationalType>& json, uint64_t const& id, bool value, boost::optional<storm::storage::sparse::StateValuations> const& stateValuations = boost::none,  boost::optional<storm::models::sparse::StateLabeling> const& stateLabels = boost::none) {
             storm::json<JsonRationalType> entry;
             if (stateValuations) {
                 entry["s"] = stateValuations->template toJson<JsonRationalType>(id);
@@ -244,28 +244,32 @@ namespace storm {
                 entry["s"] = id;
             }
             entry["v"] = value;
+            if (stateLabels) {
+                auto labs = stateLabels->getLabelsOfState(id);
+                entry["l"] = labs;
+            }
             json.push_back(std::move(entry));
         }
         
         template<typename JsonRationalType>
-        storm::json<JsonRationalType> ExplicitQualitativeCheckResult::toJson(boost::optional<storm::storage::sparse::StateValuations> const& stateValuations) const {
+        storm::json<JsonRationalType> ExplicitQualitativeCheckResult::toJson(boost::optional<storm::storage::sparse::StateValuations> const& stateValuations, boost::optional<storm::models::sparse::StateLabeling> const& stateLabels) const {
             storm::json<JsonRationalType> result;
             if (this->isResultForAllStates()) {
                 vector_type const& valuesAsVector = boost::get<vector_type>(truthValues);
                 for (uint64_t state = 0; state < valuesAsVector.size(); ++state) {
-                    insertJsonEntry(result, state, valuesAsVector.get(state), stateValuations);
+                    insertJsonEntry(result, state, valuesAsVector.get(state), stateValuations, stateLabels);
                 }
             } else {
                 map_type const& valuesAsMap = boost::get<map_type>(truthValues);
                 for (auto const& stateValue : valuesAsMap) {
-                    insertJsonEntry(result, stateValue.first, stateValue.second, stateValuations);
+                    insertJsonEntry(result, stateValue.first, stateValue.second, stateValuations, stateLabels);
                 }
             }
             return result;
         }
         
-        template storm::json<double> ExplicitQualitativeCheckResult::toJson<double>(boost::optional<storm::storage::sparse::StateValuations> const&) const;
-        template storm::json<storm::RationalNumber> ExplicitQualitativeCheckResult::toJson<storm::RationalNumber>(boost::optional<storm::storage::sparse::StateValuations> const&) const;
+        template storm::json<double> ExplicitQualitativeCheckResult::toJson<double>(boost::optional<storm::storage::sparse::StateValuations> const&, boost::optional<storm::models::sparse::StateLabeling> const&) const;
+        template storm::json<storm::RationalNumber> ExplicitQualitativeCheckResult::toJson<storm::RationalNumber>(boost::optional<storm::storage::sparse::StateValuations> const&, boost::optional<storm::models::sparse::StateLabeling> const&) const;
 
         
     }

--- a/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.h
@@ -9,6 +9,7 @@
 #include "storm/storage/sparse/StateType.h"
 #include "storm/storage/BitVector.h"
 #include "storm/storage/sparse/StateValuations.h"
+#include "storm/models/sparse/StateLabeling.h"
 
 #include "storm/utility/OsDetection.h"
 #include "storm/adapters/JsonAdapter.h"
@@ -66,7 +67,7 @@ namespace storm {
             virtual void filter(QualitativeCheckResult const& filter) override;
             
             template<typename JsonRationalType = storm::RationalNumber>
-            storm::json<JsonRationalType> toJson(boost::optional<storm::storage::sparse::StateValuations> const& stateValuations = boost::none) const;
+            storm::json<JsonRationalType> toJson(boost::optional<storm::storage::sparse::StateValuations> const& stateValuations = boost::none, boost::optional<storm::models::sparse::StateLabeling> const& stateLabels = boost::none) const;
 
         private:
             static void performLogicalOperation(ExplicitQualitativeCheckResult& first, QualitativeCheckResult const& second, bool logicalAnd);

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -443,7 +443,7 @@ namespace storm {
         }
         
         template<typename ValueType>
-        void insertJsonEntry(storm::json<ValueType>& json, uint64_t const& id, ValueType const& value, boost::optional<storm::storage::sparse::StateValuations> const& stateValuations = boost::none) {
+        void insertJsonEntry(storm::json<ValueType>& json, uint64_t const& id, ValueType const& value, boost::optional<storm::storage::sparse::StateValuations> const& stateValuations = boost::none, boost::optional<storm::models::sparse::StateLabeling> const& stateLabels = boost::none) {
             typename storm::json<ValueType> entry;
             if (stateValuations) {
                 entry["s"] = stateValuations->template toJson<ValueType>(id);
@@ -451,28 +451,32 @@ namespace storm {
                 entry["s"] = id;
             }
             entry["v"] = value;
+            if (stateLabels) {
+                auto labs = stateLabels->getLabelsOfState(id);
+                entry["l"] = labs;
+            }
             json.push_back(std::move(entry));
         }
         
         template<typename ValueType>
-        storm::json<ValueType> ExplicitQuantitativeCheckResult<ValueType>::toJson(boost::optional<storm::storage::sparse::StateValuations> const& stateValuations) const {
+        storm::json<ValueType> ExplicitQuantitativeCheckResult<ValueType>::toJson(boost::optional<storm::storage::sparse::StateValuations> const& stateValuations, boost::optional<storm::models::sparse::StateLabeling> const& stateLabels) const {
             storm::json<ValueType> result;
             if (this->isResultForAllStates()) {
                 vector_type const& valuesAsVector = boost::get<vector_type>(values);
                 for (uint64_t state = 0; state < valuesAsVector.size(); ++state) {
-                    insertJsonEntry(result, state, valuesAsVector[state], stateValuations);
+                    insertJsonEntry(result, state, valuesAsVector[state], stateValuations, stateLabels);
                 }
             } else {
                 map_type const& valuesAsMap = boost::get<map_type>(values);
                 for (auto const& stateValue : valuesAsMap) {
-                    insertJsonEntry(result, stateValue.first, stateValue.second, stateValuations);
+                    insertJsonEntry(result, stateValue.first, stateValue.second, stateValuations, stateLabels);
                 }
             }
             return result;
         }
         
         template<>
-        storm::json<storm::RationalFunction> ExplicitQuantitativeCheckResult<storm::RationalFunction>::toJson(boost::optional<storm::storage::sparse::StateValuations> const&) const {
+        storm::json<storm::RationalFunction> ExplicitQuantitativeCheckResult<storm::RationalFunction>::toJson(boost::optional<storm::storage::sparse::StateValuations> const&, boost::optional<storm::models::sparse::StateLabeling> const&) const {
             STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Export of Check results is not supported for Rational Functions.");
         }
         

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -10,6 +10,7 @@
 #include "storm/storage/sparse/StateType.h"
 #include "storm/storage/Scheduler.h"
 #include "storm/storage/sparse/StateValuations.h"
+#include "storm/models/sparse/StateLabeling.h"
 
 #include "storm/utility/OsDetection.h"
 #include "storm/adapters/JsonAdapter.h"
@@ -78,7 +79,7 @@ namespace storm {
             storm::storage::Scheduler<ValueType> const& getScheduler() const;
             storm::storage::Scheduler<ValueType>& getScheduler();
             
-            storm::json<ValueType> toJson(boost::optional<storm::storage::sparse::StateValuations> const& stateValuations = boost::none) const;
+            storm::json<ValueType> toJson(boost::optional<storm::storage::sparse::StateValuations> const& stateValuations = boost::none, boost::optional<storm::models::sparse::StateLabeling> const& stateLabels = boost::none) const;
             
         private:
             // The values of the quantitative check result.

--- a/src/storm/settings/modules/IOSettings.cpp
+++ b/src/storm/settings/modules/IOSettings.cpp
@@ -48,6 +48,7 @@ namespace storm {
             const std::string IOSettings::propertyOptionName = "prop";
             const std::string IOSettings::propertyOptionShortName = "prop";
             const std::string IOSettings::steadyStateDistrOptionName = "steadystate";
+            const std::string IOSettings::expectedVisitingTimesOptionName = "expvisittimes";
             
             const std::string IOSettings::qvbsInputOptionName = "qvbs";
             const std::string IOSettings::qvbsInputOptionShortName = "qvbs";
@@ -105,6 +106,7 @@ namespace storm {
                 this->addOption(storm::settings::OptionBuilder(moduleName, janiPropertyOptionName, false, "Specifies the properties from the jani model (given by --" + janiInputOptionName + ") to be checked.").setShortName(janiPropertyOptionShortName)
                                 .addArgument(storm::settings::ArgumentBuilder::createStringArgument("values", "A comma separated list of properties to be checked").setDefaultValueString("").makeOptional().build()).build());
                 this->addOption(storm::settings::OptionBuilder(moduleName,  steadyStateDistrOptionName, false, "Computes the steady state distribution. Result can be exported using --" + exportCheckResultOptionName +".").setIsAdvanced().build());
+                this->addOption(storm::settings::OptionBuilder(moduleName,  expectedVisitingTimesOptionName, false, "Computes the expected time we visit each state. Result can be exported using --" + exportCheckResultOptionName +".").setIsAdvanced().build());
 
                 this->addOption(storm::settings::OptionBuilder(moduleName, qvbsInputOptionName, false, "Selects a model from the Quantitative Verification Benchmark Set.").setShortName(qvbsInputOptionShortName)
                         .addArgument(storm::settings::ArgumentBuilder::createStringArgument("model", "The short model name as in the benchmark set.").build())
@@ -318,6 +320,10 @@ namespace storm {
             
             bool IOSettings::isComputeSteadyStateDistributionSet() const {
                 return this->getOption(steadyStateDistrOptionName).getHasOptionBeenSet();
+            }
+            
+            bool IOSettings::isComputeExpectedVisitingTimesSet() const {
+                return this->getOption(expectedVisitingTimesOptionName).getHasOptionBeenSet();
             }
             
             bool IOSettings::isQvbsInputSet() const {

--- a/src/storm/settings/modules/IOSettings.cpp
+++ b/src/storm/settings/modules/IOSettings.cpp
@@ -106,7 +106,7 @@ namespace storm {
                 this->addOption(storm::settings::OptionBuilder(moduleName, janiPropertyOptionName, false, "Specifies the properties from the jani model (given by --" + janiInputOptionName + ") to be checked.").setShortName(janiPropertyOptionShortName)
                                 .addArgument(storm::settings::ArgumentBuilder::createStringArgument("values", "A comma separated list of properties to be checked").setDefaultValueString("").makeOptional().build()).build());
                 this->addOption(storm::settings::OptionBuilder(moduleName,  steadyStateDistrOptionName, false, "Computes the steady state distribution. Result can be exported using --" + exportCheckResultOptionName +".").setIsAdvanced().build());
-                this->addOption(storm::settings::OptionBuilder(moduleName,  expectedVisitingTimesOptionName, false, "Computes the expected time we visit each state. Result can be exported using --" + exportCheckResultOptionName +".").setIsAdvanced().build());
+                this->addOption(storm::settings::OptionBuilder(moduleName,  expectedVisitingTimesOptionName, false, "Computes the expected number of times each state is visited (DTMC) or the expected time spend in each state (CTMC). Result can be exported using --" + exportCheckResultOptionName +".").setIsAdvanced().build());
 
                 this->addOption(storm::settings::OptionBuilder(moduleName, qvbsInputOptionName, false, "Selects a model from the Quantitative Verification Benchmark Set.").setShortName(qvbsInputOptionShortName)
                         .addArgument(storm::settings::ArgumentBuilder::createStringArgument("model", "The short model name as in the benchmark set.").build())

--- a/src/storm/settings/modules/IOSettings.h
+++ b/src/storm/settings/modules/IOSettings.h
@@ -335,6 +335,11 @@ namespace storm {
                 bool isComputeSteadyStateDistributionSet() const;
                 
                 /*!
+                 * Retrieves whether the expected visiting times are to be computed.
+                 */
+                bool isComputeExpectedVisitingTimesSet() const;
+                
+                /*!
                  * Retrieves whether the input model is to be read from the quantitative verification benchmark set (QVBS)
                  */
                 bool isQvbsInputSet() const;
@@ -401,6 +406,7 @@ namespace storm {
                 static const std::string propertyOptionName;
                 static const std::string propertyOptionShortName;
                 static const std::string steadyStateDistrOptionName;
+                static const std::string expectedVisitingTimesOptionName;
                 static const std::string qvbsInputOptionName;
                 static const std::string qvbsInputOptionShortName;
                 static const std::string qvbsRootOptionName;

--- a/src/storm/storage/StronglyConnectedComponentDecomposition.cpp
+++ b/src/storm/storage/StronglyConnectedComponentDecomposition.cpp
@@ -242,6 +242,11 @@ namespace storm {
         }
         
         template <typename ValueType>
+        bool StronglyConnectedComponentDecomposition<ValueType>::hasSccDepth() const {
+            return sccDepths.is_initialized();
+        }
+        
+        template <typename ValueType>
         uint_fast64_t StronglyConnectedComponentDecomposition<ValueType>::getSccDepth(uint_fast64_t const& sccIndex) const {
             STORM_LOG_THROW(sccDepths.is_initialized(), storm::exceptions::InvalidOperationException, "Tried to get the SCC depth but SCC depths were not computed upon construction.");
             STORM_LOG_ASSERT(sccIndex < sccDepths->size(), "SCC index " << sccIndex << " is out of range (" << sccDepths->size() << ")");

--- a/src/storm/storage/StronglyConnectedComponentDecomposition.h
+++ b/src/storm/storage/StronglyConnectedComponentDecomposition.h
@@ -92,6 +92,11 @@ namespace storm {
             StronglyConnectedComponentDecomposition& operator=(StronglyConnectedComponentDecomposition&& other);
             
             /*!
+             * Retrieves whether SCCDepths have been computed during construction of this.
+             */
+             bool hasSccDepth() const;
+             
+            /*!
              * Gets the depth of the SCC with the given index. This is the number of different SCCs a path starting in the given SCC can reach.
              * E.g., bottom SCCs have depth 0, SCCs from which only bottom SCCs are reachable have depth 1, ...
              * This requires that SCCDepths are computed upon construction of this.

--- a/src/test/storm/modelchecker/csl/ExpectedVisitingTimesCtmcCslModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/csl/ExpectedVisitingTimesCtmcCslModelCheckerTest.cpp
@@ -1,0 +1,124 @@
+#include "storm-config.h"
+#include "test/storm_gtest.h"
+
+#include "storm-parsers/api/model_descriptions.h"
+#include "storm/api/builder.h"
+#include "storm/environment/solver/EigenSolverEnvironment.h"
+#include "storm/environment/solver/GmmxxSolverEnvironment.h"
+#include "storm/environment/solver/NativeSolverEnvironment.h"
+#include "storm/modelchecker/csl/SparseCtmcCslModelChecker.h"
+#include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
+#include "storm/models/sparse/Ctmc.h"
+#include "storm/models/sparse/StandardRewardModel.h"
+
+namespace {
+
+enum class CtmcEngine { JaniSparse };
+
+class SparseGmmxxGmresIluEnvironment {
+   public:
+    static const CtmcEngine engine = CtmcEngine::JaniSparse;
+    static const bool isExact = false;
+    typedef double ValueType;
+    typedef storm::models::sparse::Ctmc<ValueType> ModelType;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Gmmxx);
+        env.solver().gmmxx().setMethod(storm::solver::GmmxxLinearEquationSolverMethod::Gmres);
+        env.solver().gmmxx().setPreconditioner(storm::solver::GmmxxLinearEquationSolverPreconditioner::Ilu);
+        // env.solver().gmmxx().setPrecision(storm::utility::convertNumber<storm::RationalNumber>(1e-6)); // Need to increase precision because eq sys yields
+        // incorrect results
+        return env;
+    }
+};
+
+class SparseEigenRationalLuEnvironment {
+   public:
+    static const CtmcEngine engine = CtmcEngine::JaniSparse;
+    static const bool isExact = true;
+    typedef storm::RationalNumber ValueType;
+    typedef storm::models::sparse::Ctmc<ValueType> ModelType;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Eigen);
+        env.solver().eigen().setMethod(storm::solver::EigenLinearEquationSolverMethod::SparseLU);
+        env.solver().setForceExact(true);
+        return env;
+    }
+};
+
+template<typename TestType>
+class ExpectedVisitingTimesCtmcCslModelCheckerTest : public ::testing::Test {
+   public:
+    typedef typename TestType::ValueType ValueType;
+    typedef typename storm::models::sparse::Ctmc<ValueType> SparseModelType;
+
+    ExpectedVisitingTimesCtmcCslModelCheckerTest() : _environment(TestType::createEnvironment()) {}
+    storm::Environment const& env() const { return _environment; }
+    ValueType parseNumber(std::string const& input) const { return storm::utility::convertNumber<ValueType>(input); }
+    ValueType precision() const { return TestType::isExact ? parseNumber("0") : parseNumber("1e-6"); }
+    bool isSparseModel() const { return std::is_same<typename TestType::ModelType, SparseModelType>::value; }
+    CtmcEngine getEngine() const { return TestType::engine; }
+
+    template<typename MT = typename TestType::ModelType>
+    typename std::enable_if<std::is_same<MT, SparseModelType>::value, std::shared_ptr<MT>>::type buildJaniModel(
+        std::string const& pathToJaniModel, std::string const& constantDefinitionString = "") const {
+        auto janiDescr = storm::storage::SymbolicModelDescription(storm::api::parseJaniModel(pathToJaniModel).first);
+        janiDescr = janiDescr.preprocess(constantDefinitionString);
+        return storm::api::buildSparseModel<ValueType>(janiDescr, storm::builder::BuilderOptions())->template as<MT>();
+    }
+
+    template<typename MT = typename TestType::ModelType>
+    typename std::enable_if<std::is_same<MT, SparseModelType>::value, std::shared_ptr<storm::modelchecker::SparseCtmcCslModelChecker<MT>>>::type
+    createModelChecker(std::shared_ptr<MT> const& model) const {
+        if (TestType::engine == CtmcEngine::JaniSparse) {
+            return std::make_shared<storm::modelchecker::SparseCtmcCslModelChecker<SparseModelType>>(*model);
+        }
+        return nullptr;
+    }
+
+   private:
+    storm::Environment _environment;
+};
+
+typedef ::testing::Types<SparseGmmxxGmresIluEnvironment, SparseEigenRationalLuEnvironment> TestingTypes;
+
+TYPED_TEST_SUITE(ExpectedVisitingTimesCtmcCslModelCheckerTest, TestingTypes, );
+
+TYPED_TEST(ExpectedVisitingTimesCtmcCslModelCheckerTest, expvisittimestest) {
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto model = this->buildJaniModel(STORM_TEST_RESOURCES_DIR "/ctmc/expvisittimes.jani");
+    EXPECT_EQ(10ul, model->getNumberOfStates());
+    EXPECT_EQ(19ul, model->getNumberOfTransitions());
+    ASSERT_EQ(model->getType(), storm::models::ModelType::Ctmc);
+    auto checker = this->createModelChecker(model);
+    auto result = checker->computeExpectedVisitingTimes(this->env());
+
+    ASSERT_TRUE(result->isExplicitQuantitativeCheckResult());
+    auto resultVector = result->template asExplicitQuantitativeCheckResult<ValueType>().getValueVector();
+    auto sortedVector = resultVector;
+    std::sort(sortedVector.begin(), sortedVector.end());
+
+    EXPECT_NEAR(sortedVector[0], this->parseNumber("8/2025"), this->precision())
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+    EXPECT_NEAR(sortedVector[1], this->parseNumber("4/135"), this->precision())
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+    EXPECT_NEAR(sortedVector[2], this->parseNumber("2/27"), this->precision())
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+    EXPECT_NEAR(sortedVector[3], this->parseNumber("17/81"), this->precision())
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+    EXPECT_NEAR(sortedVector[4], this->parseNumber("401/1620"), this->precision())
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+    EXPECT_NEAR(sortedVector[5], this->parseNumber("341/1215"), this->precision())
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+    EXPECT_EQ(sortedVector[6], storm::utility::infinity<ValueType>())
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+    EXPECT_EQ(sortedVector[7], storm::utility::infinity<ValueType>())
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+    EXPECT_EQ(sortedVector[8], storm::utility::infinity<ValueType>())
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+    EXPECT_EQ(sortedVector[9], storm::utility::infinity<ValueType>())
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+}
+}  // namespace


### PR DESCRIPTION
This PR adds the functionality to compute the expected times each state of a DTMC or CTMC is visited. 
In other words, the resulting value at state `s` coincides with the total reward `R{"rew_s"}=? [C]`, where the reward structure `rew_s`  only assigns reward 1 to state `s`. If `s` does not lie on a cycle, this value actually also coincides with the probability to reach `s`.

The underlying idea is to solve the infamous forward equation system (`x * P + init = x`) for each non-bottom SCC with probability matrix `P`.

States in (reachable) BSCCs always have value `inf`.

Other related stuff in here:

- Improved the `--exportresult` output to also include state labels.
- Changed the JSON output for weird floats such as `inf` or `nan`. Before, the output just said `null` in those cases but I think a string literal like `"inf"` is better for our purposes.
- Replaced an old implementation of the expected visiting times with the new one. The old implementation was used to compute the reachability of each BSCC when computing the (very related) steady state distributions via `--steadystate`.


Here is an example output

```console
storm-debug --prism resources/examples/testfiles/dtmc/die.pm --expvisittimes --exportresult res.json --buildstateval --build-all-labels
Storm 1.6.4 (dev)
DEBUG BUILD

Date: Tue Nov 16 12:52:27 2021
Command line arguments: --prism resources/examples/testfiles/dtmc/die.pm --expvisittimes --exportresult res.json --buildstateval --build-all-labels
Current working directory: /Users/tim/storm

Time for model input parsing: 0.047s.

Time for model construction: 0.130s.

-------------------------------------------------------------- 
Model type: 	DTMC (sparse)
States: 	13
Transitions: 	20
Reward Models:  none
State Labels: 	6 labels
   * deadlock -> 0 item(s)
   * two -> 1 item(s)
   * done -> 6 item(s)
   * three -> 1 item(s)
   * init -> 1 item(s)
   * one -> 1 item(s)
Choice Labels: 	none
-------------------------------------------------------------- 
Write to file res.json.
Result: [0.3333333333, inf] (range)
Time for model checking: 0.007s.
?expvisittimes ~/storm> head -n 70 res.json                                                                                                                    
[
    {
        "l": [
            "init"
        ],
        "s": {
            "d": 0,
            "s": 0
        },
        "v": 1
    },
    {
        "l": [],
        "s": {
            "d": 0,
            "s": 1
        },
        "v": 0.666666666666667
    },
    {
        "l": [],
        "s": {
            "d": 0,
            "s": 2
        },
        "v": 0.666666666666667
    },
    {
        "l": [],
        "s": {
            "d": 0,
            "s": 3
        },
        "v": 0.333333333333333
    },
    {
        "l": [],
        "s": {
            "d": 0,
            "s": 4
        },
        "v": 0.333333333333333
    },
    {
        "l": [],
        "s": {
            "d": 0,
            "s": 5
        },
        "v": 0.333333333333333
    },
    {
        "l": [],
        "s": {
            "d": 0,
            "s": 6
        },
        "v": 0.333333333333333
    },
    {
        "l": [
            "done",
            "one"
        ],
        "s": {
            "d": 1,
            "s": 7
        },
        "v": "inf"
    },
```