### PR TITLE
Added missing includes

### DIFF
--- a/resources/3rdparty/sylvan/src/sylvan_bdd_storm.h
+++ b/resources/3rdparty/sylvan/src/sylvan_bdd_storm.h
@@ -1,3 +1,5 @@
+#include "sylvan.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/resources/3rdparty/sylvan/src/sylvan_mtbdd_storm.h
+++ b/resources/3rdparty/sylvan/src/sylvan_mtbdd_storm.h
@@ -1,3 +1,5 @@
+#include "sylvan.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/storm/api/bisimulation.h
+++ b/src/storm/api/bisimulation.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "storm/models/sparse/Ctmc.h"
+#include "storm/models/sparse/Dtmc.h"
+#include "storm/models/sparse/Mdp.h"
+
 #include "storm/storage/bisimulation/DeterministicModelBisimulationDecomposition.h"
 #include "storm/storage/bisimulation/NondeterministicModelBisimulationDecomposition.h"
 


### PR DESCRIPTION
This PR adds some `#include`s that apparently were missing.

I discovered this when applying code formating (which also sorts `#include`s) to the code base.