### PR TITLE
Replace std::endl with the newline char

### DIFF
--- a/src/storm-cli-utilities/cli.cpp
+++ b/src/storm-cli-utilities/cli.cpp
@@ -86,9 +86,9 @@ std::string shellQuoteSingleIfNecessary(const std::string& arg) {
 }
 
 void printHeader(std::string const& name, const int argc, const char** argv) {
-    STORM_PRINT(name << " " << storm::StormVersion::shortVersionString() << std::endl);
+    STORM_PRINT(name << " " << storm::StormVersion::shortVersionString() << '\n');
 #ifndef NDEBUG
-    STORM_PRINT("DEBUG BUILD" << std::endl);
+    STORM_PRINT("DEBUG BUILD\n");
 #endif
     // "Compute" the command line argument string with which storm was invoked.
     std::stringstream commandStream;
@@ -99,45 +99,44 @@ void printHeader(std::string const& name, const int argc, const char** argv) {
     std::string command = commandStream.str();
 
     if (!command.empty()) {
-        STORM_PRINT(std::endl);
+        STORM_PRINT('\n');
         std::time_t result = std::time(nullptr);
         STORM_PRINT("Date: " << std::ctime(&result));
-        STORM_PRINT("Command line arguments:" << commandStream.str() << std::endl);
-        STORM_PRINT("Current working directory: " << storm::utility::cli::getCurrentWorkingDirectory() << std::endl << std::endl);
+        STORM_PRINT("Command line arguments:" << commandStream.str() << '\n');
+        STORM_PRINT("Current working directory: " << storm::utility::cli::getCurrentWorkingDirectory() << "\n\n");
     }
 }
 
 void printVersion(std::string const& name) {
-    STORM_PRINT(storm::StormVersion::longVersionString() << std::endl);
-    STORM_PRINT(storm::StormVersion::buildInfo() << std::endl);
+    STORM_PRINT(storm::StormVersion::longVersionString() << '\n');
+    STORM_PRINT(storm::StormVersion::buildInfo() << '\n');
 
 #ifdef STORM_HAVE_INTELTBB
     STORM_PRINT("Linked with Intel Threading Building Blocks v" << TBB_VERSION_MAJOR << "." << TBB_VERSION_MINOR << " (Interface version "
-                                                                << TBB_INTERFACE_VERSION << ")." << std::endl);
+                                                                << TBB_INTERFACE_VERSION << ").\n");
 #endif
 #ifdef STORM_HAVE_GLPK
-    STORM_PRINT("Linked with GNU Linear Programming Kit v" << GLP_MAJOR_VERSION << "." << GLP_MINOR_VERSION << "." << std::endl);
+    STORM_PRINT("Linked with GNU Linear Programming Kit v" << GLP_MAJOR_VERSION << "." << GLP_MINOR_VERSION << ".\n");
 #endif
 #ifdef STORM_HAVE_GUROBI
-    STORM_PRINT("Linked with Gurobi Optimizer v" << GRB_VERSION_MAJOR << "." << GRB_VERSION_MINOR << "." << GRB_VERSION_TECHNICAL << "." << std::endl);
+    STORM_PRINT("Linked with Gurobi Optimizer v" << GRB_VERSION_MAJOR << "." << GRB_VERSION_MINOR << "." << GRB_VERSION_TECHNICAL << ".\n");
 #endif
 #ifdef STORM_HAVE_Z3
     unsigned int z3Major, z3Minor, z3BuildNumber, z3RevisionNumber;
     Z3_get_version(&z3Major, &z3Minor, &z3BuildNumber, &z3RevisionNumber);
-    STORM_PRINT("Linked with Microsoft Z3 Optimizer v" << z3Major << "." << z3Minor << " Build " << z3BuildNumber << " Rev " << z3RevisionNumber << "."
-                                                       << std::endl);
+    STORM_PRINT("Linked with Microsoft Z3 Optimizer v" << z3Major << "." << z3Minor << " Build " << z3BuildNumber << " Rev " << z3RevisionNumber << ".\n");
 #endif
 #ifdef STORM_HAVE_MSAT
     char* msatVersion = msat_get_version();
-    STORM_PRINT("Linked with " << msatVersion << "." << std::endl);
+    STORM_PRINT("Linked with " << msatVersion << ".\n");
     msat_free(msatVersion);
 #endif
 #ifdef STORM_HAVE_SMTRAT
-    STORM_PRINT("Linked with SMT-RAT " << SMTRAT_VERSION << "." << std::endl);
+    STORM_PRINT("Linked with SMT-RAT " << SMTRAT_VERSION << ".\n");
 #endif
 #ifdef STORM_HAVE_CARL
     // TODO get version string
-    STORM_PRINT("Linked with CArL." << std::endl);
+    STORM_PRINT("Linked with CArL.\n");
 #endif
 
 #ifdef STORM_HAVE_CUDA
@@ -148,9 +147,9 @@ void printVersion(std::string const& name) {
         STORM_PRINT("Compiled with CUDA support, ");
         // This function call returns 0 if there are no CUDA capable devices.
         if (deviceCount == 0) {
-            STORM_PRINT("but there are no available device(s) that support CUDA." << std::endl);
+            STORM_PRINT("but there are no available device(s) that support CUDA.\n");
         } else {
-            STORM_PRINT("detected " << deviceCount << " CUDA capable device(s):" << std::endl);
+            STORM_PRINT("detected " << deviceCount << " CUDA capable device(s):\n");
         }
 
         int dev, driverVersion = 0, runtimeVersion = 0;
@@ -160,18 +159,18 @@ void printVersion(std::string const& name) {
             cudaDeviceProp deviceProp;
             cudaGetDeviceProperties(&deviceProp, dev);
 
-            STORM_PRINT("CUDA device " << dev << ": \"" << deviceProp.name << "\"" << std::endl);
+            STORM_PRINT("CUDA device " << dev << ": \"" << deviceProp.name << "\"\n");
 
             // Console log
             cudaDriverGetVersion(&driverVersion);
             cudaRuntimeGetVersion(&runtimeVersion);
             STORM_PRINT("  CUDA Driver Version / Runtime Version          " << driverVersion / 1000 << "." << (driverVersion % 100) / 10 << " / "
-                                                                            << runtimeVersion / 1000 << "." << (runtimeVersion % 100) / 10 << std::endl);
-            STORM_PRINT("  CUDA Capability Major/Minor version number:    " << deviceProp.major << "." << deviceProp.minor << std::endl);
+                                                                            << runtimeVersion / 1000 << "." << (runtimeVersion % 100) / 10 << '\n');
+            STORM_PRINT("  CUDA Capability Major/Minor version number:    " << deviceProp.major << "." << deviceProp.minor << '\n');
         }
-        STORM_PRINT(std::endl);
+        STORM_PRINT('\n');
     } else {
-        STORM_PRINT("Compiled with CUDA support, but an error occured trying to find CUDA devices." << std::endl);
+        STORM_PRINT("Compiled with CUDA support, but an error occured trying to find CUDA devices.\n");
     }
 #endif
 }
@@ -290,7 +289,7 @@ void printTimeAndMemoryStatistics(uint64_t wallclockMilliseconds) {
     struct rusage ru;
     getrusage(RUSAGE_SELF, &ru);
 
-    std::cout << std::endl << "Performance statistics:" << std::endl;
+    std::cout << "\nPerformance statistics:\n";
 #ifdef MACOS
     // For Mac OS, this is returned in bytes.
     uint64_t maximumResidentSizeInMegabytes = ru.ru_maxrss / 1024 / 1024;
@@ -299,11 +298,11 @@ void printTimeAndMemoryStatistics(uint64_t wallclockMilliseconds) {
     // For Linux, this is returned in kilobytes.
     uint64_t maximumResidentSizeInMegabytes = ru.ru_maxrss / 1024;
 #endif
-    std::cout << "  * peak memory usage: " << maximumResidentSizeInMegabytes << "MB" << std::endl;
+    std::cout << "  * peak memory usage: " << maximumResidentSizeInMegabytes << "MB\n";
     char oldFillChar = std::cout.fill('0');
-    std::cout << "  * CPU time: " << ru.ru_utime.tv_sec << "." << std::setw(3) << ru.ru_utime.tv_usec / 1000 << "s" << std::endl;
+    std::cout << "  * CPU time: " << ru.ru_utime.tv_sec << "." << std::setw(3) << ru.ru_utime.tv_usec / 1000 << "s\n";
     if (wallclockMilliseconds != 0) {
-        std::cout << "  * wallclock time: " << (wallclockMilliseconds / 1000) << "." << std::setw(3) << (wallclockMilliseconds % 1000) << "s" << std::endl;
+        std::cout << "  * wallclock time: " << (wallclockMilliseconds / 1000) << "." << std::setw(3) << (wallclockMilliseconds % 1000) << "s\n";
     }
     std::cout.fill(oldFillChar);
 }

--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -90,7 +90,7 @@ void parseSymbolicModelDescription(storm::settings::modules::IOSettings const& i
             }
         }
         modelParsingWatch.stop();
-        STORM_PRINT("Time for model input parsing: " << modelParsingWatch << "." << std::endl << std::endl);
+        STORM_PRINT("Time for model input parsing: " << modelParsingWatch << ".\n\n");
     }
 }
 
@@ -118,7 +118,7 @@ SymbolicInput parseSymbolicInputQvbs(storm::settings::modules::IOSettings const&
     input.model = std::move(janiInput.first);
     input.properties = std::move(janiInput.second);
     modelParsingWatch.stop();
-    STORM_PRINT("Time for model input parsing: " << modelParsingWatch << "." << std::endl << std::endl);
+    STORM_PRINT("Time for model input parsing: " << modelParsingWatch << ".\n\n");
 
     // Parse additional properties
     boost::optional<std::set<std::string>> propertyFilter = storm::api::parsePropertyFilter(ioSettings.getPropertyFilter());
@@ -200,10 +200,9 @@ void getModelProcessingInformationAutomatic(SymbolicInput const& input, ModelPro
     if (as.enableExact() && mpi.verificationValueType == ModelProcessingInformation::ValueType::FinitePrecision) {
         mpi.verificationValueType = ModelProcessingInformation::ValueType::Exact;
     }
-    STORM_PRINT_AND_LOG("Automatic engine picked the following settings: "
-                        << std::endl
-                        << "\tengine=" << mpi.engine << std::boolalpha << "\t bisimulation=" << mpi.applyBisimulation << "\t exact="
-                        << (mpi.verificationValueType != ModelProcessingInformation::ValueType::FinitePrecision) << std::noboolalpha << std::endl);
+    STORM_PRINT_AND_LOG("Automatic engine picked the following settings: \n"
+                        << "\tengine=" << mpi.engine << std::boolalpha << "\t bisimulation=" << mpi.applyBisimulation
+                        << "\t exact=" << (mpi.verificationValueType != ModelProcessingInformation::ValueType::FinitePrecision) << std::noboolalpha << '\n');
 }
 
 /*!
@@ -526,7 +525,7 @@ std::shared_ptr<storm::models::ModelBase> buildModel(SymbolicInput const& input,
 
     modelBuildingWatch.stop();
     if (result) {
-        STORM_PRINT("Time for model construction: " << modelBuildingWatch << "." << std::endl << std::endl);
+        STORM_PRINT("Time for model construction: " << modelBuildingWatch << ".\n\n");
     }
 
     return result;
@@ -780,23 +779,23 @@ std::pair<std::shared_ptr<storm::models::ModelBase>, bool> preprocessModel(std::
     preprocessingWatch.stop();
 
     if (result.second) {
-        STORM_PRINT(std::endl << "Time for model preprocessing: " << preprocessingWatch << "." << std::endl << std::endl);
+        STORM_PRINT("\nTime for model preprocessing: " << preprocessingWatch << ".\n\n");
     }
     return result;
 }
 
 void printComputingCounterexample(storm::jani::Property const& property) {
-    STORM_PRINT("Computing counterexample for property " << *property.getRawFormula() << " ..." << std::endl);
+    STORM_PRINT("Computing counterexample for property " << *property.getRawFormula() << " ...\n");
 }
 
 void printCounterexample(std::shared_ptr<storm::counterexamples::Counterexample> const& counterexample, storm::utility::Stopwatch* watch = nullptr) {
     if (counterexample) {
-        STORM_PRINT(*counterexample << std::endl);
+        STORM_PRINT(*counterexample << '\n');
         if (watch) {
-            STORM_PRINT("Time for computation: " << *watch << "." << std::endl);
+            STORM_PRINT("Time for computation: " << *watch << ".\n");
         }
     } else {
-        STORM_PRINT(" failed." << std::endl);
+        STORM_PRINT(" failed.\n");
     }
 }
 
@@ -903,7 +902,7 @@ void printFilteredResult(std::unique_ptr<storm::modelchecker::CheckResult> const
     } else {
         switch (ft) {
             case storm::modelchecker::FilterType::VALUES:
-                STORM_PRINT(*result << std::endl);
+                STORM_PRINT(*result << '\n');
                 break;
             case storm::modelchecker::FilterType::EXISTS:
                 STORM_PRINT(result->asQualitativeCheckResult().existsTrue());
@@ -924,11 +923,11 @@ void printFilteredResult(std::unique_ptr<storm::modelchecker::CheckResult> const
                 STORM_LOG_THROW(false, storm::exceptions::InvalidArgumentException, "Filter type only defined for quantitative results.");
         }
     }
-    STORM_PRINT(std::endl);
+    STORM_PRINT('\n');
 }
 
 void printModelCheckingProperty(storm::jani::Property const& property) {
-    STORM_PRINT(std::endl << "Model checking property \"" << property.getName() << "\": " << *property.getRawFormula() << " ..." << std::endl);
+    STORM_PRINT("\nModel checking property \"" << property.getName() << "\": " << *property.getRawFormula() << " ...\n");
 }
 
 template<typename ValueType>
@@ -941,10 +940,10 @@ void printResult(std::unique_ptr<storm::modelchecker::CheckResult> const& result
                     << " (for " << (property.getFilter().getStatesFormula()->isInitialFormula() ? "initial" : ss.str()) << " states): ");
         printFilteredResult<ValueType>(result, property.getFilter().getFilterType());
         if (watch) {
-            STORM_PRINT("Time for model checking: " << *watch << "." << std::endl);
+            STORM_PRINT("Time for model checking: " << *watch << ".\n");
         }
     } else {
-        STORM_LOG_ERROR("Property is unsupported by selected engine/settings." << std::endl);
+        STORM_LOG_ERROR("Property is unsupported by selected engine/settings.\n");
     }
 }
 
@@ -1170,8 +1169,8 @@ void verifyWithSparseEngine(std::shared_ptr<storm::models::ModelBase> const& mod
         }
         watch.stop();
         postprocessingCallback(result);
-        STORM_PRINT((storm::utility::resources::isTerminate() ? "Result till abort: " : "Result: ") << *result << std::endl);
-        STORM_PRINT("Time for model checking: " << watch << "." << std::endl);
+        STORM_PRINT((storm::utility::resources::isTerminate() ? "Result till abort: " : "Result: ") << *result << '\n');
+        STORM_PRINT("Time for model checking: " << watch << ".\n");
     }
     if (ioSettings.isComputeExpectedVisitingTimesSet()) {
         storm::utility::Stopwatch watch(true);
@@ -1183,8 +1182,8 @@ void verifyWithSparseEngine(std::shared_ptr<storm::models::ModelBase> const& mod
         }
         watch.stop();
         postprocessingCallback(result);
-        STORM_PRINT((storm::utility::resources::isTerminate() ? "Result till abort: " : "Result: ") << *result << std::endl);
-        STORM_PRINT("Time for model checking: " << watch << "." << std::endl);
+        STORM_PRINT((storm::utility::resources::isTerminate() ? "Result till abort: " : "Result: ") << *result << '\n');
+        STORM_PRINT("Time for model checking: " << watch << ".\n");
     }
 }
 

--- a/src/storm-conv-cli/storm-conv.cpp
+++ b/src/storm-conv-cli/storm-conv.cpp
@@ -50,7 +50,7 @@ storm::utility::Stopwatch startStopwatch(std::string const& message) {
 
 void stopStopwatch(storm::utility::Stopwatch& stopWatch) {
     stopWatch.stop();
-    STORM_PRINT_AND_LOG(" done. (" << stopWatch << " seconds)." << std::endl);
+    STORM_PRINT_AND_LOG(" done. (" << stopWatch << " seconds).\n");
 }
 
 void processPrismInputJaniOutput(storm::prism::Program const& prismProg, std::vector<storm::jani::Property> const& properties) {

--- a/src/storm-conv/api/storm-conv.cpp
+++ b/src/storm-conv/api/storm-conv.cpp
@@ -140,23 +140,23 @@ void printJaniToStream(storm::jani::Model const& model, std::vector<storm::jani:
 void exportPrismToFile(storm::prism::Program const& program, std::vector<storm::jani::Property> const& properties, std::string const& filename) {
     std::ofstream stream;
     storm::utility::openFile(filename, stream);
-    stream << program << std::endl;
+    stream << program << '\n';
     storm::utility::closeFile(stream);
 
     if (!properties.empty()) {
         storm::utility::openFile(filename + ".props", stream);
         for (auto const& prop : properties) {
-            stream << prop.asPrismSyntax() << std::endl;
+            stream << prop.asPrismSyntax() << '\n';
             STORM_LOG_WARN_COND(!prop.containsUndefinedConstants(), "A property contains undefined constants. These might not be exported correctly.");
         }
         storm::utility::closeFile(stream);
     }
 }
 void printPrismToStream(storm::prism::Program const& program, std::vector<storm::jani::Property> const& properties, std::ostream& ostream) {
-    ostream << program << std::endl;
+    ostream << program << '\n';
     for (auto const& prop : properties) {
         STORM_LOG_WARN_COND(!prop.containsUndefinedConstants(), "A property contains undefined constants. These might not be exported correctly.");
-        ostream << prop.asPrismSyntax() << std::endl;
+        ostream << prop.asPrismSyntax() << '\n';
     }
 }
 

--- a/src/storm-counterexamples/counterexamples/HighLevelCounterexample.cpp
+++ b/src/storm-counterexamples/counterexamples/HighLevelCounterexample.cpp
@@ -20,7 +20,7 @@ storm::storage::SymbolicModelDescription const& HighLevelCounterexample::getMode
 }
 
 void HighLevelCounterexample::writeToStream(std::ostream& out) const {
-    out << "High-level counterexample: " << std::endl;
+    out << "High-level counterexample: \n";
     out << model;
 }
 

--- a/src/storm-counterexamples/counterexamples/MILPMinimalLabelSetGenerator.h
+++ b/src/storm-counterexamples/counterexamples/MILPMinimalLabelSetGenerator.h
@@ -1001,7 +1001,7 @@ class MILPMinimalLabelSetGenerator {
                             storm::exceptions::InvalidArgumentException,
                             "Given probability threshold " << probabilityThreshold << " can not be " << (strictBound ? "achieved" : "exceeded")
                                                            << " in model with maximal reachability probability of " << maximalReachabilityProbability << ".");
-            std::cout << std::endl << "Maximal reachability in model is " << maximalReachabilityProbability << "." << std::endl << std::endl;
+            std::cout << "\nMaximal reachability in model is " << maximalReachabilityProbability << ".\n\n";
         }
 
         // (2) Identify relevant and problematic states.
@@ -1042,7 +1042,7 @@ class MILPMinimalLabelSetGenerator {
     static std::shared_ptr<HighLevelCounterexample> computeCounterexample(Environment const& env, storm::storage::SymbolicModelDescription const& symbolicModel,
                                                                           storm::models::sparse::Mdp<T> const& mdp,
                                                                           std::shared_ptr<storm::logic::Formula const> const& formula) {
-        std::cout << std::endl << "Generating minimal label counterexample for formula " << *formula << std::endl;
+        std::cout << "\nGenerating minimal label counterexample for formula " << *formula << '\n';
 
         // Check whether there are choice origins available
         STORM_LOG_THROW(mdp.hasChoiceOrigins(), storm::exceptions::InvalidArgumentException,
@@ -1113,9 +1113,8 @@ class MILPMinimalLabelSetGenerator {
             getMinimalLabelSet(env, mdp, labelSets, phiStates, psiStates, threshold, strictBound, true,
                                storm::settings::getModule<storm::settings::modules::CounterexampleGeneratorSettings>().isUseSchedulerCutsSet());
         auto endTime = std::chrono::high_resolution_clock::now();
-        std::cout << std::endl
-                  << "Computed minimal command set of size " << usedLabelSet.size() << " in "
-                  << std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count() << "ms." << std::endl;
+        std::cout << "\nComputed minimal command set of size " << usedLabelSet.size() << " in "
+                  << std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count() << "ms.\n";
 
         if (symbolicModel.isPrismProgram()) {
             return std::make_shared<HighLevelCounterexample>(symbolicModel.asPrismProgram().restrictCommands(usedLabelSet));

--- a/src/storm-counterexamples/counterexamples/PathCounterexample.cpp
+++ b/src/storm-counterexamples/counterexamples/PathCounterexample.cpp
@@ -20,9 +20,9 @@ void PathCounterexample<ValueType>::addPath(std::vector<storage::sparse::state_t
 
 template<typename ValueType>
 void PathCounterexample<ValueType>::writeToStream(std::ostream& out) const {
-    out << "Shortest path counterexample with k = " << shortestPaths.size() << " paths: " << std::endl;
+    out << "Shortest path counterexample with k = " << shortestPaths.size() << " paths: \n";
     for (size_t i = 0; i < shortestPaths.size(); ++i) {
-        out << i + 1 << "-shortest path: " << std::endl;
+        out << i + 1 << "-shortest path: \n";
         for (auto it = shortestPaths[i].rbegin(); it != shortestPaths[i].rend(); ++it) {
             out << "\tstate " << *it;
             if (model->hasStateValuations()) {
@@ -30,7 +30,7 @@ void PathCounterexample<ValueType>::writeToStream(std::ostream& out) const {
             }
             out << ": {";
             storm::utility::outputFixedWidth(out, model->getLabelsOfState(*it), 0);
-            out << "}" << std::endl;
+            out << "}\n";
         }
     }
 }

--- a/src/storm-counterexamples/counterexamples/SMTMinimalLabelSetGenerator.h
+++ b/src/storm-counterexamples/counterexamples/SMTMinimalLabelSetGenerator.h
@@ -483,7 +483,7 @@ class SMTMinimalLabelSetGenerator {
                 //                        for (auto const& e : labelSetAndPrecedingLabelSetsPair.first) {
                 //                            std::cout << e << ", ";
                 //                        }
-                //                        std::cout << std::endl;
+                //                        std::cout << '\n';
                 // Find out the commands for the currently considered label set.
                 storm::expressions::Expression guardConjunction;
 
@@ -538,7 +538,7 @@ class SMTMinimalLabelSetGenerator {
                 if (checkResult == storm::solver::SmtSolver::CheckResult::Unsat) {
                     STORM_LOG_DEBUG("Selection not enabled in initial state.");
 
-                    // std::cout << "not gc: " << !guardConjunction << std::endl;
+                    // std::cout << "not gc: " << !guardConjunction << '\n';
                     localSolver->add(!guardConjunction);
                     STORM_LOG_DEBUG("Asserted disjunction of negated guards.");
 
@@ -547,7 +547,7 @@ class SMTMinimalLabelSetGenerator {
                         if (labelSetAndPrecedingLabelSetsPair.first == precedingLabelSet)
                             continue;
 
-                        // std::cout << "push" << std::endl;
+                        // std::cout << "push\n";
                         // Create a restore point so we can easily pop-off all weakest precondition expressions.
                         localSolver->push();
 
@@ -607,7 +607,7 @@ class SMTMinimalLabelSetGenerator {
                             }
                         }
 
-                        // std::cout << "pgc: " << preceedingGuardConjunction << std::endl;
+                        // std::cout << "pgc: " << preceedingGuardConjunction << '\n';
 
                         // Assert all the guards of the preceding command set.
                         localSolver->add(preceedingGuardConjunction);
@@ -808,11 +808,11 @@ class SMTMinimalLabelSetGenerator {
                 if (initialCombinations.find(labelSet) == initialCombinations.end() && hasKnownPredecessor.find(labelSet) == hasKnownPredecessor.end()) {
                     predecessorExpression = variableInformation.manager->boolean(false);
 
-                    //                        std::cout << "labelSet" << std::endl;
+                    //                        std::cout << "labelSet\n";
                     //                        for (auto const& e : labelSet) {
                     //                            std::cout << e << ", ";
                     //                        }
-                    //                        std::cout << std::endl;
+                    //                        std::cout << '\n';
 
                     auto const& preceedingLabelSets = backwardImplications.at(labelSet);
 
@@ -1792,7 +1792,7 @@ class SMTMinimalLabelSetGenerator {
                                 "Given probability threshold " << propertyThreshold[i] << " can not be " << (strictBound ? "achieved" : "exceeded")
                                                                << " in model with maximal reachability probability of " << maximalReachabilityProbability[i]
                                                                << ".");
-                std::cout << std::endl << "Maximal property value in model is " << maximalReachabilityProbability[i] << "." << std::endl << std::endl;
+                std::cout << "\nMaximal property value in model is " << maximalReachabilityProbability[i] << ".\n\n";
             }
         }
 
@@ -1983,25 +1983,21 @@ class SMTMinimalLabelSetGenerator {
                 allLabels.insert(e.begin(), e.end());
             }
 
-            std::cout << "Metrics:" << std::endl;
-            std::cout << "    * all labels: " << allLabels.size() << std::endl;
-            std::cout << "    * known labels: " << relevancyInformation.knownLabels.size() << std::endl;
-            std::cout << "    * relevant labels: " << (relevancyInformation.knownLabels.size() + relevancyInformation.relevantLabels.size()) << std::endl;
-            std::cout << std::endl;
-            std::cout << "Time breakdown:" << std::endl;
-            std::cout << "    * time for setup: " << std::chrono::duration_cast<std::chrono::milliseconds>(totalSetupTime).count() << "ms" << std::endl;
-            std::cout << "    * time for solving: " << std::chrono::duration_cast<std::chrono::milliseconds>(totalSolverTime).count() << "ms" << std::endl;
-            std::cout << "    * time for checking: " << std::chrono::duration_cast<std::chrono::milliseconds>(totalModelCheckingTime).count() << "ms"
-                      << std::endl;
-            std::cout << "    * time for analysis: " << std::chrono::duration_cast<std::chrono::milliseconds>(totalAnalysisTime).count() << "ms" << std::endl;
-            std::cout << "------------------------------------------" << std::endl;
-            std::cout << "    * total time: " << std::chrono::duration_cast<std::chrono::milliseconds>(totalTime).count() << "ms" << std::endl;
-            std::cout << std::endl;
-            std::cout << "Other:" << std::endl;
-            std::cout << "    * number of models checked: " << iterations << std::endl;
+            std::cout << "Metrics:\n";
+            std::cout << "    * all labels: " << allLabels.size() << '\n';
+            std::cout << "    * known labels: " << relevancyInformation.knownLabels.size() << '\n';
+            std::cout << "    * relevant labels: " << (relevancyInformation.knownLabels.size() + relevancyInformation.relevantLabels.size()) << "\n\n";
+            std::cout << "Time breakdown:\n";
+            std::cout << "    * time for setup: " << std::chrono::duration_cast<std::chrono::milliseconds>(totalSetupTime).count() << "ms\n";
+            std::cout << "    * time for solving: " << std::chrono::duration_cast<std::chrono::milliseconds>(totalSolverTime).count() << "ms\n";
+            std::cout << "    * time for checking: " << std::chrono::duration_cast<std::chrono::milliseconds>(totalModelCheckingTime).count() << "ms\n";
+            std::cout << "    * time for analysis: " << std::chrono::duration_cast<std::chrono::milliseconds>(totalAnalysisTime).count() << "ms\n";
+            std::cout << "------------------------------------------\n";
+            std::cout << "    * total time: " << std::chrono::duration_cast<std::chrono::milliseconds>(totalTime).count() << "ms\n\n";
+            std::cout << "Other:\n";
+            std::cout << "    * number of models checked: " << iterations << '\n';
             std::cout << "    * number of models that could not reach a target state: " << zeroProbabilityCount << " ("
-                      << 100 * static_cast<double>(zeroProbabilityCount) / iterations << "%)" << std::endl
-                      << std::endl;
+                      << 100 * static_cast<double>(zeroProbabilityCount) / iterations << "%)\n\n";
         }
 
         return result;
@@ -2091,9 +2087,8 @@ class SMTMinimalLabelSetGenerator {
 
         auto endTime = std::chrono::high_resolution_clock::now();
         if (!silent) {
-            std::cout << std::endl
-                      << "Extended command for lower bounded property to size " << commandSet.size() << " in "
-                      << std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count() << "ms." << std::endl;
+            std::cout << "\nExtended command for lower bounded property to size " << commandSet.size() << " in "
+                      << std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count() << "ms.\n";
         }
     }
 
@@ -2220,9 +2215,9 @@ class SMTMinimalLabelSetGenerator {
         auto endTime = std::chrono::high_resolution_clock::now();
         if (!options.silent) {
             for (auto const& labelSet : labelSets) {
-                std::cout << std::endl << "Computed minimal label set of size " << labelSet.size();
+                std::cout << "\nComputed minimal label set of size " << labelSet.size();
             }
-            std::cout << std::endl << " in " << std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count() << "ms." << std::endl;
+            std::cout << "\n in " << std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count() << "ms.\n";
         }
 
         // Extend the command set properly.
@@ -2239,7 +2234,7 @@ class SMTMinimalLabelSetGenerator {
                                                                           storm::models::sparse::Model<T> const& model,
                                                                           std::shared_ptr<storm::logic::Formula const> const& formula) {
 #ifdef STORM_HAVE_Z3
-        std::cout << std::endl << "Generating minimal label counterexample for formula " << *formula << std::endl;
+        std::cout << "\nGenerating minimal label counterexample for formula " << *formula << '\n';
         GeneratorStats stats;
         CexInput prec = precompute(env, symbolicModel, model, formula);
         if (prec.lowerBoundedFormula) {

--- a/src/storm-dft-cli/storm-dft.cpp
+++ b/src/storm-dft-cli/storm-dft.cpp
@@ -42,7 +42,7 @@ void processOptions() {
     // Show statistics about DFT (number of gates, etc.)
     if (dftIOSettings.isShowDftStatisticsSet()) {
         dft->writeStatsToStream(std::cout);
-        std::cout << std::endl;
+        std::cout << '\n';
     }
 
     // Export to json

--- a/src/storm-dft/builder/ExplicitDFTModelBuilder.cpp
+++ b/src/storm-dft/builder/ExplicitDFTModelBuilder.cpp
@@ -179,7 +179,7 @@ namespace storm {
 
                     // Build transition matrix
                     modelComponents.transitionMatrix = matrixBuilder.builder.build(1, 1);
-                    STORM_LOG_TRACE("Transition matrix: " << std::endl << modelComponents.transitionMatrix);
+                    STORM_LOG_TRACE("Transition matrix: \n" << modelComponents.transitionMatrix);
 
                     buildLabeling();
                     return;
@@ -248,7 +248,7 @@ namespace storm {
             // Build transition matrix
             modelComponents.transitionMatrix = matrixBuilder.builder.build(stateSize, stateSize);
             if (stateSize <= 15) {
-                STORM_LOG_TRACE("Transition matrix: " << std::endl << modelComponents.transitionMatrix);
+                STORM_LOG_TRACE("Transition matrix: \n" << modelComponents.transitionMatrix);
             } else {
                 STORM_LOG_TRACE("Transition matrix: too big to print");
             }
@@ -311,7 +311,7 @@ namespace storm {
             }
             STORM_LOG_TRACE("New state remapping: " << matrixBuilder.stateRemapping);
             std::stringstream ss;
-            ss << "Index remapping:" << std::endl;
+            ss << "Index remapping:\n";
             for (auto tmp : indexRemapping) {
                 ss << tmp << " ";
             }
@@ -651,7 +651,7 @@ namespace storm {
                 }
 
                 if (model->getNumberOfStates() <= 15) {
-                    STORM_LOG_TRACE("Transition matrix: " << std::endl << model->getTransitionMatrix());
+                    STORM_LOG_TRACE("Transition matrix: \n" << model->getTransitionMatrix());
                 } else {
                     STORM_LOG_TRACE("Transition matrix: too big to print");
                 }
@@ -707,7 +707,7 @@ namespace storm {
             }
 
             if (model->getNumberOfStates() <= 15) {
-                STORM_LOG_TRACE("Transition matrix: " << std::endl << model->getTransitionMatrix());
+                STORM_LOG_TRACE("Transition matrix: \n" << model->getTransitionMatrix());
             } else {
                 STORM_LOG_TRACE("Transition matrix: too big to print");
             }
@@ -942,9 +942,9 @@ namespace storm {
 
         template<typename ValueType, typename StateType>
         void ExplicitDFTModelBuilder<ValueType, StateType>::printNotExplored() const {
-            std::cout << "states not explored:" << std::endl;
+            std::cout << "states not explored:\n";
             for (auto it : statesNotExplored) {
-                std::cout << it.first << " -> " << dft.getStateString(it.second.first) << std::endl;
+                std::cout << it.first << " -> " << dft.getStateString(it.second.first) << '\n';
             }
         }
 

--- a/src/storm-dft/modelchecker/dft/DFTASFChecker.cpp
+++ b/src/storm-dft/modelchecker/dft/DFTASFChecker.cpp
@@ -549,35 +549,35 @@ namespace storm {
         void DFTASFChecker::toFile(std::string const &filename) {
             std::ofstream stream;
             storm::utility::openFile(filename, stream);
-            stream << "; time point variables" << std::endl;
+            stream << "; time point variables\n";
             for (auto const &timeVarEntry : timePointVariables) {
-                stream << "(declare-fun " << varNames[timeVarEntry.second] << "() Int)" << std::endl;
+                stream << "(declare-fun " << varNames[timeVarEntry.second] << "() Int)\n";
             }
-            stream << "; claim variables" << std::endl;
+            stream << "; claim variables\n";
             for (auto const &claimVarEntry : claimVariables) {
-                stream << "(declare-fun " << varNames[claimVarEntry.second] << "() Int)" << std::endl;
+                stream << "(declare-fun " << varNames[claimVarEntry.second] << "() Int)\n";
             }
-            stream << "; Markovian variables" << std::endl;
+            stream << "; Markovian variables\n";
             for (auto const &markovianVarEntry : markovianVariables) {
-                stream << "(declare-fun " << varNames[markovianVarEntry.second] << "() Bool)" << std::endl;
+                stream << "(declare-fun " << varNames[markovianVarEntry.second] << "() Bool)\n";
             }
-            stream << "; Dependency variables" << std::endl;
+            stream << "; Dependency variables\n";
             for (auto const &depVarEntry : dependencyVariables) {
-                stream << "(declare-fun " << varNames[depVarEntry.second] << "() Int)" << std::endl;
+                stream << "(declare-fun " << varNames[depVarEntry.second] << "() Int)\n";
             }
             if (!tmpTimePointVariables.empty()) {
-                stream << "; Temporary variables" << std::endl;
+                stream << "; Temporary variables\n";
                 for (auto const &tmpVar : tmpTimePointVariables) {
-                    stream << "(declare-fun " << varNames[tmpVar] << "() Int)" << std::endl;
+                    stream << "(declare-fun " << varNames[tmpVar] << "() Int)\n";
                 }
             }
             for (auto const &constraint : constraints) {
                 if (!constraint->description().empty()) {
-                    stream << "; " << constraint->description() << std::endl;
+                    stream << "; " << constraint->description() << '\n';
                 }
-                stream << "(assert " << constraint->toSmtlib2(varNames) << ")" << std::endl;
+                stream << "(assert " << constraint->toSmtlib2(varNames) << ")\n";
             }
-            stream << "(check-sat)" << std::endl;
+            stream << "(check-sat)\n";
             storm::utility::closeFile(stream);
         }
 

--- a/src/storm-dft/modelchecker/dft/DFTModelChecker.cpp
+++ b/src/storm-dft/modelchecker/dft/DFTModelChecker.cpp
@@ -205,7 +205,7 @@ namespace storm {
                         auto colouring = ft.colourDFT();
                         symmetries = ft.findSymmetries(colouring);
                         STORM_LOG_DEBUG("Found " << symmetries.groups.size() << " symmetries.");
-                        STORM_LOG_TRACE("Symmetries: " << std::endl << symmetries);
+                        STORM_LOG_TRACE("Symmetries: \n" << symmetries);
                     }
 
                     // Build a single CTMC
@@ -245,7 +245,7 @@ namespace storm {
                     STORM_LOG_DEBUG("No. states (Composed): " << composedModel->getNumberOfStates());
                     STORM_LOG_DEBUG("No. transitions (Composed): " << composedModel->getNumberOfTransitions());
                     if (composedModel->getNumberOfStates() <= 15) {
-                        STORM_LOG_TRACE("Transition matrix: " << std::endl << composedModel->getTransitionMatrix());
+                        STORM_LOG_TRACE("Transition matrix: \n" << composedModel->getTransitionMatrix());
                     } else {
                         STORM_LOG_TRACE("Transition matrix: too big to print");
                     }
@@ -268,7 +268,7 @@ namespace storm {
                     auto colouring = dft.colourDFT();
                     symmetries = dft.findSymmetries(colouring);
                     STORM_LOG_DEBUG("Found " << symmetries.groups.size() << " symmetries.");
-                    STORM_LOG_TRACE("Symmetries: " << std::endl << symmetries);
+                    STORM_LOG_TRACE("Symmetries: \n" << symmetries);
                 }
                 // Build a single CTMC
                 STORM_LOG_DEBUG("Building Model...");
@@ -304,7 +304,7 @@ namespace storm {
                 auto colouring = dft.colourDFT();
                 symmetries = dft.findSymmetries(colouring);
                 STORM_LOG_DEBUG("Found " << symmetries.groups.size() << " symmetries.");
-                STORM_LOG_TRACE("Symmetries: " << std::endl << symmetries);
+                STORM_LOG_TRACE("Symmetries: \n" << symmetries);
             }
 
             if (approximationError > 0.0) {
@@ -346,7 +346,7 @@ namespace storm {
                     model = builder.getModelApproximation(true, !probabilityFormula);
                     // We only output the info from the lower bound as the info for the upper bound is the same
                     if (printInfo && dftIOSettings.isShowDftStatisticsSet()) {
-                        std::cout << "Model in iteration " << (iteration + 1) << ":" << std::endl;
+                        std::cout << "Model in iteration " << (iteration + 1) << ":\n";
                         model->printModelInformationToStream(std::cout);
                     }
                     buildingTimer.stop();
@@ -385,9 +385,9 @@ namespace storm {
                                                             << approxResult.second);
                     totalTimer.stop();
                     if (printInfo && dftIOSettings.isShowDftStatisticsSet()) {
-                        std::cout << "Result after iteration " << (iteration + 1) << ": (" << std::setprecision(10) << approxResult.first << ", " << approxResult.second << ")" << std::endl;
+                        std::cout << "Result after iteration " << (iteration + 1) << ": (" << std::setprecision(10) << approxResult.first << ", " << approxResult.second << ")\n";
                         printTimings();
-                        std::cout << std::endl;
+                        std::cout << '\n';
                     } else {
                         STORM_LOG_DEBUG("Result after iteration " << (iteration + 1) << ": (" << std::setprecision(10) << approxResult.first << ", " << approxResult.second << ")");
                     }
@@ -474,7 +474,7 @@ namespace storm {
             for (auto property : properties) {
                 singleModelCheckingTimer.reset();
                 singleModelCheckingTimer.start();
-                //STORM_PRINT_AND_LOG("Model checking property " << *property << " ..." << std::endl);
+                //STORM_PRINT_AND_LOG("Model checking property " << *property << " ...\n");
                 std::unique_ptr<storm::modelchecker::CheckResult> result(
                         storm::api::verifyWithSparseEngine<ValueType>(model, storm::api::createTask<ValueType>(property,true)));
 
@@ -486,9 +486,9 @@ namespace storm {
                     STORM_LOG_WARN("The property '" << *property << "' could not be checked with the current settings.");
                     results.push_back(-storm::utility::one<ValueType>());
                 }
-                //STORM_PRINT_AND_LOG("Result (initial states): " << resultValue << std::endl);
+                //STORM_PRINT_AND_LOG("Result (initial states): " << resultValue << '\n');
                 singleModelCheckingTimer.stop();
-                //STORM_PRINT_AND_LOG("Time for model checking: " << singleModelCheckingTimer << "." << std::endl);
+                //STORM_PRINT_AND_LOG("Time for model checking: " << singleModelCheckingTimer << ".\n");
             }
             modelCheckingTimer.stop();
             STORM_LOG_DEBUG("Model checking done.");
@@ -514,12 +514,12 @@ namespace storm {
 
         template<typename ValueType>
         void DFTModelChecker<ValueType>::printTimings(std::ostream &os) {
-            os << "Times:" << std::endl;
-            os << "Exploration:\t" << explorationTimer << std::endl;
-            os << "Building:\t" << buildingTimer << std::endl;
-            os << "Bisimulation:\t" << bisimulationTimer << std::endl;
-            os << "Modelchecking:\t" << modelCheckingTimer << std::endl;
-            os << "Total:\t\t" << totalTimer << std::endl;
+            os << "Times:\n";
+            os << "Exploration:\t" << explorationTimer << '\n';
+            os << "Building:\t" << buildingTimer << '\n';
+            os << "Bisimulation:\t" << bisimulationTimer << '\n';
+            os << "Modelchecking:\t" << modelCheckingTimer << '\n';
+            os << "Total:\t\t" << totalTimer << '\n';
         }
 
         template<typename ValueType>
@@ -535,7 +535,7 @@ namespace storm {
                 boost::variant<std::ostream&> stream(os);
                 boost::apply_visitor(ResultOutputVisitor(), result, stream);
             }
-            os << "]" << std::endl;
+            os << "]\n";
         }
 
 

--- a/src/storm-dft/parser/DFTGalileoParser.cpp
+++ b/src/storm-dft/parser/DFTGalileoParser.cpp
@@ -169,8 +169,8 @@ namespace storm {
 
             // Build DFT
             storm::storage::DFT<ValueType> dft = builder.build();
-            STORM_LOG_DEBUG("DFT Elements:" << std::endl << dft.getElementsString());
-            STORM_LOG_DEBUG("Spare Modules:" << std::endl << dft.getSpareModulesString());
+            STORM_LOG_DEBUG("DFT Elements:\n" << dft.getElementsString());
+            STORM_LOG_DEBUG("Spare Modules:\n" << dft.getSpareModulesString());
             return dft;
         }
 

--- a/src/storm-dft/parser/DFTJsonParser.cpp
+++ b/src/storm-dft/parser/DFTJsonParser.cpp
@@ -159,8 +159,8 @@ namespace storm {
 
             // Build DFT
             storm::storage::DFT<ValueType> dft = builder.build();
-            STORM_LOG_DEBUG("Elements:" << std::endl << dft.getElementsString());
-            STORM_LOG_DEBUG("Spare Modules:" << std::endl << dft.getSpareModulesString());
+            STORM_LOG_DEBUG("Elements:\n" << dft.getElementsString());
+            STORM_LOG_DEBUG("Spare Modules:\n" << dft.getSpareModulesString());
             return dft;
 
         }

--- a/src/storm-dft/storage/BucketPriorityQueue.cpp
+++ b/src/storm-dft/storage/BucketPriorityQueue.cpp
@@ -170,18 +170,18 @@ namespace storm {
 
         template<typename PriorityType>
         void BucketPriorityQueue<PriorityType>::print(std::ostream& out) const {
-            out << "Bucket priority queue with size " << buckets.size() << ", lower value: " << lowerValue << " and logBase: " << logBase << std::endl;
+            out << "Bucket priority queue with size " << buckets.size() << ", lower value: " << lowerValue << " and logBase: " << logBase << '\n';
             out << "Immediate bucket: ";
             for (auto item : immediateBucket) {
                 out << item->getId() << ", ";
             }
-            out << std::endl;
-            out << "Current bucket (" << currentBucket << ") has " << nrUnsortedItems  << " unsorted items" << std::endl;
+            out << '\n';
+            out << "Current bucket (" << currentBucket << ") has " << nrUnsortedItems  << " unsorted items\n";
             for (size_t bucket = 0; bucket < buckets.size(); ++bucket) {
                 if (!buckets[bucket].empty()) {
-                    out << "Bucket " << bucket << ":" << std::endl;
+                    out << "Bucket " << bucket << ":\n";
                     for (auto item : buckets[bucket]) {
-                        out << "\t" << item->getId() << ": " << item->getPriority() << std::endl;
+                        out << "\t" << item->getId() << ": " << item->getPriority() << '\n';
                     }
                 }
             }
@@ -193,7 +193,7 @@ namespace storm {
             for (size_t bucket = 0; bucket < buckets.size(); ++bucket) {
                 out << buckets[bucket].size() << " ";
             }
-            out << std::endl;
+            out << '\n';
         }
 
         // Template instantiations

--- a/src/storm-dft/storage/dft/DFT.cpp
+++ b/src/storm-dft/storage/dft/DFT.cpp
@@ -596,7 +596,7 @@ namespace storm {
         std::string DFT<ValueType>::getElementsString() const {
             std::stringstream stream;
             for (auto const& elem : mElements) {
-                stream << "[" << elem->id() << "]" << *elem << std::endl;
+                stream << "[" << elem->id() << "]" << *elem << '\n';
             }
             return stream.str();
         }
@@ -614,7 +614,7 @@ namespace storm {
             stream << "[" << mElements[mTopLevelIndex]->id() << "] {";
             std::vector<size_t>::const_iterator it = mTopModule.begin();
             if (it == mTopModule.end()) {
-                stream << "}" << std::endl;
+                stream << "}\n";
                 return stream.str();
             }
             STORM_LOG_ASSERT(it != mTopModule.end(), "Element not found.");
@@ -624,7 +624,7 @@ namespace storm {
                 stream << ", " << mElements[(*it)]->name();
                 ++it;
             }
-            stream << "}" << std::endl;
+            stream << "}\n";
 
             for (auto const& spareModule : mSpareModules) {
                 stream << "[" << mElements[spareModule.first]->name() << "] = {";
@@ -638,7 +638,7 @@ namespace storm {
                         ++it;
                     }
                 }
-                stream << "}" << std::endl;
+                stream << "}\n";
             }
             return stream.str();
         }
@@ -661,7 +661,7 @@ namespace storm {
                         stream << "using " << useId;
                     }
                 }
-                stream << std::endl;
+                stream << '\n';
             }
             return stream.str();
         }
@@ -763,7 +763,7 @@ namespace storm {
                     for (auto module2 = std::next(module1); module2 != mSpareModules.end(); ++module2) {
                         if (std::find(module2->second.begin(), module2->second.end(), firstElement) != module2->second.end()) {
                             if (!wellformed) {
-                                stream << std::endl;
+                                stream << '\n';
                             }
                             stream << "Spare modules of '" << getElement(module1->first)->name() << "' and '" << getElement(module2->first)->name() << "' should not overlap.";
                             wellformed = false;
@@ -778,7 +778,7 @@ namespace storm {
                     std::shared_ptr<DFTDependency<ValueType> const> dependency = this->getDependency(idDependency);
                     if (dependency->dependentEvents().size() != 1) {
                         if (!wellformed) {
-                            stream << std::endl;
+                            stream << '\n';
                         }
                         stream << "Dependency '" << dependency->name() << "' is not binary.";
                         wellformed = false;
@@ -1140,40 +1140,40 @@ namespace storm {
             STORM_LOG_ASSERT(noBE + noStatic + noDynamic == nrElements(), "No. of elements does not match.");
 
             // Print output
-            stream << "=============DFT Statistics==============" << std::endl;
-            stream << "Number of BEs: " << nrBasicElements() << std::endl;
-            stream << "Number of static elements: " << noStatic << std::endl;
-            stream << "Number of dynamic elements: " << noDynamic << std::endl;
-            stream << "Number of elements: " << nrElements() << std::endl;
-            stream << "-----------------------------------------" << std::endl;
+            stream << "=============DFT Statistics==============\n";
+            stream << "Number of BEs: " << nrBasicElements() << '\n';
+            stream << "Number of static elements: " << noStatic << '\n';
+            stream << "Number of dynamic elements: " << noDynamic << '\n';
+            stream << "Number of elements: " << nrElements() << '\n';
+            stream << "-----------------------------------------\n";
             if (noBE > 0) {
-                stream << "Number of BEs: " << noBE << std::endl;
+                stream << "Number of BEs: " << noBE << '\n';
             }
             if (noAnd > 0) {
-                stream << "Number of AND gates: " << noAnd << std::endl;
+                stream << "Number of AND gates: " << noAnd << '\n';
             }
             if (noOr > 0) {
-                stream << "Number of OR gates: " << noOr << std::endl;
+                stream << "Number of OR gates: " << noOr << '\n';
             }
             if (noVot > 0) {
-                stream << "Number of VOT gates: " << noVot << std::endl;
+                stream << "Number of VOT gates: " << noVot << '\n';
             }
             if (noPand > 0) {
-                stream << "Number of PAND gates: " << noPand << std::endl;
+                stream << "Number of PAND gates: " << noPand << '\n';
             }
             if (noPor > 0) {
-                stream << "Number of POR gates: " << noPor << std::endl;
+                stream << "Number of POR gates: " << noPor << '\n';
             }
             if (noSpare > 0) {
-                stream << "Number of SPARE gates: " << noSpare << std::endl;
+                stream << "Number of SPARE gates: " << noSpare << '\n';
             }
             if (noDependency > 0) {
-                stream << "Number of Dependencies: " << noDependency << std::endl;
+                stream << "Number of Dependencies: " << noDependency << '\n';
             }
             if (noRestriction > 0) {
-                stream << "Number of Restrictions: " << noRestriction << std::endl;
+                stream << "Number of Restrictions: " << noRestriction << '\n';
             }
-            stream << "=========================================" << std::endl;
+            stream << "=========================================\n";
         }
 
         // Explicitly instantiate the class.

--- a/src/storm-dft/storage/dft/DFTStateGenerationInfo.h
+++ b/src/storm-dft/storage/dft/DFTStateGenerationInfo.h
@@ -178,27 +178,27 @@ namespace storm {
             }
 
             friend std::ostream& operator<<(std::ostream& os, DFTStateGenerationInfo const& info) {
-                os << "StateGenerationInfo:" << std::endl;
-                os << "Length of state vector: " << info.stateIndexSize << std::endl;
-                os << "Id to state index:" << std::endl;
+                os << "StateGenerationInfo:\n";
+                os << "Length of state vector: " << info.stateIndexSize << '\n';
+                os << "Id to state index:\n";
                 for (size_t id = 0; id < info.mIdToStateIndex.size(); ++id) {
-                    os << id << " -> " << info.getStateIndex(id) << std::endl;
+                    os << id << " -> " << info.getStateIndex(id) << '\n';
                 }
-                os << "Spare usage index with usage InfoBits of size " << info.mUsageInfoBits << ":" << std::endl;
+                os << "Spare usage index with usage InfoBits of size " << info.mUsageInfoBits << ":\n";
                 for (auto pair : info.mSpareUsageIndex) {
-                    os << pair.first << " -> " << pair.second << std::endl;
+                    os << pair.first << " -> " << pair.second << '\n';
                 }
-                os << "Spare activation index:" << std::endl;
+                os << "Spare activation index:\n";
                 for (auto pair : info.mSpareActivationIndex) {
-                    os << pair.first << " -> " << pair.second << std::endl;
+                    os << pair.first << " -> " << pair.second << '\n';
                 }
-                os << "Symmetries:" << std::endl;
+                os << "Symmetries:\n";
                 for (auto pair : info.mSymmetries) {
                     os << "Length: " << pair.first << ", starting indices: ";
                     for (size_t index : pair.second) {
                         os << index << ", ";
                     }
-                    os << std::endl;
+                    os << '\n';
                 }
                 return os;
             }

--- a/src/storm-dft/storage/dft/DftJsonExporter.cpp
+++ b/src/storm-dft/storage/dft/DftJsonExporter.cpp
@@ -20,7 +20,7 @@ namespace storm {
 
         template<typename ValueType>
         void DftJsonExporter<ValueType>::toStream(storm::storage::DFT<ValueType> const& dft, std::ostream& os) {
-            os << translate(dft).dump(4) << std::endl;
+            os << translate(dft).dump(4) << '\n';
         }
 
         template<typename ValueType>

--- a/src/storm-dft/storage/dft/SymmetricUnits.h
+++ b/src/storm-dft/storage/dft/SymmetricUnits.h
@@ -151,12 +151,12 @@ namespace storm {
         
         inline std::ostream& operator<<(std::ostream& os, DFTIndependentSymmetries const& s)  {
             for(size_t index : s.sortedSymmetries) {
-                os << "Symmetry group for " << index << std::endl;
+                os << "Symmetry group for " << index << '\n';
                 for(auto const& eqClass : s.groups.at(index)) {
                     for(auto const& i : eqClass) {
                         os << i << " ";
                     }
-                    os << std::endl;
+                    os << '\n';
                 }
             }
             return os;

--- a/src/storm-gspn/api/storm-gspn.cpp
+++ b/src/storm-gspn/api/storm-gspn.cpp
@@ -48,9 +48,9 @@ void handleGSPNExportSettings(storm::gspn::GSPN const& gspn,
     }
 
     if (exportSettings.isDisplayStatsSet()) {
-        std::cout << "============GSPN Statistics==============" << std::endl;
+        std::cout << "============GSPN Statistics==============\n";
         gspn.writeStatsToStream(std::cout);
-        std::cout << "=========================================" << std::endl;
+        std::cout << "=========================================\n";
     }
 
     if (exportSettings.isWriteStatsToFileSet()) {

--- a/src/storm-gspn/builder/ExplicitGspnModelBuilder.cpp
+++ b/src/storm-gspn/builder/ExplicitGspnModelBuilder.cpp
@@ -46,7 +46,7 @@
 //                // create new row group for the current marking
 //                builder.newRowGroup(markings.getValue(*currentBitvector));
 //
-//                std::cout << "work on: " << *currentBitvector << std::endl;
+//                std::cout << "work on: " << *currentBitvector << '\n';
 //
 //                auto enabledImmediateTransitions = getEnabledImmediateTransition(currentMarking);
 //                if (!enabledImmediateTransitions.empty()) {
@@ -62,7 +62,7 @@
 //                        markovianStates.set(currentRowIndex, 1);
 //
 //                        auto accRate = getAccumulatedRate(enabledTimedTransitions);
-//                        std::cout << "\t\tacc. rate: " << accRate << std::endl;
+//                        std::cout << "\t\tacc. rate: " << accRate << '\n';
 //                        exitRates.push_back(accRate);
 //
 //                        addRowForTimedTransitions(enabledTimedTransitions, currentMarking, accRate);
@@ -90,8 +90,8 @@
 //            storm::models::sparse::StateLabeling labeling(markings.size());
 //            storm::expressions::ExpressionEvaluator<double> expressionEvaluator(*expressionManager);
 //
-//            std::cout << std::endl;
-//            std::cout << "build labeling:" << std::endl;
+//            std::cout << '\n';
+//            std::cout << "build labeling:\n";
 //            for (auto& atomicFormula : atomicFormulas) {
 //                std::cout << atomicFormula;
 //                auto label = atomicFormula->toString();
@@ -120,15 +120,15 @@
 //        void ExplicitGspnModelBuilder<ValueType>::addRowForPartitions(std::vector<std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>>>
 //        const& partitions, storm::gspn::Marking const& currentMarking) {
 //            for (auto& partition : partitions) {
-//                std::cout << "\tnew partition:" << std::endl;
+//                std::cout << "\tnew partition:\n";
 //                auto accWeight = getAccumulatedWeight(partition);
-//                std::cout << "\t\tacc. weight: " << accWeight << std::endl;
+//                std::cout << "\t\tacc. weight: " << accWeight << '\n';
 //
 //                std::map<uint_fast64_t , double, storm::builder::ExplicitGspnModelBuilder<ValueType>::cmpByIndex> weights;
 //                for (auto& trans : partition) {
-//                    std::cout << "\t\ttransname: " << trans.getName() << std::endl;
+//                    std::cout << "\t\ttransname: " << trans.getName() << '\n';
 //                    auto newMarking = trans.fire(currentMarking);
-//                    std::cout << "\t\t\t target marking: " << *newMarking.getBitVector() << std::endl;
+//                    std::cout << "\t\t\t target marking: " << *newMarking.getBitVector() << '\n';
 //
 //                    findOrAddBitvectorToMarkings(*newMarking.getBitVector());
 //
@@ -150,9 +150,9 @@
 //        enabledTimedTransitions, storm::gspn::Marking const& currentMarking, double const& accRate) {
 //            std::map<uint_fast64_t , double, storm::builder::ExplicitGspnModelBuilder<ValueType>::cmpByIndex> rates;
 //            for (auto& trans : enabledTimedTransitions) {
-//                std::cout << "\t\ttransname: " << trans.getName() << std::endl;
+//                std::cout << "\t\ttransname: " << trans.getName() << '\n';
 //                auto newMarking = trans.fire(currentMarking);
-//                std::cout << "\t\t\t target marking: " << *newMarking.getBitVector() << std::endl;
+//                std::cout << "\t\t\t target marking: " << *newMarking.getBitVector() << '\n';
 //
 //                findOrAddBitvectorToMarkings(*newMarking.getBitVector());
 //
@@ -173,7 +173,7 @@
 //        void ExplicitGspnModelBuilder<ValueType>::addValuesToBuilder(std::map<uint_fast64_t , double,
 //        storm::builder::ExplicitGspnModelBuilder<ValueType>::cmpByIndex> const& values) {
 //            for (auto& it : values) {
-//                std::cout << "\t\tadd value \"" << it.second << "\" to " << getBitvector(it.first) << std::endl;
+//                std::cout << "\t\tadd value \"" << it.second << "\" to " << getBitvector(it.first) << '\n';
 //                builder.addNextValue(currentRowIndex, it.first, it.second);
 //            }
 //        }
@@ -318,7 +318,7 @@
 //                storm::gspn::Marking marking(gspn.getNumberOfPlaces(), numberOfBits, bitvector);
 //                for (auto i = 0; i < marking.getNumberOfPlaces(); i++) {
 //                    if (marking.getNumberOfTokensAt(i) > 0) {
-//                        std::cout << i << std::endl;
+//                        std::cout << i << '\n';
 //                        labeling.addLabelToState(idToName.at(i), i);
 //                    }
 //                }

--- a/src/storm-gspn/builder/JaniGSPNBuilder.cpp
+++ b/src/storm-gspn/builder/JaniGSPNBuilder.cpp
@@ -92,7 +92,7 @@ void JaniGSPNBuilder::addEdges(storm::jani::Automaton& automaton, uint64_t locId
         for (auto const& transId : partition.transitions) {
             auto const& trans = gspn.getImmediateTransitions()[transId];
             if (trans.noWeightAttached()) {
-                std::cout << "ERROR -- no weights attached at transition" << std::endl;
+                std::cout << "ERROR -- no weights attached at transition\n";
                 continue;
             }
             storm::expressions::Expression destguard = expressionManager->boolean(true);

--- a/src/storm-gspn/parser/GreatSpnEditorProjectParser.cpp
+++ b/src/storm-gspn/parser/GreatSpnEditorProjectParser.cpp
@@ -182,7 +182,7 @@ void GreatSpnEditorProjectParser::traverseConstantOrTemplateElement(xercesc::DOM
             } else if (storm::adapters::XMLtoString(attr->getNodeValue()).compare("INTEGER") == 0) {
                 type = manager->getIntegerType();
             } else {
-                STORM_PRINT_AND_LOG("Unknown consttype: " << storm::adapters::XMLtoString(attr->getNodeValue()) << std::endl);
+                STORM_PRINT_AND_LOG("Unknown consttype: " << storm::adapters::XMLtoString(attr->getNodeValue()) << '\n');
             }
         } else if (name.compare("value") == 0) {
             valueStr = storm::adapters::XMLtoString(attr->getNodeValue());

--- a/src/storm-gspn/storage/gspn/GSPN.cpp
+++ b/src/storm-gspn/storage/gspn/GSPN.cpp
@@ -152,28 +152,28 @@ void GSPN::setCapacities(std::unordered_map<std::string, uint64_t> const& mappin
 }
 
 void GSPN::writeDotToStream(std::ostream& outStream) const {
-    outStream << "digraph " << this->getName() << " {" << std::endl;
+    outStream << "digraph " << this->getName() << " {\n";
 
     // print places with initial marking (not printed is the capacity)
     outStream << "\t"
-              << "node [shape=ellipse]" << std::endl;
+              << "node [shape=ellipse]\n";
     for (auto& place : this->getPlaces()) {
         outStream << "\t" << place.getName() << " [label=\"" << place.getName() << "(" << place.getNumberOfInitialTokens();
-        outStream << ")\"];" << std::endl;
+        outStream << ")\"];\n";
     }
 
     // print transitions with weight/rate
     outStream << "\t"
-              << "node [shape=box]" << std::endl;
+              << "node [shape=box]\n";
 
     for (auto& trans : this->getImmediateTransitions()) {
         outStream << "\t" << trans.getName() << " [fontcolor=white, style=filled, fillcolor=black, label=<" << trans.getName()
-                  << "<br/><FONT POINT-SIZE=\"10\"> π = " + std::to_string(trans.getPriority()) << "</FONT>>];" << std::endl;
+                  << "<br/><FONT POINT-SIZE=\"10\"> π = " + std::to_string(trans.getPriority()) << "</FONT>>];\n";
     }
 
     for (auto& trans : this->getTimedTransitions()) {
         outStream << "\t" << trans.getName() << " [label=\"" << trans.getName();
-        outStream << "(" << trans.getRate() << ")\"];" << std::endl;
+        outStream << "(" << trans.getRate() << ")\"];\n";
         STORM_LOG_WARN_COND(trans.hasSingleServerSemantics(), "Unable to export non-trivial transition semantics");  // TODO
     }
 
@@ -182,27 +182,27 @@ void GSPN::writeDotToStream(std::ostream& outStream) const {
         for (auto const& inEntry : trans.getInputPlaces()) {
             if (trans.getOutputPlaces().count(inEntry.first) == 0) {
                 outStream << "\t" << places.at(inEntry.first).getName() << " -> " << trans.getName() << "[label=\""
-                          << (inEntry.second > 1 ? std::to_string(inEntry.second) : "") << "\"];" << std::endl;
+                          << (inEntry.second > 1 ? std::to_string(inEntry.second) : "") << "\"];\n";
             }
         }
 
         for (auto const& inhEntry : trans.getInhibitionPlaces()) {
             if (trans.getOutputPlaces().count(inhEntry.first) == 0) {
                 outStream << "\t" << places.at(inhEntry.first).getName() << " -> " << trans.getName() << "[arrowhead=\"dot\", label=\""
-                          << (inhEntry.second > 1 ? std::to_string(inhEntry.second) : "") << "\"];" << std::endl;
+                          << (inhEntry.second > 1 ? std::to_string(inhEntry.second) : "") << "\"];\n";
             }
         }
 
         for (auto const& outEntry : trans.getOutputPlaces()) {
             if (trans.getInhibitionPlaces().count(outEntry.first) == 1) {
                 outStream << "\t" << trans.getName() << " -> " << places.at(outEntry.first).getName() << "[arrowtail=\"dot\", label=\""
-                          << (outEntry.second > 1 ? std::to_string(outEntry.second) : "") << "\", dir=both];" << std::endl;
+                          << (outEntry.second > 1 ? std::to_string(outEntry.second) : "") << "\", dir=both];\n";
             } else if (trans.getInputPlaces().count(outEntry.first) == 1) {
                 outStream << "\t" << trans.getName() << " -> " << places.at(outEntry.first).getName() << "[label=\""
-                          << (outEntry.second > 1 ? std::to_string(outEntry.second) : "") << "\", dir=both];" << std::endl;
+                          << (outEntry.second > 1 ? std::to_string(outEntry.second) : "") << "\", dir=both];\n";
             } else {
                 outStream << "\t" << trans.getName() << " -> " << places.at(outEntry.first).getName() << "[label=\""
-                          << (outEntry.second > 1 ? std::to_string(outEntry.second) : "") << "\"];" << std::endl;
+                          << (outEntry.second > 1 ? std::to_string(outEntry.second) : "") << "\"];\n";
             }
         }
     }
@@ -211,32 +211,32 @@ void GSPN::writeDotToStream(std::ostream& outStream) const {
         for (auto const& inEntry : trans.getInputPlaces()) {
             if (trans.getOutputPlaces().count(inEntry.first) == 0) {
                 outStream << "\t" << places.at(inEntry.first).getName() << " -> " << trans.getName() << "[label=\""
-                          << (inEntry.second > 1 ? std::to_string(inEntry.second) : "") << "\"];" << std::endl;
+                          << (inEntry.second > 1 ? std::to_string(inEntry.second) : "") << "\"];\n";
             }
         }
 
         for (auto const& inhEntry : trans.getInhibitionPlaces()) {
             if (trans.getOutputPlaces().count(inhEntry.first) == 0) {
                 outStream << "\t" << places.at(inhEntry.first).getName() << " -> " << trans.getName() << "[arrowhead=\"dot\", label=\""
-                          << (inhEntry.second > 1 ? std::to_string(inhEntry.second) : "") << "\"];" << std::endl;
+                          << (inhEntry.second > 1 ? std::to_string(inhEntry.second) : "") << "\"];\n";
             }
         }
 
         for (auto const& outEntry : trans.getOutputPlaces()) {
             if (trans.getInhibitionPlaces().count(outEntry.first) == 1) {
                 outStream << "\t" << trans.getName() << " -> " << places.at(outEntry.first).getName() << "[arrowtail=\"dot\", label=\""
-                          << (outEntry.second > 1 ? std::to_string(outEntry.second) : "") << "\", dir=both];" << std::endl;
+                          << (outEntry.second > 1 ? std::to_string(outEntry.second) : "") << "\", dir=both];\n";
             } else if (trans.getInputPlaces().count(outEntry.first) == 1) {
                 outStream << "\t" << trans.getName() << " -> " << places.at(outEntry.first).getName() << "[label=\""
-                          << (outEntry.second > 1 ? std::to_string(outEntry.second) : "") << "\", dir=both];" << std::endl;
+                          << (outEntry.second > 1 ? std::to_string(outEntry.second) : "") << "\", dir=both];\n";
             } else {
                 outStream << "\t" << trans.getName() << " -> " << places.at(outEntry.first).getName() << "[label=\""
-                          << (outEntry.second > 1 ? std::to_string(outEntry.second) : "") << "\"];" << std::endl;
+                          << (outEntry.second > 1 ? std::to_string(outEntry.second) : "") << "\"];\n";
             }
         }
     }
 
-    outStream << "}" << std::endl;
+    outStream << "}\n";
 }
 
 void GSPN::setName(std::string const& name) {
@@ -422,11 +422,11 @@ void GSPN::toPnpro(std::ostream& stream) const {
     auto space2 = "    ";
     auto space3 = "      ";
     auto projectName = "storm-export";  // TODO add to args
-    stream << "<project name=\"" << projectName << "\" version=\"121\">" << std::endl;
-    stream << space << "<gspn name=\"" << getName() << "\" >" << std::endl;
+    stream << "<project name=\"" << projectName << "\" version=\"121\">\n";
+    stream << space << "<gspn name=\"" << getName() << "\" >\n";
 
     u_int32_t x = 1;
-    stream << space2 << "<nodes>" << std::endl;
+    stream << space2 << "<nodes>\n";
     for (auto& place : places) {
         stream << space3 << "<place marking=\"" << place.getNumberOfInitialTokens() << "\" ";
         stream << "name =\"" << place.getName() << "\" ";
@@ -437,7 +437,7 @@ void GSPN::toPnpro(std::ostream& stream) const {
             stream << "x=\"" << x << "\" ";
             stream << "y=\"1\" ";
         }
-        stream << "/>" << std::endl;
+        stream << "/>\n";
         x = x + 3;
     }
     x = 1;
@@ -457,7 +457,7 @@ void GSPN::toPnpro(std::ostream& stream) const {
             stream << "x=\"" << x << "\" ";
             stream << "y=\"4\" ";
         }
-        stream << "/>" << std::endl;
+        stream << "/>\n";
         x = x + 3;
     }
     for (auto& trans : immediateTransitions) {
@@ -472,12 +472,12 @@ void GSPN::toPnpro(std::ostream& stream) const {
             stream << "x=\"" << x << "\" ";
             stream << "y=\"4\" ";
         }
-        stream << "/>" << std::endl;
+        stream << "/>\n";
         x = x + 3;
     }
-    stream << space2 << "</nodes>" << std::endl;
+    stream << space2 << "</nodes>\n";
 
-    stream << space2 << "<edges>" << std::endl;
+    stream << space2 << "<edges>\n";
     for (auto& trans : timedTransitions) {
         for (auto const& inEntry : trans.getInputPlaces()) {
             stream << space3 << "<arc ";
@@ -485,7 +485,7 @@ void GSPN::toPnpro(std::ostream& stream) const {
             stream << "tail=\"" << places.at(inEntry.first).getName() << "\" ";
             stream << "kind=\"INPUT\" ";
             stream << "mult=\"" << inEntry.second << "\" ";
-            stream << "/>" << std::endl;
+            stream << "/>\n";
         }
         for (auto const& inhEntry : trans.getInhibitionPlaces()) {
             stream << space3 << "<arc ";
@@ -493,7 +493,7 @@ void GSPN::toPnpro(std::ostream& stream) const {
             stream << "tail=\"" << places.at(inhEntry.first).getName() << "\" ";
             stream << "kind=\"INHIBITOR\" ";
             stream << "mult=\"" << inhEntry.second << "\" ";
-            stream << "/>" << std::endl;
+            stream << "/>\n";
         }
         for (auto const& outEntry : trans.getOutputPlaces()) {
             stream << space3 << "<arc ";
@@ -501,7 +501,7 @@ void GSPN::toPnpro(std::ostream& stream) const {
             stream << "tail=\"" << trans.getName() << "\" ";
             stream << "kind=\"OUTPUT\" ";
             stream << "mult=\"" << outEntry.second << "\" ";
-            stream << "/>" << std::endl;
+            stream << "/>\n";
         }
     }
     for (auto& trans : immediateTransitions) {
@@ -511,7 +511,7 @@ void GSPN::toPnpro(std::ostream& stream) const {
             stream << "tail=\"" << places.at(inEntry.first).getName() << "\" ";
             stream << "kind=\"INPUT\" ";
             stream << "mult=\"" << inEntry.second << "\" ";
-            stream << "/>" << std::endl;
+            stream << "/>\n";
         }
         for (auto const& inhEntry : trans.getInhibitionPlaces()) {
             stream << space3 << "<arc ";
@@ -519,7 +519,7 @@ void GSPN::toPnpro(std::ostream& stream) const {
             stream << "tail=\"" << places.at(inhEntry.first).getName() << "\" ";
             stream << "kind=\"INHIBITOR\" ";
             stream << "mult=\"" << inhEntry.second << "\" ";
-            stream << "/>" << std::endl;
+            stream << "/>\n";
         }
         for (auto const& outEntry : trans.getOutputPlaces()) {
             stream << space3 << "<arc ";
@@ -527,12 +527,12 @@ void GSPN::toPnpro(std::ostream& stream) const {
             stream << "tail=\"" << trans.getName() << "\" ";
             stream << "kind=\"OUTPUT\" ";
             stream << "mult=\"" << outEntry.second << "\" ";
-            stream << "/>" << std::endl;
+            stream << "/>\n";
         }
     }
-    stream << space2 << "</edges>" << std::endl;
-    stream << space << "</gspn>" << std::endl;
-    stream << "</project>" << std::endl;
+    stream << space2 << "</edges>\n";
+    stream << space << "</gspn>\n";
+    stream << "</project>\n";
 }
 
 void GSPN::toPnml(std::ostream& stream) const {
@@ -541,46 +541,46 @@ void GSPN::toPnml(std::ostream& stream) const {
     std::string space3 = "      ";
     std::string space4 = "        ";
 
-    stream << "<pnml>" << std::endl;
-    stream << space << "<net id=\"" << getName() << "\">" << std::endl;
+    stream << "<pnml>\n";
+    stream << space << "<net id=\"" << getName() << "\">\n";
 
     // add places
     for (const auto& place : places) {
-        stream << space2 << "<place id=\"" << place.getName() << "\">" << std::endl;
-        stream << space3 << "<initialMarking>" << std::endl;
-        stream << space4 << "<value>Default," << place.getNumberOfInitialTokens() << "</value>" << std::endl;
-        stream << space3 << "</initialMarking>" << std::endl;
+        stream << space2 << "<place id=\"" << place.getName() << "\">\n";
+        stream << space3 << "<initialMarking>\n";
+        stream << space4 << "<value>Default," << place.getNumberOfInitialTokens() << "</value>\n";
+        stream << space3 << "</initialMarking>\n";
         if (place.hasRestrictedCapacity()) {
-            stream << space3 << "<capacity>" << std::endl;
-            stream << space4 << "<value>Default," << place.getCapacity() << "</value>" << std::endl;
-            stream << space3 << "</capacity>" << std::endl;
+            stream << space3 << "<capacity>\n";
+            stream << space4 << "<value>Default," << place.getCapacity() << "</value>\n";
+            stream << space3 << "</capacity>\n";
         }
-        stream << space2 << "</place>" << std::endl;
+        stream << space2 << "</place>\n";
     }
 
     // add immediate transitions
     for (const auto& trans : immediateTransitions) {
-        stream << space2 << "<transition id=\"" << trans.getName() << "\">" << std::endl;
-        stream << space3 << "<rate>" << std::endl;
-        stream << space4 << "<value>" << trans.getWeight() << "</value>" << std::endl;
-        stream << space3 << "</rate>" << std::endl;
-        stream << space3 << "<timed>" << std::endl;
-        stream << space4 << "<value>false</value>" << std::endl;
-        stream << space3 << "</timed>" << std::endl;
-        stream << space2 << "</transition>" << std::endl;
+        stream << space2 << "<transition id=\"" << trans.getName() << "\">\n";
+        stream << space3 << "<rate>\n";
+        stream << space4 << "<value>" << trans.getWeight() << "</value>\n";
+        stream << space3 << "</rate>\n";
+        stream << space3 << "<timed>\n";
+        stream << space4 << "<value>false</value>\n";
+        stream << space3 << "</timed>\n";
+        stream << space2 << "</transition>\n";
     }
 
     // add timed transitions
     for (const auto& trans : timedTransitions) {
         STORM_LOG_WARN_COND(trans.hasInfiniteServerSemantics(), "Unable to export non-trivial transition semantics");  // TODO
-        stream << space2 << "<transition id=\"" << trans.getName() << "\">" << std::endl;
-        stream << space3 << "<rate>" << std::endl;
-        stream << space4 << "<value>" << trans.getRate() << "</value>" << std::endl;
-        stream << space3 << "</rate>" << std::endl;
-        stream << space3 << "<timed>" << std::endl;
-        stream << space4 << "<value>true</value>" << std::endl;
-        stream << space3 << "</timed>" << std::endl;
-        stream << space2 << "</transition>" << std::endl;
+        stream << space2 << "<transition id=\"" << trans.getName() << "\">\n";
+        stream << space3 << "<rate>\n";
+        stream << space4 << "<value>" << trans.getRate() << "</value>\n";
+        stream << space3 << "</rate>\n";
+        stream << space3 << "<timed>\n";
+        stream << space4 << "<value>true</value>\n";
+        stream << space3 << "</timed>\n";
+        stream << space2 << "</transition>\n";
     }
 
     uint64_t i = 0;
@@ -592,15 +592,15 @@ void GSPN::toPnml(std::ostream& stream) const {
             stream << "id=\"arc" << i++ << "\" ";
             stream << "source=\"" << places.at(inEntry.first).getName() << "\" ";
             stream << "target=\"" << trans.getName() << "\" ";
-            stream << ">" << std::endl;
+            stream << ">\n";
 
-            stream << space3 << "<inscription>" << std::endl;
-            stream << space4 << "<value>Default," << inEntry.second << "</value>" << std::endl;
-            stream << space3 << "</inscription>" << std::endl;
+            stream << space3 << "<inscription>\n";
+            stream << space4 << "<value>Default," << inEntry.second << "</value>\n";
+            stream << space3 << "</inscription>\n";
 
-            stream << space3 << "<type value=\"normal\" />" << std::endl;
+            stream << space3 << "<type value=\"normal\" />\n";
 
-            stream << space2 << "</arc>" << std::endl;
+            stream << space2 << "</arc>\n";
         }
 
         // add inhibition arcs
@@ -609,15 +609,15 @@ void GSPN::toPnml(std::ostream& stream) const {
             stream << "id=\"arc" << i++ << "\" ";
             stream << "source=\"" << places.at(inhEntry.first).getName() << "\" ";
             stream << "target=\"" << trans.getName() << "\" ";
-            stream << ">" << std::endl;
+            stream << ">\n";
 
-            stream << space3 << "<inscription>" << std::endl;
-            stream << space4 << "<value>Default," << inhEntry.second << "</value>" << std::endl;
-            stream << space3 << "</inscription>" << std::endl;
+            stream << space3 << "<inscription>\n";
+            stream << space4 << "<value>Default," << inhEntry.second << "</value>\n";
+            stream << space3 << "</inscription>\n";
 
-            stream << space3 << "<type value=\"inhibition\" />" << std::endl;
+            stream << space3 << "<type value=\"inhibition\" />\n";
 
-            stream << space2 << "</arc>" << std::endl;
+            stream << space2 << "</arc>\n";
         }
 
         // add output arcs
@@ -626,15 +626,15 @@ void GSPN::toPnml(std::ostream& stream) const {
             stream << "id=\"arc" << i++ << "\" ";
             stream << "source=\"" << trans.getName() << "\" ";
             stream << "target=\"" << places.at(outEntry.first).getName() << "\" ";
-            stream << ">" << std::endl;
+            stream << ">\n";
 
-            stream << space3 << "<inscription>" << std::endl;
-            stream << space4 << "<value>Default," << outEntry.second << "</value>" << std::endl;
-            stream << space3 << "</inscription>" << std::endl;
+            stream << space3 << "<inscription>\n";
+            stream << space4 << "<value>Default," << outEntry.second << "</value>\n";
+            stream << space3 << "</inscription>\n";
 
-            stream << space3 << "<type value=\"normal\" />" << std::endl;
+            stream << space3 << "<type value=\"normal\" />\n";
 
-            stream << space2 << "</arc>" << std::endl;
+            stream << space2 << "</arc>\n";
         }
     }
 
@@ -646,15 +646,15 @@ void GSPN::toPnml(std::ostream& stream) const {
             stream << "id=\"arc" << i++ << "\" ";
             stream << "source=\"" << places.at(inEntry.first).getName() << "\" ";
             stream << "target=\"" << trans.getName() << "\" ";
-            stream << ">" << std::endl;
+            stream << ">\n";
 
-            stream << space3 << "<inscription>" << std::endl;
-            stream << space4 << "<value>Default," << inEntry.second << "</value>" << std::endl;
-            stream << space3 << "</inscription>" << std::endl;
+            stream << space3 << "<inscription>\n";
+            stream << space4 << "<value>Default," << inEntry.second << "</value>\n";
+            stream << space3 << "</inscription>\n";
 
-            stream << space3 << "<type value=\"normal\" />" << std::endl;
+            stream << space3 << "<type value=\"normal\" />\n";
 
-            stream << space2 << "</arc>" << std::endl;
+            stream << space2 << "</arc>\n";
         }
 
         // add inhibition arcs
@@ -663,15 +663,15 @@ void GSPN::toPnml(std::ostream& stream) const {
             stream << "id=\"arc" << i++ << "\" ";
             stream << "source=\"" << places.at(inhEntry.first).getName() << "\" ";
             stream << "target=\"" << trans.getName() << "\" ";
-            stream << ">" << std::endl;
+            stream << ">\n";
 
-            stream << space3 << "<inscription>" << std::endl;
-            stream << space4 << "<value>Default," << inhEntry.second << "</value>" << std::endl;
-            stream << space3 << "</inscription>" << std::endl;
+            stream << space3 << "<inscription>\n";
+            stream << space4 << "<value>Default," << inhEntry.second << "</value>\n";
+            stream << space3 << "</inscription>\n";
 
-            stream << space3 << "<type value=\"inhibition\" />" << std::endl;
+            stream << space3 << "<type value=\"inhibition\" />\n";
 
-            stream << space2 << "</arc>" << std::endl;
+            stream << space2 << "</arc>\n";
         }
 
         // add output arcs
@@ -680,20 +680,20 @@ void GSPN::toPnml(std::ostream& stream) const {
             stream << "id=\"arc" << i++ << "\" ";
             stream << "source=\"" << trans.getName() << "\" ";
             stream << "target=\"" << places.at(outEntry.first).getName() << "\" ";
-            stream << ">" << std::endl;
+            stream << ">\n";
 
-            stream << space3 << "<inscription>" << std::endl;
-            stream << space4 << "<value>Default," << outEntry.second << "</value>" << std::endl;
-            stream << space3 << "</inscription>" << std::endl;
+            stream << space3 << "<inscription>\n";
+            stream << space4 << "<value>Default," << outEntry.second << "</value>\n";
+            stream << space3 << "</inscription>\n";
 
-            stream << space3 << "<type value=\"normal\" />" << std::endl;
+            stream << space3 << "<type value=\"normal\" />\n";
 
-            stream << space2 << "</arc>" << std::endl;
+            stream << space2 << "</arc>\n";
         }
     }
 
-    stream << space << "</net>" << std::endl;
-    stream << "</pnml>" << std::endl;
+    stream << space << "</net>\n";
+    stream << "</pnml>\n";
 }
 
 void GSPN::toJson(std::ostream& stream) const {
@@ -701,9 +701,9 @@ void GSPN::toJson(std::ostream& stream) const {
 }
 
 void GSPN::writeStatsToStream(std::ostream& stream) const {
-    stream << "Number of places: " << getNumberOfPlaces() << std::endl;
-    stream << "Number of timed transitions: " << getNumberOfTimedTransitions() << std::endl;
-    stream << "Number of immediate transitions: " << getNumberOfImmediateTransitions() << std::endl;
+    stream << "Number of places: " << getNumberOfPlaces() << '\n';
+    stream << "Number of timed transitions: " << getNumberOfTimedTransitions() << '\n';
+    stream << "Number of immediate transitions: " << getNumberOfImmediateTransitions() << '\n';
 }
 }  // namespace gspn
 }  // namespace storm

--- a/src/storm-gspn/storage/gspn/GspnJsonExporter.cpp
+++ b/src/storm-gspn/storage/gspn/GspnJsonExporter.cpp
@@ -13,7 +13,7 @@ namespace gspn {
 static constexpr const uint64_t scaleFactor = 50;
 
 void GspnJsonExporter::toStream(storm::gspn::GSPN const& gspn, std::ostream& os) {
-    os << translate(gspn).dump(4) << std::endl;
+    os << translate(gspn).dump(4) << '\n';
 }
 
 typename GspnJsonExporter::Json GspnJsonExporter::translate(storm::gspn::GSPN const& gspn) {

--- a/src/storm-pars-cli/storm-pars.cpp
+++ b/src/storm-pars-cli/storm-pars.cpp
@@ -171,7 +171,7 @@ namespace storm {
                 storm::utility::Stopwatch eliminationWatch(true);
                 std::shared_ptr<storm::models::ModelBase> result;
                 if (model->isOfType(storm::models::ModelType::Dtmc)) {
-                    STORM_PRINT("Applying scc elimination" << std::endl);
+                    STORM_PRINT("Applying scc elimination\n");
                     auto sparseModel = model->as<storm::models::sparse::Model<ValueType>>();
                     auto matrix = sparseModel->getTransitionMatrix();
                     auto backwardsTransitionMatrix = matrix.transpose();
@@ -227,7 +227,7 @@ namespace storm {
                     result = std::make_shared<storm::models::sparse::Dtmc<ValueType>>(std::move(newTransitionMatrix), sparseModel->getStateLabeling().getSubLabeling(selectedStates));
 
                     eliminationWatch.stop();
-                    STORM_PRINT(std::endl << "Time for scc elimination: " << eliminationWatch << "." << std::endl << std::endl);
+                    STORM_PRINT("\nTime for scc elimination: " << eliminationWatch << ".\n\n");
                     result->printModelInformationToStream(std::cout);
                 } else if (model->isOfType(storm::models::ModelType::Mdp)) {
                     STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "Unable to perform SCC elimination for monotonicity analysis on MDP: Not mplemented");
@@ -266,7 +266,7 @@ namespace storm {
             }
 
             simplifyingWatch.stop();
-            STORM_PRINT(std::endl << "Time for model simplification: " << simplifyingWatch << "." << std::endl << std::endl);
+            STORM_PRINT("\nTime for model simplification: " << simplifyingWatch << ".\n\n");
             result->printModelInformationToStream(std::cout);
             return result;
         }
@@ -364,7 +364,7 @@ namespace storm {
             }
 
             if (result.changed) {
-                STORM_PRINT_AND_LOG(std::endl << "Time for model preprocessing: " << preprocessingWatch << "." << std::endl << std::endl);
+                STORM_PRINT_AND_LOG("\nTime for model preprocessing: " << preprocessingWatch << ".\n\n");
             }
             return result;
         }
@@ -398,23 +398,23 @@ namespace storm {
                     } else {
                         regionCheckResult->writeCondensedToStream(outStream);
                     }
-                    outStream << std::endl;
+                    outStream << '\n';
                     if (!regionSettings.isPrintNoIllustrationSet()) {
                         auto const* regionRefinementCheckResult = dynamic_cast<storm::modelchecker::RegionRefinementCheckResult<ValueType> const*>(regionCheckResult);
                         if (regionRefinementCheckResult != nullptr) {
                             regionRefinementCheckResult->writeIllustrationToStream(outStream);
                         }
                     }
-                    outStream << std::endl;
+                    outStream << '\n';
                     STORM_PRINT_AND_LOG(outStream.str());
                 } else {
-                    STORM_PRINT_AND_LOG(*result << std::endl);
+                    STORM_PRINT_AND_LOG(*result << '\n');
                 }
                 if (watch) {
-                    STORM_PRINT_AND_LOG("Time for model checking: " << *watch << "." << std::endl << std::endl);
+                    STORM_PRINT_AND_LOG("Time for model checking: " << *watch << ".\n\n");
                 }
             } else {
-                STORM_LOG_ERROR("Property is unsupported by selected engine/settings." << std::endl);
+                STORM_LOG_ERROR("Property is unsupported by selected engine/settings.\n");
             }
         }
 
@@ -496,7 +496,7 @@ namespace storm {
                 }
 
                 watch.stop();
-                STORM_PRINT_AND_LOG("Overall time for sampling all instances: " << watch << std::endl << std::endl);
+                STORM_PRINT_AND_LOG("Overall time for sampling all instances: " << watch << "\n\n");
             }
         }
 
@@ -583,7 +583,7 @@ namespace storm {
             for (auto const& entry : vars) {
                 std::cout << entry << " ";
             }
-            std::cout << std::endl;
+            std::cout << '\n';
 
             if (omittedParameters && !omittedParameters->empty()) {
                 std::cout << "Parameters ";
@@ -592,9 +592,9 @@ namespace storm {
                 }
                 std::cout << "are inconsequential.";
                 if (derSettings.areInconsequentialParametersOmitted()) {
-                    std::cout << " They will be omitted in the found instantiation." << std::endl;
+                    std::cout << " They will be omitted in the found instantiation.\n";
                 } else {
-                    std::cout << " They will be set to 0.5 in the found instantiation. To omit them, set the flag --omit-inconsequential-params." << std::endl;
+                    std::cout << " They will be set to 0.5 in the found instantiation. To omit them, set the flag --omit-inconsequential-params.\n";
                 }
             }
 
@@ -660,11 +660,11 @@ namespace storm {
                     std::cout << "Derivative w.r.t. " << parameter << ": ";
                     
                     auto result = modelChecker.check(Environment(), instantiation, parameter);
-                    std::cout << *result << std::endl;
+                    std::cout << *result << '\n';
                 }
                 return;
             } else if (derSettings.isFeasibleInstantiationSearchSet()) {
-                STORM_PRINT("Finding an extremum using Gradient Descent" << std::endl);
+                STORM_PRINT("Finding an extremum using Gradient Descent\n");
                 storm::utility::Stopwatch derivativeWatch(true);
                 storm::derivative::GradientDescentInstantiationSearcher<storm::RationalFunction, double> derivativeChecker(*dtmc, *method, derSettings.getLearningRate(), derSettings.getAverageDecay(), derSettings.getSquaredAverageDecay(), derSettings.getMiniBatchSize(), derSettings.getTerminationEpsilon(), startPoint, *constraintMethod, derSettings.isPrintJsonSet());
                 storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> checkTask(*formula);
@@ -683,7 +683,7 @@ namespace storm {
                 if (derSettings.isPrintJsonSet()) {
                     derivativeChecker.printRunAsJson();
                 } else {
-                    std::cout << "Found value " << instantiationAndValue.second << " at instantiation " << std::endl;
+                    std::cout << "Found value " << instantiationAndValue.second << " at instantiation \n";
                     bool isFirstLoop = true;
                     for (auto const& p : instantiationAndValue.first) {
                         if (!isFirstLoop) {
@@ -692,9 +692,9 @@ namespace storm {
                         isFirstLoop = false;
                         std::cout << p.first << "=" << p.second;
                     }
-                    std::cout << std::endl;
+                    std::cout << '\n';
                 }
-                std::cout << "Finished in " << derivativeWatch << std::endl;
+                std::cout << "Finished in " << derivativeWatch << '\n';
                 return;
             }
         }
@@ -768,7 +768,7 @@ namespace storm {
             }
 
             monotonicityWatch.stop();
-            STORM_PRINT(std::endl << "Total time for monotonicity checking: " << monotonicityWatch << "." << std::endl << std::endl);
+            STORM_PRINT("\nTotal time for monotonicity checking: " << monotonicityWatch << ".\n\n");
             return;
         }
 
@@ -787,12 +787,12 @@ namespace storm {
                         STORM_PRINT_AND_LOG("Computing extremal value for property " << property.getName() << ": "
                                                                                      << *property.getRawFormula()
                                                                                      << " within region " << region
-                                                                                     << " and using monotonicity ..." << std::endl);
+                                                                                     << " and using monotonicity ...\n");
                     } else {
                         STORM_PRINT_AND_LOG("Computing extremal value for property " << property.getName() << ": "
                                                                                      << *property.getRawFormula()
                                                                                      << " within region " << region
-                                                                                     << "..." << std::endl);
+                                                                                     << "...\n");
                     }
                     storm::utility::Stopwatch watch(true);
                     // TODO: hier eventueel checkExtremalValue van maken
@@ -817,8 +817,8 @@ namespace storm {
                             }
                             valuationStr << v.first << "=" << v.second;
                         }
-                        STORM_PRINT_AND_LOG("Result at initial state: " << valueValuation.first << " ( approx. " << storm::utility::convertNumber<double>(valueValuation.first) << ") at [" << valuationStr.str() << "]." << std::endl)
-                        STORM_PRINT_AND_LOG("Time for model checking: " << watch << "." << std::endl);
+                        STORM_PRINT_AND_LOG("Result at initial state: " << valueValuation.first << " ( approx. " << storm::utility::convertNumber<double>(valueValuation.first) << ") at [" << valuationStr.str() << "].\n")
+                        STORM_PRINT_AND_LOG("Time for model checking: " << watch << ".\n");
                     }
                 }
             }
@@ -834,7 +834,7 @@ namespace storm {
             std::function<std::unique_ptr<storm::modelchecker::CheckResult>(std::shared_ptr<storm::logic::Formula const> const& formula)> verificationCallback;
             std::function<void(std::unique_ptr<storm::modelchecker::CheckResult> const&)> postprocessingCallback;
 
-            STORM_PRINT_AND_LOG(std::endl);
+            STORM_PRINT_AND_LOG('\n');
             if (regionSettings.isHypothesisSet()) {
                 STORM_PRINT_AND_LOG("Checking hypothesis " << regionSettings.getHypothesis() << " on ");
             } else {
@@ -854,7 +854,7 @@ namespace storm {
             // Check the given set of regions with or without refinement
             if (regionSettings.isRefineSet()) {
                 STORM_LOG_THROW(regions.size() == 1, storm::exceptions::NotSupportedException, "Region refinement is not supported for multiple initial regions.");
-                STORM_PRINT_AND_LOG(" with iterative refinement until " << (1.0 - regionSettings.getCoverageThreshold()) * 100.0 << "% is covered." << (regionSettings.isDepthLimitSet() ? " Depth limit is " + std::to_string(regionSettings.getDepthLimit()) + "." : "") << std::endl);
+                STORM_PRINT_AND_LOG(" with iterative refinement until " << (1.0 - regionSettings.getCoverageThreshold()) * 100.0 << "% is covered." << (regionSettings.isDepthLimitSet() ? " Depth limit is " + std::to_string(regionSettings.getDepthLimit()) + "." : "") << '\n');
                 verificationCallback = [&] (std::shared_ptr<storm::logic::Formula const> const& formula) {
                     ValueType refinementThreshold = storm::utility::convertNumber<ValueType>(regionSettings.getCoverageThreshold());
                     boost::optional<uint64_t> optionalDepthLimit;
@@ -866,7 +866,7 @@ namespace storm {
                     return result;
                 };
             } else {
-                STORM_PRINT_AND_LOG("." << std::endl);
+                STORM_PRINT_AND_LOG(".\n");
                 verificationCallback = [&] (std::shared_ptr<storm::logic::Formula const> const& formula) {
                     std::unique_ptr<storm::modelchecker::CheckResult> result = storm::api::checkRegionsWithSparseEngine<ValueType>(model, storm::api::createTask<ValueType>(formula, true), regions, engine, regionSettings.getHypothesis());
                     return result;

--- a/src/storm-pars/analysis/AssumptionMaker.cpp
+++ b/src/storm-pars/analysis/AssumptionMaker.cpp
@@ -29,7 +29,7 @@ namespace storm {
                 if (assumption.second == AssumptionStatus::VALID) {
                     assert (createAndCheckAssumption(val2, val1, expressions::BinaryRelationExpression::RelationType::Greater, order, region, minValues, maxValues).second != AssumptionStatus::VALID
                             && createAndCheckAssumption(val1, val2, expressions::BinaryRelationExpression::RelationType::Equal, order, region, minValues, maxValues).second != AssumptionStatus::VALID);
-                    STORM_LOG_INFO("Assumption " << assumption.first << "is valid" << std::endl);
+                    STORM_LOG_INFO("Assumption " << assumption.first << "is valid\n");
                     return result;
                 }
             }
@@ -40,7 +40,7 @@ namespace storm {
                     result.clear();
                     result.insert(assumption);
                     assert (createAndCheckAssumption(val1, val2, expressions::BinaryRelationExpression::RelationType::Equal, order, region, minValues, maxValues).second != AssumptionStatus::VALID);
-                    STORM_LOG_INFO("Assumption " << assumption.first << "is valid" << std::endl);
+                    STORM_LOG_INFO("Assumption " << assumption.first << "is valid\n");
                     return result;
                 }
                 result.insert(assumption);
@@ -51,13 +51,13 @@ namespace storm {
                 if (assumption.second == AssumptionStatus::VALID) {
                     result.clear();
                     result.insert(assumption);
-                    STORM_LOG_INFO("Assumption " << assumption.first << "is valid" << std::endl);
+                    STORM_LOG_INFO("Assumption " << assumption.first << "is valid\n");
                     return result;
                 }
                 result.insert(assumption);
             }
                 assert (order->compare(val1, val2) == Order::UNKNOWN);
-            STORM_LOG_INFO("None of the assumptions is valid, number of possible assumptions:  " << result.size() << std::endl);
+            STORM_LOG_INFO("None of the assumptions is valid, number of possible assumptions:  " << result.size() << '\n');
             return result;
         }
 

--- a/src/storm-pars/analysis/MonotonicityHelper.cpp
+++ b/src/storm-pars/analysis/MonotonicityHelper.cpp
@@ -78,14 +78,14 @@ namespace storm {
                 storm::utility::Stopwatch plaWatch(true);
                 this->extender->initializeMinMaxValues(region);
                 plaWatch.stop();
-                STORM_PRINT(std::endl << "Total time for pla checking: " << plaWatch << "." << std::endl << std::endl);
+                STORM_PRINT("\nTotal time for pla checking: " << plaWatch << ".\n\n");
             }
             createOrder();
 
             //output of results
             for (auto itr : monResults) {
                 if (itr.first != nullptr) {
-                    std::cout << "Number of done states: " << itr.first->getNumberOfDoneStates() << std::endl;
+                    std::cout << "Number of done states: " << itr.first->getNumberOfDoneStates() << '\n';
                 }
                 if (checkSamples) {
                     for (auto & entry : resultCheckOnSamples.getMonotonicityResult()) {
@@ -100,23 +100,23 @@ namespace storm {
                     if (!first) {
                         outfile << " & ";
                     } else {
-                        outfile << "Assumptions: " << std::endl << "    ";
+                        outfile << "Assumptions: \n" << "    ";
                         first = false;
                     }
                     outfile << *assumption;
                 }
                 if (!first) {
-                    outfile << std::endl;
+                    outfile << '\n';
                 } else {
-                    outfile << "No Assumptions" << std::endl;
+                    outfile << "No Assumptions\n";
                 }
-                outfile << "Monotonicity Result: " << std::endl << "    " << temp << std::endl << std::endl;
+                outfile << "Monotonicity Result: \n" << "    " << temp << "\n\n";
             }
 
             if (monResults.size() == 0) {
-                outfile << "No monotonicity found, as the order is insufficient" << std::endl;
+                outfile << "No monotonicity found, as the order is insufficient\n";
                 if (checkSamples) {
-                        outfile << "Monotonicity Result on samples: " << resultCheckOnSamples.toString() << std::endl;
+                        outfile << "Monotonicity Result on samples: " << resultCheckOnSamples.toString() << '\n';
                 }
             }
 
@@ -129,14 +129,14 @@ namespace storm {
                     std::ofstream dotOutfile;
                     std::string name = dotOutfileName + std::to_string(i);
                     utility::openFile(name, dotOutfile);
-                    dotOutfile << "Assumptions:" << std::endl;
+                    dotOutfile << "Assumptions:\n";
                     auto assumptionItr = orderItr->second.second.begin();
                     while (assumptionItr != orderItr->second.second.end()) {
-                        dotOutfile << *assumptionItr << std::endl;
-                        dotOutfile << std::endl;
+                        dotOutfile << *assumptionItr << '\n';
+                        dotOutfile << '\n';
                         assumptionItr++;
                     }
-                    dotOutfile << std::endl;
+                    dotOutfile << '\n';
                     orderItr->first->dotOutputToFile(dotOutfile);
                     utility::closeFile(dotOutfile);
                     i++;

--- a/src/storm-pars/analysis/Order.cpp
+++ b/src/storm-pars/analysis/Order.cpp
@@ -70,7 +70,7 @@ namespace storm {
         }
 
         void Order::addAbove(uint_fast64_t state, Node *node) {
-            STORM_LOG_INFO("Add " << state << " above " << *node->states.begin() << std::endl);
+            STORM_LOG_INFO("Add " << state << " above " << *node->states.begin() << '\n');
 
             assert (nodes[state] == nullptr);
             Node *newNode = new Node();
@@ -91,7 +91,7 @@ namespace storm {
         }
 
         void Order::addBelow(uint_fast64_t state, Node *node) {
-            STORM_LOG_INFO("Add " << state << " below " << *node->states.begin()<< std::endl);
+            STORM_LOG_INFO("Add " << state << " below " << *node->states.begin()<< '\n');
 
             assert (nodes[state] == nullptr);
             Node *newNode = new Node();
@@ -112,7 +112,7 @@ namespace storm {
         }
 
         void Order::addBetween(uint_fast64_t state, Node *above, Node *below) {
-            STORM_LOG_INFO("Add " << state << " between (above) " << *above->states.begin() << " and " << *below->states.begin() << std::endl);
+            STORM_LOG_INFO("Add " << state << " between (above) " << *above->states.begin() << " and " << *below->states.begin() << '\n');
 
             assert(compare(above, below) == ABOVE);
             assert (above != nullptr && below != nullptr);
@@ -156,7 +156,7 @@ namespace storm {
         void Order::addRelationNodes(Order::Node *above, Order::Node * below, bool allowMerge) {
             assert (allowMerge || compare(above, below) != BELOW);
 
-            STORM_LOG_INFO("Add relation between (above) " << *above->states.begin() << " and " << *below->states.begin() << std::endl);
+            STORM_LOG_INFO("Add relation between (above) " << *above->states.begin() << " and " << *below->states.begin() << '\n');
 
             if (allowMerge) {
                 if (compare(below, above) == ABOVE) {
@@ -172,7 +172,7 @@ namespace storm {
         }
 
         void Order::addToNode(uint_fast64_t state, Node *node) {
-            STORM_LOG_INFO("Add "<< state << " to between (above) " << *node->states.begin() << std::endl);
+            STORM_LOG_INFO("Add "<< state << " to between (above) " << *node->states.begin() << '\n');
 
             if (nodes[state] == nullptr) {
                 // State is not in the order yet
@@ -191,7 +191,7 @@ namespace storm {
         }
 
         bool Order::mergeNodes(storm::analysis::Order::Node *node1, storm::analysis::Order::Node *node2) {
-            STORM_LOG_INFO("Merge " << *node1->states.begin() << " and " << *node2->states.begin() << std::endl);
+            STORM_LOG_INFO("Merge " << *node1->states.begin() << " and " << *node2->states.begin() << '\n');
 
             // Merges node2 into node 1
             // everything above n2 also above n1
@@ -564,7 +564,7 @@ namespace storm {
 
         void Order::toDotOutput() const {
             // Graphviz Output start
-            STORM_PRINT("Dot Output:" << std::endl << "digraph model {" << std::endl);
+            STORM_PRINT("Dot Output:\n" << "digraph model {\n");
 
             // Vertices of the digraph
             storm::storage::BitVector stateCoverage = storm::storage::BitVector(doneStates);
@@ -577,7 +577,7 @@ namespace storm {
                 for (uint_fast64_t j = i + 1; j < numberOfStates; j++) {
                     if (getNode(j) == getNode(i)) stateCoverage.set(j, false);
                 }
-                STORM_PRINT("\t" << nodeName(*getNode(i)) << " [ label = \"" << nodeLabel(*getNode(i)) << "\" ];" << std::endl);
+                STORM_PRINT("\t" << nodeName(*getNode(i)) << " [ label = \"" << nodeLabel(*getNode(i)) << "\" ];\n");
             }
 
             // Edges of the digraph
@@ -594,18 +594,18 @@ namespace storm {
                     if (std::find(seenNodes.begin(), seenNodes.end(), n) == seenNodes.end()) {
                         seenNodes.insert(n);
                         if (!v[state]) {
-                            STORM_PRINT("\t" << nodeName(*currentNode) << " ->  " << nodeName(*getNode(state)) << ";" << std::endl);
+                            STORM_PRINT("\t" << nodeName(*currentNode) << " ->  " << nodeName(*getNode(state)) << ";\n");
                         }
                     }
                 }
             }
             // Graphviz Output end
-            STORM_PRINT("}" << std::endl);
+            STORM_PRINT("}\n");
         }
 
         void Order::dotOutputToFile(std::ofstream& dotOutfile) const {
             // Graphviz Output start
-            dotOutfile << "Dot Output:" << std::endl << "digraph model {" << std::endl;
+            dotOutfile << "Dot Output:\n" << "digraph model {\n";
 
             // Vertices of the digraph
             storm::storage::BitVector stateCoverage = storm::storage::BitVector(numberOfStates, true);
@@ -617,7 +617,7 @@ namespace storm {
                     if (getNode(j) == getNode(i)) stateCoverage.set(j, false);
                 }
 
-                dotOutfile << "\t" << nodeName(*getNode(i)) << " [ label = \"" << nodeLabel(*getNode(i)) << "\" ];" << std::endl;
+                dotOutfile << "\t" << nodeName(*getNode(i)) << " [ label = \"" << nodeLabel(*getNode(i)) << "\" ];\n";
             }
 
             // Edges of the digraph
@@ -638,7 +638,7 @@ namespace storm {
                     if (std::find(seenNodes.begin(), seenNodes.end(), n) == seenNodes.end()) {
                         seenNodes.insert(n);
                         if (!v[state]) {
-                            dotOutfile << "\t" << nodeName(*currentNode) << " ->  " << nodeName(*getNode(state)) << ";" << std::endl;
+                            dotOutfile << "\t" << nodeName(*currentNode) << " ->  " << nodeName(*getNode(state)) << ";\n";
                         }
 
                     }
@@ -647,7 +647,7 @@ namespace storm {
             }
 
             // Graphviz Output end
-            dotOutfile << "}" << std::endl;
+            dotOutfile << "}\n";
         }
 
         /*** Private methods ***/

--- a/src/storm-pars/analysis/OrderExtender.cpp
+++ b/src/storm-pars/analysis/OrderExtender.cpp
@@ -297,7 +297,7 @@ namespace storm {
         template <typename ValueType, typename ConstantType>
         std::tuple<std::shared_ptr<Order>, uint_fast64_t, uint_fast64_t> OrderExtender<ValueType, ConstantType>::extendOrder(std::shared_ptr<Order> order, std::shared_ptr<MonotonicityResult<VariableType>> monRes, std::shared_ptr<expressions::BinaryRelationExpression> assumption) {
             if (assumption != nullptr) {
-                STORM_LOG_INFO("Handling assumption " << *assumption << std::endl);
+                STORM_LOG_INFO("Handling assumption " << *assumption << '\n');
                 handleAssumption(order, assumption);
             }
 

--- a/src/storm-pars/api/export.h
+++ b/src/storm-pars/api/export.h
@@ -18,15 +18,15 @@ namespace storm {
             filestream << "$Parameters: ";
             auto const& vars = constraintCollector.getVariables();
             std::copy(vars.begin(), vars.end(), std::ostream_iterator<storm::RationalFunctionVariable>(filestream, "; "));
-            filestream << std::endl;
+            filestream << '\n';
             if(result) {
-                filestream << "$Result: " << result->toString(false, true) << std::endl;
+                filestream << "$Result: " << result->toString(false, true) << '\n';
             }
-            filestream << "$Well-formed Constraints: " << std::endl;
+            filestream << "$Well-formed Constraints: \n";
             std::vector<std::string> stringConstraints;
             std::transform(constraintCollector.getWellformedConstraints().begin(), constraintCollector.getWellformedConstraints().end(), std::back_inserter(stringConstraints), [](carl::Formula<typename storm::Polynomial::PolyType> const& c) ->  std::string { return c.toString();});
             std::copy(stringConstraints.begin(), stringConstraints.end(), std::ostream_iterator<std::string>(filestream, "\n"));
-            filestream << "$Graph-preserving Constraints: " << std::endl;
+            filestream << "$Graph-preserving Constraints: \n";
             stringConstraints.clear();
             std::transform(constraintCollector.getGraphPreservingConstraints().begin(), constraintCollector.getGraphPreservingConstraints().end(), std::back_inserter(stringConstraints), [](carl::Formula<typename storm::Polynomial::PolyType> const& c) ->  std::string { return c.toString();});
             std::copy(stringConstraints.begin(), stringConstraints.end(), std::ostream_iterator<std::string>(filestream, "\n"));

--- a/src/storm-pars/api/region.h
+++ b/src/storm-pars/api/region.h
@@ -279,7 +279,7 @@ namespace storm {
             for (auto const& res : regionCheckResult->getRegionResults()) {
 
                 if (!onlyConclusiveResults || res.second == storm::modelchecker::RegionResult::AllViolated || res.second == storm::modelchecker::RegionResult::AllSat) {
-                    filestream << res.second << ": " << res.first << std::endl;
+                    filestream << res.second << ": " << res.first << '\n';
                 }
             }
         }

--- a/src/storm-pars/derivative/GradientDescentInstantiationSearcher.cpp
+++ b/src/storm-pars/derivative/GradientDescentInstantiationSearcher.cpp
@@ -248,7 +248,7 @@ namespace storm {
                 if (printUpdateStopwatch.getTimeInSeconds() >= 15) {
                     printUpdateStopwatch.restart();
                     std::cout << "Currently at ";
-                    std::cout << currentValue << std::endl;
+                    std::cout << currentValue << '\n';
                 }
 
                 std::vector<VariableType<FunctionType>> miniBatch;
@@ -409,9 +409,9 @@ namespace storm {
             bool initialGuess = true;
             std::map<VariableType<FunctionType>, CoefficientType<FunctionType>> point;
             while (true) {
-                std::cout << "Trying out a new starting point" << std::endl;
+                std::cout << "Trying out a new starting point\n";
                 if (initialGuess) {
-                    std::cout << "Trying initial guess (p->0.5 for every parameter p or set start point)" << std::endl;
+                    std::cout << "Trying initial guess (p->0.5 for every parameter p or set start point)\n";
                 }
                 // Generate random starting point
                 for (auto const& param : this->parameters) {
@@ -434,7 +434,7 @@ namespace storm {
                 /* walk.clear(); */
 
                 stochasticWatch.start();
-                std::cout << "Starting at " << point << std::endl;
+                std::cout << "Starting at " << point << '\n';
                 ConstantType prob = stochasticGradientDescent(env, point);
                 stochasticWatch.stop();
 
@@ -455,19 +455,19 @@ namespace storm {
                 }
 
                 if (currentCheckTask->getBound().isSatisfied(bestValue)) {
-                    std::cout << "Aborting because the bound is satisfied" << std::endl;
+                    std::cout << "Aborting because the bound is satisfied\n";
                     break;
                 } else if (storm::utility::resources::isTerminate()) {
                     break;
                 } else {
                     if (constraintMethod == GradientDescentConstraintMethod::BARRIER_LOGARITHMIC) {
                         logarithmicBarrierTerm = logarithmicBarrierTerm / 10;
-                        std::cout << "Smaller term" << std::endl;
-                        std::cout << bestValue << std::endl;
-                        std::cout << logarithmicBarrierTerm << std::endl;
+                        std::cout << "Smaller term\n";
+                        std::cout << bestValue << '\n';
+                        std::cout << logarithmicBarrierTerm << '\n';
                         continue;
                     }
-                    std::cout << "Sorry, couldn't satisfy the bound (yet). Best found value so far: " << bestValue << std::endl;
+                    std::cout << "Sorry, couldn't satisfy the bound (yet). Best found value so far: " << bestValue << '\n';
                     continue;
                 }
             }
@@ -528,9 +528,9 @@ namespace storm {
                     std::cout << ",";
                 }
             }
-            std::cout << "]" << std::endl;
+            std::cout << "]\n";
             // Print value at last step for data collection
-            std::cout << storm::utility::convertNumber<double>(walk.at(walk.size() - 1).value) << std::endl;
+            std::cout << storm::utility::convertNumber<double>(walk.at(walk.size() - 1).value) << '\n';
         }
 
         template<typename FunctionType, typename ConstantType>

--- a/src/storm-pars/derivative/SparseDerivativeInstantiationModelChecker.cpp
+++ b/src/storm-pars/derivative/SparseDerivativeInstantiationModelChecker.cpp
@@ -262,13 +262,13 @@ namespace storm {
                 if(storm::utility::isConstant(parametricEntryIt->getValue())){
                     //Constant entries can be inserted directly
                     constantEntryIt->setValue(storm::utility::convertNumber<ConstantType>(parametricEntryIt->getValue()));
-                    /* std::cout << "Setting constant entry" << std::endl; */
+                    /* std::cout << "Setting constant entry\n"; */
                 } else {
                     //insert the new function and store that the current constantMatrix entry needs to be set to the value of this function
                     auto functionsIt = functions.insert(std::make_pair(parametricEntryIt->getValue(), dummyValue)).first;
                     matrixMapping.emplace_back(std::make_pair(constantEntryIt, &(functionsIt->second)));
                     //Note that references to elements of an unordered map remain valid after calling unordered_map::insert.
-                    /* std::cout << "Setting non-constant entry" << std::endl; */
+                    /* std::cout << "Setting non-constant entry\n"; */
                 }
                 ++constantEntryIt;
                 ++parametricEntryIt;

--- a/src/storm-pars/modelchecker/region/RegionModelChecker.cpp
+++ b/src/storm-pars/modelchecker/region/RegionModelChecker.cpp
@@ -71,7 +71,7 @@ namespace storm {
                 uint_fast64_t numOfAnalyzedRegions = 0;
                 CoefficientType displayedProgress = storm::utility::zero<CoefficientType>();
                 if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-                    STORM_PRINT_AND_LOG("Progress (solved fraction) :" << std::endl <<  "0% [");
+                    STORM_PRINT_AND_LOG("Progress (solved fraction) :\n" <<  "0% [");
                     while (displayedProgress < storm::utility::one<CoefficientType>() - thresholdAsCoefficient) {
                         STORM_PRINT_AND_LOG(" ");
                         displayedProgress += storm::utility::convertNumber<CoefficientType>(0.01);
@@ -80,7 +80,7 @@ namespace storm {
                         STORM_PRINT_AND_LOG("-");
                         displayedProgress += storm::utility::convertNumber<CoefficientType>(0.01);
                     }
-                    STORM_PRINT_AND_LOG("] 100%" << std::endl << "   [");
+                    STORM_PRINT_AND_LOG("] 100%\n" << "   [");
                     displayedProgress = storm::utility::zero<CoefficientType>();
                 }
 
@@ -174,7 +174,7 @@ namespace storm {
                         }
                     }
                     monWatch.stop();
-                    STORM_PRINT(std::endl << "Time for orderBuilding and monRes initialization: " << monWatch << "." << std::endl << std::endl);
+                    STORM_PRINT("\nTime for orderBuilding and monRes initialization: " << monWatch << ".\n\n");
                 }
                 bool useSameOrder = useMonotonicity && order->getDoneBuilding();
                 bool useSameLocalMonotonicityResult = useSameOrder && localMonotonicityResult->isDone();
@@ -309,13 +309,13 @@ namespace storm {
                         STORM_PRINT_AND_LOG("-");
                         displayedProgress += storm::utility::convertNumber<CoefficientType>(0.01);
                     }
-                    STORM_PRINT_AND_LOG("]" << std::endl);
+                    STORM_PRINT_AND_LOG("]\n");
                     
-                    STORM_PRINT_AND_LOG("Region Refinement Statistics:" << std::endl);
-                    STORM_PRINT_AND_LOG("    Analyzed a total of " << numOfAnalyzedRegions << " regions." << std::endl);
+                    STORM_PRINT_AND_LOG("Region Refinement Statistics:\n");
+                    STORM_PRINT_AND_LOG("    Analyzed a total of " << numOfAnalyzedRegions << " regions.\n");
 
                     if (useMonotonicity) {
-                        STORM_PRINT_AND_LOG("    " << numberOfRegionsKnownThroughMonotonicity << " regions where discovered with help of monotonicity." << std::endl);
+                        STORM_PRINT_AND_LOG("    " << numberOfRegionsKnownThroughMonotonicity << " regions where discovered with help of monotonicity.\n");
 
                     }
                 }

--- a/src/storm-pars/modelchecker/region/SparseParameterLiftingModelChecker.cpp
+++ b/src/storm-pars/modelchecker/region/SparseParameterLiftingModelChecker.cpp
@@ -110,13 +110,13 @@ namespace storm {
 
                     // Check for result
                     if (existsSat && getInstantiationCheckerSAT().check(env, valuationToCheckSat)->asExplicitQualitativeCheckResult()[*this->parametricModel->getInitialStates().begin()]) {
-                        STORM_LOG_INFO("Region " << region << " is AllSat, discovered with instantiation checker on " << valuationToCheckSat << " and help of monotonicity" << std::endl);
+                        STORM_LOG_INFO("Region " << region << " is AllSat, discovered with instantiation checker on " << valuationToCheckSat << " and help of monotonicity\n");
                         RegionModelChecker<typename SparseModelType::ValueType>::numberOfRegionsKnownThroughMonotonicity++;
                         return RegionResult::AllSat;
                     }
 
                     if (existsViolated && !getInstantiationCheckerVIO().check(env, valuationToCheckViolated)->asExplicitQualitativeCheckResult()[*this->parametricModel->getInitialStates().begin()]) {
-                        STORM_LOG_INFO("Region " << region << " is AllViolated, discovered with instantiation checker on " << valuationToCheckViolated << " and help of monotonicity" << std::endl);
+                        STORM_LOG_INFO("Region " << region << " is AllViolated, discovered with instantiation checker on " << valuationToCheckViolated << " and help of monotonicity\n");
                         RegionModelChecker<typename SparseModelType::ValueType>::numberOfRegionsKnownThroughMonotonicity++;
                         return RegionResult::AllViolated;
                     }
@@ -270,7 +270,7 @@ namespace storm {
                 storm::utility::Stopwatch monotonicityWatch(true);
                 this->extendLocalMonotonicityResult(region, order, monRes);
                 monotonicityWatch.stop();
-                STORM_LOG_INFO(std::endl << "Total time for monotonicity checking: " << monotonicityWatch << "." << std::endl << std::endl);
+                STORM_LOG_INFO("\nTotal time for monotonicity checking: " << monotonicityWatch << ".\n\n");
 
                 regionQueue.emplace(region, order, monRes, initBound);
                 first = false;
@@ -290,7 +290,7 @@ namespace storm {
             }
 
             initialWatch.stop();
-            STORM_LOG_INFO(std::endl << "Total time for initial points: " << initialWatch << "." << std::endl << std::endl);
+            STORM_LOG_INFO("\nTotal time for initial points: " << initialWatch << ".\n\n");
             if (!initialValue) {
                 STORM_LOG_INFO("Initial value: " << value.get() << " at " << valuation);
             } else {
@@ -426,21 +426,21 @@ namespace storm {
                     }
 
                     STORM_LOG_INFO("Current value : " << value.get() << ", current bound: " << currBound << ".");
-                    STORM_LOG_INFO("Covered " << (coveredArea * storm::utility::convertNumber<ConstantType>(100.0) / totalArea) << "% of the region." << std::endl);
+                    STORM_LOG_INFO("Covered " << (coveredArea * storm::utility::convertNumber<ConstantType>(100.0) / totalArea) << "% of the region.\n");
                 }
                 loopWatch.stop();
             }
 
-            STORM_LOG_INFO("Total number of splits: " << numberOfSplits << std::endl);
-            STORM_PRINT("Total number of plaCalls: " << numberOfPLACalls << std::endl);
+            STORM_LOG_INFO("Total number of splits: " << numberOfSplits << '\n');
+            STORM_PRINT("Total number of plaCalls: " << numberOfPLACalls << '\n');
             if (useMonotonicity) {
-                STORM_PRINT("Total number of plaCalls for bounds for monotonicity checking: " << numberOfPLACallsBounds << std::endl);
-                STORM_PRINT("Total number of copies of the order: " << numberOfOrderCopies << std::endl);
+                STORM_PRINT("Total number of plaCalls for bounds for monotonicity checking: " << numberOfPLACallsBounds << '\n');
+                STORM_PRINT("Total number of copies of the order: " << numberOfOrderCopies << '\n');
                 STORM_PRINT("Total number of copies of the local monotonicity result: " << numberOfMonResCopies
-                                                                                        << std::endl);
+                                                                                        << '\n');
             }
-            STORM_LOG_INFO(std::endl << "Total time for region refinement: " << loopWatch << "." << std::endl << std::endl);
-            STORM_LOG_INFO(std::endl << "Total time for additional bounds: " << boundsWatch << "." << std::endl << std::endl);
+            STORM_LOG_INFO("\nTotal time for region refinement: " << loopWatch << ".\n\n");
+            STORM_LOG_INFO("\nTotal time for additional bounds: " << boundsWatch << ".\n\n");
 
             return std::make_pair(storm::utility::convertNumber<typename SparseModelType::ValueType>(value.get()), valuation);
         }
@@ -568,18 +568,18 @@ namespace storm {
             ConstantType value = storm::solver::minimize(dir) ? 1 : 0;
             Valuation valuation;
             std::set<VariableType> monIncr, monDecr, notMon, notMonFirst;
-            STORM_LOG_INFO("Number of parameters: " << region.getVariables().size() << std::endl;);
+            STORM_LOG_INFO("Number of parameters: " << region.getVariables().size() << '\n';);
 
             if (localMonRes != nullptr) {
                 localMonRes->getGlobalMonotonicityResult()->splitBasedOnMonotonicity(region.getVariables(), monIncr, monDecr, notMonFirst);
 
                 auto numMon = monIncr.size() + monDecr.size();
-                STORM_LOG_INFO("Number of monotone parameters: " << numMon << std::endl;);
+                STORM_LOG_INFO("Number of monotone parameters: " << numMon << '\n';);
 
                 if (numMon < region.getVariables().size()) {
                     checkForPossibleMonotonicity(env, region, monIncr, monDecr, notMon, notMonFirst, dir);
-                    STORM_LOG_INFO("Number of possible monotone parameters: " << (monIncr.size() + monDecr.size() - numMon) << std::endl;);
-                    STORM_LOG_INFO("Number of definitely not monotone parameters: " << notMon.size() << std::endl;);
+                    STORM_LOG_INFO("Number of possible monotone parameters: " << (monIncr.size() + monDecr.size() - numMon) << '\n';);
+                    STORM_LOG_INFO("Number of definitely not monotone parameters: " << notMon.size() << '\n';);
                 }
 
                 valuation = region.getPoint(dir, monIncr, monDecr);

--- a/src/storm-pars/modelchecker/region/ValidatingSparseParameterLiftingModelChecker.cpp
+++ b/src/storm-pars/modelchecker/region/ValidatingSparseParameterLiftingModelChecker.cpp
@@ -18,7 +18,7 @@ namespace storm {
         template <typename SparseModelType, typename ImpreciseType, typename PreciseType>
         ValidatingSparseParameterLiftingModelChecker<SparseModelType, ImpreciseType, PreciseType>::~ValidatingSparseParameterLiftingModelChecker() {
             if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-                STORM_PRINT_AND_LOG("Validating Parameter Lifting Model Checker detected " << numOfWrongRegions << " regions where the imprecise method was wrong." << std::endl);
+                STORM_PRINT_AND_LOG("Validating Parameter Lifting Model Checker detected " << numOfWrongRegions << " regions where the imprecise method was wrong.\n");
             }
         }
         

--- a/src/storm-pars/modelchecker/results/RegionCheckResult.cpp
+++ b/src/storm-pars/modelchecker/results/RegionCheckResult.cpp
@@ -60,9 +60,9 @@ namespace storm {
         template<typename ValueType>
         std::ostream& RegionCheckResult<ValueType>::writeToStream(std::ostream& out) const {
             writeCondensedToStream(out);
-            out << std::endl << "Region results: " << std::endl;
+            out << "\nRegion results: \n";
             for (auto const& res : this->regionResults) {
-                out << res.first.toString() << ": \t" << res.second << std::endl;
+                out << res.first.toString() << ": \t" << res.second << '\n';
             }
             return out;
         }
@@ -73,16 +73,16 @@ namespace storm {
             double unsatPercent = storm::utility::convertNumber<double>(unsatFraction) * 100.0;
             auto oneHundred = storm::utility::convertNumber<typename storm::storage::ParameterRegion<ValueType>::CoefficientType>(100.0);
             auto one = storm::utility::convertNumber<typename storm::storage::ParameterRegion<ValueType>::CoefficientType>(1.0);
-            out << "  Fraction of satisfied area: " << satPercent << "%" << std::endl;
-            out << "Fraction of unsatisfied area: " << unsatPercent << "%" << std::endl;
-            out << "            Unknown fraction: " << (100.0 - satPercent - unsatPercent) << "%" << std::endl;
-            out << "     Total number of regions: " << regionResults.size() << std::endl;
+            out << "  Fraction of satisfied area: " << satPercent << "%\n";
+            out << "Fraction of unsatisfied area: " << unsatPercent << "%\n";
+            out << "            Unknown fraction: " << (100.0 - satPercent - unsatPercent) << "%\n";
+            out << "     Total number of regions: " << regionResults.size() << '\n';
             std::map<storm::modelchecker::RegionResult, uint_fast64_t> counters;
             for (auto const& res : this->regionResults) {
                 ++counters[res.second];
             }
             for (auto const& counter : counters) {
-                out << std::setw(28) << counter.first << ": " << counter.second << std::endl;
+                out << std::setw(28) << counter.first << ": " << counter.second << '\n';
             }
             return out;
         }

--- a/src/storm-pars/modelchecker/results/RegionRefinementCheckResult.cpp
+++ b/src/storm-pars/modelchecker/results/RegionRefinementCheckResult.cpp
@@ -46,12 +46,12 @@ namespace storm {
                 uint_fast64_t const sizeX = 128;
                 uint_fast64_t const sizeY = 64;
                 
-                out << "Region refinement Check result (visualization):" << std::endl;
-                out << " \t x-axis: " << x << "  \t y-axis: " << y << "  \t S=safe, [ ]=unsafe, -=ambiguous " << std::endl;
+                out << "Region refinement Check result (visualization):\n";
+                out << " \t x-axis: " << x << "  \t y-axis: " << y << "  \t S=safe, [ ]=unsafe, -=ambiguous \n";
                 for (uint_fast64_t i = 0; i < sizeX+2; ++i) {
                     out << "#";
                 }
-                out << std::endl;
+                out << '\n';
                 
                 CoefficientType deltaX = (getParameterSpace().getUpperBoundary(x) - getParameterSpace().getLowerBoundary(x)) / storm::utility::convertNumber<CoefficientType>(sizeX);
                 CoefficientType deltaY = (getParameterSpace().getUpperBoundary(y) - getParameterSpace().getLowerBoundary(y)) / storm::utility::convertNumber<CoefficientType>(sizeY);
@@ -95,12 +95,12 @@ namespace storm {
                             out << "-";
                         }
                     }
-                    out << "#" << std::endl;
+                    out << "#\n";
                 }
                 for (uint_fast64_t i = 0; i < sizeX+2; ++i) {
                     out << "#";
                 }
-                out << std::endl;
+                out << '\n';
             } else {
                 STORM_LOG_WARN("Writing illustration of region check result to a stream is only implemented for two parameters.");
             }

--- a/src/storm-pars/settings/modules/RegionSettings.cpp
+++ b/src/storm-pars/settings/modules/RegionSettings.cpp
@@ -139,7 +139,7 @@ namespace storm {
                 if (!generalSettings.isPrecisionSet() && generalSettings.isSoundSet()) {
                     double prec = this->getOption(extremumOptionName).getArgumentByName("precision").getValueAsDouble() / 10;
                     generalSettings.setPrecision(std::to_string(prec));
-                    STORM_LOG_WARN("Reset precision for solver to " << prec << " this is sufficient for extremum value precision of " << (prec)*10 << std::endl);
+                    STORM_LOG_WARN("Reset precision for solver to " << prec << " this is sufficient for extremum value precision of " << (prec)*10 << '\n');
                 }
                 return this->getOption(extremumOptionName).getArgumentByName("precision").getValueAsDouble();
             }

--- a/src/storm-parsers/api/properties.cpp
+++ b/src/storm-parsers/api/properties.cpp
@@ -31,7 +31,7 @@ std::vector<storm::jani::Property> parseProperties(storm::parser::FormulaParser&
     // If the given property is a file, we parse it as a file, otherwise we assume it's a property.
     std::vector<storm::jani::Property> properties;
     if (std::ifstream(inputString).good()) {
-        STORM_LOG_INFO("Loading properties from file: " << inputString << std::endl);
+        STORM_LOG_INFO("Loading properties from file: " << inputString << '\n');
         properties = formulaParser.parseFromFile(inputString);
     } else {
         properties = formulaParser.parseFromString(inputString);

--- a/src/storm-parsers/parser/DirectEncodingParser.cpp
+++ b/src/storm-parsers/parser/DirectEncodingParser.cpp
@@ -360,7 +360,7 @@ std::shared_ptr<storm::storage::sparse::ModelComponents<ValueType, RewardModelTy
         }
 
         if (storm::utility::resources::isTerminate()) {
-            std::cout << "Parsed " << state << "/" << stateSize << " states before abort." << std::endl;
+            std::cout << "Parsed " << state << "/" << stateSize << " states before abort.\n";
             STORM_LOG_THROW(false, storm::exceptions::AbortException, "Aborted in state space exploration.");
             break;
         }

--- a/src/storm-parsers/parser/SpiritErrorHandler.h
+++ b/src/storm-parsers/parser/SpiritErrorHandler.h
@@ -19,10 +19,10 @@ struct SpiritErrorHandler {
 
         std::stringstream stream;
         stream << "Parsing error at " << get_line(where) << ":" << boost::spirit::get_column(lineStart, where) << ": "
-               << " expecting " << what << ", here:" << std::endl;
-        stream << "\t" << line << std::endl;
+               << " expecting " << what << ", here:\n";
+        stream << "\t" << line << '\n';
         auto caretColumn = boost::spirit::get_column(lineStart, where);
-        stream << "\t" << std::string(caretColumn - 1, ' ') << "^" << std::endl;
+        stream << "\t" << std::string(caretColumn - 1, ' ') << "^\n";
 
         STORM_LOG_THROW(false, storm::exceptions::WrongFormatException, stream.str());
         return qi::fail;

--- a/src/storm-pgcl/storage/pgcl/StatementPrinterVisitor.cpp
+++ b/src/storm-pgcl/storage/pgcl/StatementPrinterVisitor.cpp
@@ -15,79 +15,79 @@ void StatementPrinterVisitor::visit(storm::pgcl::AssignmentStatement const& stat
     this->stream << statement.getLocationNumber() << ": ";
     if (statement.getExpression().which() == 0) {
         storm::expressions::Expression const& expression = boost::get<storm::expressions::Expression>(statement.getExpression());
-        this->stream << statement.getVariable().getType() << " " << statement.getVariable().getName() << " := " << expression << ";" << std::endl;
+        this->stream << statement.getVariable().getType() << " " << statement.getVariable().getName() << " := " << expression << ";\n";
     } else {
         storm::pgcl::UniformExpression const& unif = boost::get<storm::pgcl::UniformExpression>(statement.getExpression());
         this->stream << statement.getVariable().getType() << " " << statement.getVariable().getName() << " := "
-                     << "unif(" << unif.getBegin() << ", " << unif.getEnd() << ");" << std::endl;
+                     << "unif(" << unif.getBegin() << ", " << unif.getEnd() << ");\n";
     }
 }
 
 void StatementPrinterVisitor::visit(storm::pgcl::ObserveStatement const& statement) {
     this->stream << statement.getLocationNumber() << ": ";
-    this->stream << "observe(" << statement.getCondition().getBooleanExpression() << ");" << std::endl;
+    this->stream << "observe(" << statement.getCondition().getBooleanExpression() << ");\n";
 }
 
 void StatementPrinterVisitor::visit(storm::pgcl::IfStatement const& statement) {
     this->stream << statement.getLocationNumber() << ": ";
-    this->stream << "if (" << statement.getCondition().getBooleanExpression() << ") {" << std::endl;
+    this->stream << "if (" << statement.getCondition().getBooleanExpression() << ") {\n";
     int i = 1;
     for (iterator it = (*(statement.getIfBody())).begin(); it != (*(statement.getIfBody())).end(); ++it) {
         (*(*it)).accept(*this);
         i++;
     }
-    this->stream << "}" << std::endl;
+    this->stream << "}\n";
     if (statement.hasElse()) {
-        this->stream << "else {" << std::endl;
+        this->stream << "else {\n";
         for (iterator it = (*(statement.getElseBody())).begin(); it != (*(statement.getElseBody())).end(); ++it) {
             (*(*it)).accept(*this);
             i++;
         }
-        this->stream << "}" << std::endl;
+        this->stream << "}\n";
     }
 }
 
 void StatementPrinterVisitor::visit(storm::pgcl::LoopStatement const& statement) {
     this->stream << statement.getLocationNumber() << ": ";
-    this->stream << "while (" << statement.getCondition().getBooleanExpression() << ") {" << std::endl;
+    this->stream << "while (" << statement.getCondition().getBooleanExpression() << ") {\n";
     int i = 1;
     for (iterator it = (*(statement.getBody())).begin(); it != (*(statement.getBody())).end(); ++it) {
         (*(*it)).accept(*this);
         i++;
     }
-    this->stream << "}" << std::endl;
+    this->stream << "}\n";
 }
 
 void StatementPrinterVisitor::visit(storm::pgcl::NondeterministicBranch const& statement) {
     this->stream << statement.getLocationNumber() << ": ";
-    this->stream << "{" << std::endl;
+    this->stream << "{\n";
     int i = 1;
     for (iterator it = (*(statement.getLeftBranch())).begin(); it != (*(statement.getLeftBranch())).end(); ++it) {
         (*(*it)).accept(*this);
         i++;
     }
-    this->stream << "} [] {" << std::endl;
+    this->stream << "} [] {\n";
     for (iterator it = (*(statement.getRightBranch())).begin(); it != (*(statement.getRightBranch())).end(); ++it) {
         (*(*it)).accept(*this);
         i++;
     }
-    this->stream << "}" << std::endl;
+    this->stream << "}\n";
 }
 
 void StatementPrinterVisitor::visit(storm::pgcl::ProbabilisticBranch const& statement) {
     this->stream << statement.getLocationNumber() << ": ";
-    this->stream << "{" << std::endl;
+    this->stream << "{\n";
     int i = 1;
     for (iterator it = (*(statement.getLeftBranch())).begin(); it != (*(statement.getLeftBranch())).end(); ++it) {
         (*(*it)).accept(*this);
         i++;
     }
-    this->stream << "} [" << statement.getProbability() << "] {" << std::endl;
+    this->stream << "} [" << statement.getProbability() << "] {\n";
     for (iterator it = (*(statement.getRightBranch())).begin(); it != (*(statement.getRightBranch())).end(); ++it) {
         (*(*it)).accept(*this);
         i++;
     }
-    this->stream << "}" << std::endl;
+    this->stream << "}\n";
 }
 }  // namespace pgcl
 }  // namespace storm

--- a/src/storm-pgcl/storage/ppg/ProgramGraph.cpp
+++ b/src/storm-pgcl/storage/ppg/ProgramGraph.cpp
@@ -178,30 +178,30 @@ std::vector<ProgramVariableIdentifier> ProgramGraph::variablesNotInGuards() cons
 //        }
 
 void ProgramGraph::printDot(std::ostream& os) const {
-    os << "digraph ppg {" << std::endl;
+    os << "digraph ppg {\n";
 
     for (auto const& loc : locations) {
-        os << "\tl" << loc.first << "[label=" << loc.first << "];" << std::endl;
+        os << "\tl" << loc.first << "[label=" << loc.first << "];\n";
     }
-    os << std::endl;
+    os << '\n';
     for (auto const& loc : locations) {
         if (loc.second.nrOutgoingEdgeGroups() > 1) {
             for (auto const& edgegroup : loc.second) {
-                os << "\teg" << edgegroup->getId() << "[shape=rectangle];" << std::endl;
+                os << "\teg" << edgegroup->getId() << "[shape=rectangle];\n";
             }
         }
     }
-    os << std::endl;
+    os << '\n';
     for (auto const& loc : locations) {
         for (auto const& edgegroup : loc.second) {
             if (loc.second.nrOutgoingEdgeGroups() > 1) {
-                os << "\tl" << loc.first << " -> eg" << edgegroup->getId() << ";" << std::endl;
+                os << "\tl" << loc.first << " -> eg" << edgegroup->getId() << ";\n";
                 for (auto const& edge : *edgegroup) {
                     os << "\teg" << edgegroup->getId() << " -> l" << edge->getTargetId();
                     if (!edge->hasNoAction()) {
                         os << " [label=\"" << edge->getActionId() << "\"]";
                     }
-                    os << ";" << std::endl;
+                    os << ";\n";
                 }
             } else {
                 for (auto const& edge : *edgegroup) {
@@ -209,12 +209,12 @@ void ProgramGraph::printDot(std::ostream& os) const {
                     if (!edge->hasNoAction()) {
                         os << " [label=\"" << edge->getActionId() << "\"]";
                     }
-                    os << ";" << std::endl;
+                    os << ";\n";
                 }
             }
         }
     }
-    os << "}" << std::endl;
+    os << "}\n";
 }
 }  // namespace ppg
 }  // namespace storm

--- a/src/storm-pgcl/storage/ppg/ProgramGraph.h
+++ b/src/storm-pgcl/storage/ppg/ProgramGraph.h
@@ -242,9 +242,9 @@ class ProgramGraph {
     void checkValid() {}
 
     void printInfo(std::ostream& os) const {
-        os << "Number of variables: " << nrVariables() << std::endl;
-        os << "Number of locations: " << nrLocations() << std::endl;
-        os << "Number of actions: " << nrActions() << std::endl;
+        os << "Number of variables: " << nrVariables() << '\n';
+        os << "Number of locations: " << nrLocations() << '\n';
+        os << "Number of actions: " << nrActions() << '\n';
     }
 
     void printDot(std::ostream& os) const;

--- a/src/storm-pomdp-cli/storm-pomdp.cpp
+++ b/src/storm-pomdp-cli/storm-pomdp.cpp
@@ -55,21 +55,21 @@ namespace storm {
                         STORM_PRINT_AND_LOG("Eliminating self-loop choices ...");
                         uint64_t oldChoiceCount = pomdp->getNumberOfChoices();
                         pomdp = selfLoopEliminator.transform();
-                        STORM_PRINT_AND_LOG(oldChoiceCount - pomdp->getNumberOfChoices() << " choices eliminated through self-loop elimination." << std::endl);
+                        STORM_PRINT_AND_LOG(oldChoiceCount - pomdp->getNumberOfChoices() << " choices eliminated through self-loop elimination.\n");
                         preprocessingPerformed = true;
                     } else {
-                        STORM_PRINT_AND_LOG("Not eliminating self-loop choices as it does not preserve the formula." << std::endl);
+                        STORM_PRINT_AND_LOG("Not eliminating self-loop choices as it does not preserve the formula.\n");
                     }
                 }
                 if (pomdpSettings.isQualitativeReductionSet() && formulaInfo.isNonNestedReachabilityProbability()) {
                     storm::analysis::QualitativeAnalysisOnGraphs<ValueType> qualitativeAnalysis(*pomdp);
                     STORM_PRINT_AND_LOG("Computing states with probability 0 ...");
                     storm::storage::BitVector prob0States = qualitativeAnalysis.analyseProb0(formula.asProbabilityOperatorFormula());
-                    std::cout << prob0States << std::endl;
-                    STORM_PRINT_AND_LOG(" done. " << prob0States.getNumberOfSetBits() << " states found." << std::endl);
+                    std::cout << prob0States << '\n';
+                    STORM_PRINT_AND_LOG(" done. " << prob0States.getNumberOfSetBits() << " states found.\n");
                     STORM_PRINT_AND_LOG("Computing states with probability 1 ...");
                     storm::storage::BitVector  prob1States = qualitativeAnalysis.analyseProb1(formula.asProbabilityOperatorFormula());
-                    STORM_PRINT_AND_LOG(" done. " << prob1States.getNumberOfSetBits() << " states found." << std::endl);
+                    STORM_PRINT_AND_LOG(" done. " << prob1States.getNumberOfSetBits() << " states found.\n");
                     storm::pomdp::transformer::KnownProbabilityTransformer<ValueType> kpt = storm::pomdp::transformer::KnownProbabilityTransformer<ValueType>();
                     pomdp = kpt.transform(*pomdp, prob0States, prob1States);
                     // Update formulaInfo to changes from Preprocessing
@@ -172,9 +172,9 @@ namespace storm {
                         } else {
                             bool result = memlessSearch.analyzeForInitialStates(lookahead);
                             if (result) {
-                                STORM_PRINT_AND_LOG("From initial state, one can almost-surely reach the target." << std::endl);
+                                STORM_PRINT_AND_LOG("From initial state, one can almost-surely reach the target.\n");
                             } else {
-                                STORM_PRINT_AND_LOG("From initial state, one may not almost-surely reach the target ." << std::endl);
+                                STORM_PRINT_AND_LOG("From initial state, one may not almost-surely reach the target .\n");
                             }
                         }
                     } else if (qualSettings.getMemlessSearchMethod() == "iterative") {
@@ -196,7 +196,7 @@ namespace storm {
 
                         if (qualSettings.isPrintWinningRegionSet()) {
                             search.getLastWinningRegion().print();
-                            std::cout << std::endl;
+                            std::cout << '\n';
                         }
                         if (qualSettings.isExportWinningRegionSet()) {
                             std::size_t hash = pomdp.hash();
@@ -221,11 +221,9 @@ namespace storm {
 
                             if (search.getLastWinningRegion().isWinning(initialObservation,
                                                                         offset)) {
-                                STORM_PRINT_AND_LOG("Initial state is safe!"
-                                                            << std::endl);
+                                STORM_PRINT_AND_LOG("Initial state is safe!\n");
                             } else {
-                                STORM_PRINT_AND_LOG("Initial state may not be safe."
-                                                            << std::endl);
+                                STORM_PRINT_AND_LOG("Initial state may not be safe.\n");
                             }
                         } else {
                             STORM_LOG_WARN("Output for multiple initial states is incomplete");
@@ -233,7 +231,7 @@ namespace storm {
 
                         if (coreSettings.isShowStatisticsSet()) {
                             STORM_PRINT_AND_LOG("#STATS Number of belief support states: "
-                                                        << search.getLastWinningRegion().beliefSupportStates() << std::endl);
+                                                        << search.getLastWinningRegion().beliefSupportStates() << '\n');
                             if (qualSettings.computeExpensiveStats()) {
                                 auto wbss = search.getLastWinningRegion().computeNrWinningBeliefs();
                                 STORM_PRINT_AND_LOG(
@@ -277,7 +275,7 @@ namespace storm {
                         STORM_PRINT_AND_LOG("\nResult: ")
                     }
                     printResult(result.lowerBound, result.upperBound);
-                    STORM_PRINT_AND_LOG(std::endl);
+                    STORM_PRINT_AND_LOG('\n');
                     analysisPerformed = true;
                 }
                 if (pomdpSettings.isQualitativeAnalysisSet()) {
@@ -297,9 +295,9 @@ namespace storm {
                             STORM_PRINT_AND_LOG("\nResult: ")
                         }
                         printResult(result.getMin(), result.getMax());
-                        STORM_PRINT_AND_LOG(std::endl);
+                        STORM_PRINT_AND_LOG('\n');
                     } else {
-                        STORM_PRINT_AND_LOG("\nResult: Not available." << std::endl);
+                        STORM_PRINT_AND_LOG("\nResult: Not available.\n");
                     }
                     analysisPerformed = true;
                 }
@@ -317,10 +315,10 @@ namespace storm {
                 if (pomdpSettings.getMemoryBound() > 1) {
                     STORM_PRINT_AND_LOG("Computing the unfolding for memory bound " << pomdpSettings.getMemoryBound() << " and memory pattern '" << storm::storage::toString(pomdpSettings.getMemoryPattern()) << "' ...");
                     storm::storage::PomdpMemory memory = storm::storage::PomdpMemoryBuilder().build(pomdpSettings.getMemoryPattern(), pomdpSettings.getMemoryBound());
-                    std::cout << memory.toString() << std::endl;
+                    std::cout << memory.toString() << '\n';
                     storm::transformer::PomdpMemoryUnfolder<ValueType> memoryUnfolder(*pomdp, memory);
                     pomdp = memoryUnfolder.transform();
-                    STORM_PRINT_AND_LOG(" done." << std::endl);
+                    STORM_PRINT_AND_LOG(" done.\n");
                     pomdp->printModelInformationToStream(std::cout);
                     transformationPerformed = true;
                     memoryUnfolded = true;
@@ -334,8 +332,8 @@ namespace storm {
                     uint64_t oldChoiceCount = pomdp->getNumberOfChoices();
                     storm::transformer::GlobalPomdpMecChoiceEliminator<ValueType> mecChoiceEliminator(*pomdp);
                     pomdp = mecChoiceEliminator.transform(formula);
-                    STORM_PRINT_AND_LOG(" done." << std::endl);
-                    STORM_PRINT_AND_LOG(oldChoiceCount - pomdp->getNumberOfChoices() << " choices eliminated through MEC choice elimination." << std::endl);
+                    STORM_PRINT_AND_LOG(" done.\n");
+                    STORM_PRINT_AND_LOG(oldChoiceCount - pomdp->getNumberOfChoices() << " choices eliminated through MEC choice elimination.\n");
                     pomdp->printModelInformationToStream(std::cout);
                     transformationPerformed = true;
                 }
@@ -349,7 +347,7 @@ namespace storm {
                         pomdp = storm::transformer::BinaryPomdpTransformer<ValueType>().transform(*pomdp, false);
                     }
                     pomdp->printModelInformationToStream(std::cout);
-                    STORM_PRINT_AND_LOG(" done." << std::endl);
+                    STORM_PRINT_AND_LOG(" done.\n");
                     transformationPerformed = true;
                 }
         
@@ -358,12 +356,12 @@ namespace storm {
                     storm::transformer::ApplyFiniteSchedulerToPomdp<ValueType> toPMCTransformer(*pomdp);
                     std::string transformMode = transformSettings.getFscApplicationTypeString();
                     auto pmc = toPMCTransformer.transform(storm::transformer::parsePomdpFscApplicationMode(transformMode));
-                    STORM_PRINT_AND_LOG(" done." << std::endl);
+                    STORM_PRINT_AND_LOG(" done.\n");
                     pmc->printModelInformationToStream(std::cout);
                     if (transformSettings.allowPostSimplifications()) {
                         STORM_PRINT_AND_LOG("Simplifying pMC...");
                         pmc = storm::api::performBisimulationMinimization<storm::RationalFunction>(pmc->template as<storm::models::sparse::Dtmc<storm::RationalFunction>>(),{formula.asSharedPointer()}, storm::storage::BisimulationType::Strong)->template as<storm::models::sparse::Dtmc<storm::RationalFunction>>();
-                        STORM_PRINT_AND_LOG(" done." << std::endl);
+                        STORM_PRINT_AND_LOG(" done.\n");
                         pmc->printModelInformationToStream(std::cout);
                     }
                     STORM_PRINT_AND_LOG("Exporting pMC...");
@@ -375,11 +373,11 @@ namespace storm {
                         parameterNames.push_back(parameter.name());
                     }
                     storm::api::exportSparseModelAsDrn(pmc, pomdpSettings.getExportToParametricFilename(), parameterNames, !ioSettings.isExplicitExportPlaceholdersDisabled());
-                    STORM_PRINT_AND_LOG(" done." << std::endl);
+                    STORM_PRINT_AND_LOG(" done.\n");
                     transformationPerformed = true;
                 }
                 if (transformationPerformed && !memoryUnfolded) {
-                    STORM_PRINT_AND_LOG("Implicitly assumed restriction to memoryless schedulers for at least one transformation." << std::endl);
+                    STORM_PRINT_AND_LOG("Implicitly assumed restriction to memoryless schedulers for at least one transformation.\n");
                 }
                 return transformationPerformed;
             }
@@ -390,7 +388,7 @@ namespace storm {
                 
                 auto model = storm::cli::buildPreprocessExportModelWithValueTypeAndDdlib<DdType, ValueType>(symbolicInput, mpi);
                 if (!model) {
-                    STORM_PRINT_AND_LOG("No input model given." << std::endl);
+                    STORM_PRINT_AND_LOG("No input model given.\n");
                     return;
                 }
                 STORM_LOG_THROW(model->getType() == storm::models::ModelType::Pomdp && model->isSparseModel(), storm::exceptions::WrongFormatException, "Expected a POMDP in sparse representation.");
@@ -404,14 +402,14 @@ namespace storm {
                 std::shared_ptr<storm::logic::Formula const> formula;
                 if (!symbolicInput.properties.empty()) {
                     formula = symbolicInput.properties.front().getRawFormula();
-                    STORM_PRINT_AND_LOG("Analyzing property '" << *formula << "'" << std::endl);
+                    STORM_PRINT_AND_LOG("Analyzing property '" << *formula << "'\n");
                     STORM_LOG_WARN_COND(symbolicInput.properties.size() == 1, "There is currently no support for multiple properties. All other properties will be ignored.");
                 }
             
                 if (pomdpSettings.isAnalyzeUniqueObservationsSet()) {
-                    STORM_PRINT_AND_LOG("Analyzing states with unique observation ..." << std::endl);
+                    STORM_PRINT_AND_LOG("Analyzing states with unique observation ...\n");
                     storm::analysis::UniqueObservationStates<ValueType> uniqueAnalysis(*pomdp);
-                    std::cout << uniqueAnalysis.analyse() << std::endl;
+                    std::cout << uniqueAnalysis.analyse() << '\n';
                 }
             
                 if (formula) {
@@ -422,20 +420,20 @@ namespace storm {
                     // Note that formulaInfo contains state-based information which potentially needs to be updated during preprocessing
                     if (performPreprocessing<ValueType, DdType>(pomdp, formulaInfo, *formula)) {
                         sw.stop();
-                        STORM_PRINT_AND_LOG("Time for graph-based POMDP (pre-)processing: " << sw << "." << std::endl);
+                        STORM_PRINT_AND_LOG("Time for graph-based POMDP (pre-)processing: " << sw << ".\n");
                         pomdp->printModelInformationToStream(std::cout);
                     }
 
                     sw.restart();
                     if (performTransformation<ValueType, DdType>(pomdp, *formula)) {
                         sw.stop();
-                        STORM_PRINT_AND_LOG("Time for POMDP transformation(s): " << sw << "s." << std::endl);
+                        STORM_PRINT_AND_LOG("Time for POMDP transformation(s): " << sw << "s.\n");
                     }
                     
                     sw.restart();
                     if (performAnalysis<ValueType, DdType>(pomdp, formulaInfo, *formula)) {
                         sw.stop();
-                        STORM_PRINT_AND_LOG("Time for POMDP analysis: " << sw << "s." << std::endl);
+                        STORM_PRINT_AND_LOG("Time for POMDP analysis: " << sw << "s.\n");
                     }
                     
 

--- a/src/storm-pomdp/analysis/IterativePolicySearch.cpp
+++ b/src/storm-pomdp/analysis/IterativePolicySearch.cpp
@@ -35,16 +35,16 @@ namespace storm {
 
         template <typename ValueType>
         void IterativePolicySearch<ValueType>::Statistics::print() const {
-            STORM_PRINT_AND_LOG("#STATS Total time: " << totalTimer << std::endl);
-            STORM_PRINT_AND_LOG("#STATS SAT Calls: " << satCalls << std::endl);
-            STORM_PRINT_AND_LOG("#STATS SAT Calls time: " << smtCheckTimer << std::endl);
-            STORM_PRINT_AND_LOG("#STATS Outer iterations: " << outerIterations << std::endl);
-            STORM_PRINT_AND_LOG("#STATS Solver initialization time: " << initializeSolverTimer << std::endl);
-            STORM_PRINT_AND_LOG("#STATS Obtain partial scheduler time: " << evaluateExtensionSolverTime << std::endl );
-            STORM_PRINT_AND_LOG("#STATS Update solver to extend partial scheduler time: " << encodeExtensionSolverTime << std::endl);
-            STORM_PRINT_AND_LOG("#STATS Update solver with new scheduler time: " << updateNewStrategySolverTime << std::endl);
-            STORM_PRINT_AND_LOG("#STATS Winning regions update time: " << winningRegionUpdatesTimer << std::endl);
-            STORM_PRINT_AND_LOG("#STATS Graph search time: " << graphSearchTime << std::endl);
+            STORM_PRINT_AND_LOG("#STATS Total time: " << totalTimer << '\n');
+            STORM_PRINT_AND_LOG("#STATS SAT Calls: " << satCalls << '\n');
+            STORM_PRINT_AND_LOG("#STATS SAT Calls time: " << smtCheckTimer << '\n');
+            STORM_PRINT_AND_LOG("#STATS Outer iterations: " << outerIterations << '\n');
+            STORM_PRINT_AND_LOG("#STATS Solver initialization time: " << initializeSolverTimer << '\n');
+            STORM_PRINT_AND_LOG("#STATS Obtain partial scheduler time: " << evaluateExtensionSolverTime << '\n' );
+            STORM_PRINT_AND_LOG("#STATS Update solver to extend partial scheduler time: " << encodeExtensionSolverTime << '\n');
+            STORM_PRINT_AND_LOG("#STATS Update solver with new scheduler time: " << updateNewStrategySolverTime << '\n');
+            STORM_PRINT_AND_LOG("#STATS Winning regions update time: " << winningRegionUpdatesTimer << '\n');
+            STORM_PRINT_AND_LOG("#STATS Graph search time: " << graphSearchTime << '\n');
         }
 
         template <typename ValueType>
@@ -898,7 +898,7 @@ namespace storm {
                     std::cout << " " << state;
                 }
             }
-            std::cout << std::endl;
+            std::cout << '\n';
         }
 
         template<typename ValueType>
@@ -923,7 +923,7 @@ namespace storm {
                 std::string filepath = options.getExportSATCallsPath() + "call_" + std::to_string(iteration) + ".smt2";
                 std::ofstream filestream;
                 storm::utility::openFile(filepath, filestream);
-                filestream << smtSolver->getSmtLibString() << std::endl;
+                filestream << smtSolver->getSmtLibString() << '\n';
                 storm::utility::closeFile(filestream);
             }
 

--- a/src/storm-pomdp/analysis/WinningRegion.cpp
+++ b/src/storm-pomdp/analysis/WinningRegion.cpp
@@ -123,11 +123,11 @@ namespace pomdp {
             } else if(winningRegion[observation].empty()) {
                 loosingObservations.push_back(observation);
             } else {
-                std::cout << "***** observation" << observation << std::endl;
+                std::cout << "***** observation" << observation << '\n';
                 for (auto const& support : winningSupport) {
                     std::cout << " " << support;
                 }
-                std::cout << std::endl;
+                std::cout << '\n';
             }
             observation++;
         }
@@ -319,9 +319,9 @@ namespace pomdp {
     void WinningRegion::storeToFile(std::string const& path, std::string const& preamble, bool append) const {
         std::ofstream file;
         storm::utility::openFile(path, file, append);
-        file << ":preamble" << std::endl;
-        file << preamble << std::endl;
-        file << ":winningregion" << std::endl;
+        file << ":preamble\n";
+        file << preamble << '\n';
+        file << ":winningregion\n";
         bool firstLine = true;
         for (auto const& i : observationSizes) {
             if(!firstLine) {
@@ -331,13 +331,13 @@ namespace pomdp {
             }
             file << i;
         }
-        file << std::endl;
+        file << '\n';
         for (auto const& obsWr : winningRegion) {
             for (auto const& bv : obsWr) {
                 bv.store(file);
                 file << ";";
             }
-            file << std::endl;
+            file << '\n';
         }
         storm::utility::closeFile(file);
     }
@@ -364,7 +364,7 @@ namespace pomdp {
                 if (line == ":winningregion") {
                     state = 2; // get sizes
                 } else {
-                    preamblestream << line << std::endl;
+                    preamblestream << line << '\n';
                 }
             } else if (state == 2) {
                 std::vector<std::string> entries;

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -149,26 +149,26 @@ namespace storm {
             
             template<typename PomdpModelType, typename BeliefValueType>
             void BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType>::printStatisticsToStream(std::ostream& stream) const {
-                stream << "##### Grid Approximation Statistics ######" << std::endl;
-                stream << "# Input model: " << std::endl;
+                stream << "##### Grid Approximation Statistics ######\n";
+                stream << "# Input model: \n";
                 pomdp().printModelInformationToStream(stream);
-                stream << "# Max. Number of states with same observation: " << pomdp().getMaxNrStatesWithSameObservation() << std::endl;
+                stream << "# Max. Number of states with same observation: " << pomdp().getMaxNrStatesWithSameObservation() << '\n';
                 
                 if (statistics.beliefMdpDetectedToBeFinite) {
                     stream << "# Pre-computations detected that the belief MDP is finite.";
                 }
                 if (statistics.aborted) {
-                    stream << "# Computation aborted early" << std::endl;
+                    stream << "# Computation aborted early\n";
                 }
                 
-                stream << "# Total check time: " << statistics.totalTime << std::endl;
+                stream << "# Total check time: " << statistics.totalTime << '\n';
                 
                 // Refinement information:
                 if (statistics.refinementSteps) {
-                    stream << "# Number of refinement steps: " << statistics.refinementSteps.get() << std::endl;
+                    stream << "# Number of refinement steps: " << statistics.refinementSteps.get() << '\n';
                 }
                 if (statistics.refinementFixpointDetected) {
-                    stream << "# Detected a refinement fixpoint." << std::endl;
+                    stream << "# Detected a refinement fixpoint.\n";
                 }
                 
                 // The overapproximation MDP:
@@ -181,10 +181,10 @@ namespace storm {
                     if (statistics.overApproximationBuildAborted) {
                         stream << ">=";
                     }
-                    stream << statistics.overApproximationStates.get() << std::endl;
-                    stream << "# Maximal resolution for over-approximation: " << statistics.overApproximationMaxResolution.get() << std::endl;
-                    stream << "# Time spend for building the over-approx grid MDP(s): " << statistics.overApproximationBuildTime << std::endl;
-                    stream << "# Time spend for checking the over-approx grid MDP(s): " << statistics.overApproximationCheckTime << std::endl;
+                    stream << statistics.overApproximationStates.get() << '\n';
+                    stream << "# Maximal resolution for over-approximation: " << statistics.overApproximationMaxResolution.get() << '\n';
+                    stream << "# Time spend for building the over-approx grid MDP(s): " << statistics.overApproximationBuildTime << '\n';
+                    stream << "# Time spend for checking the over-approx grid MDP(s): " << statistics.overApproximationCheckTime << '\n';
                 }
                 
                 // The underapproximation MDP:
@@ -197,15 +197,15 @@ namespace storm {
                     if (statistics.underApproximationBuildAborted) {
                         stream << ">=";
                     }
-                    stream << statistics.underApproximationStates.get() << std::endl;
+                    stream << statistics.underApproximationStates.get() << '\n';
                     if (statistics.underApproximationStateLimit) {
-                        stream << "# Exploration state limit for under-approximation: " << statistics.underApproximationStateLimit.get() << std::endl;
+                        stream << "# Exploration state limit for under-approximation: " << statistics.underApproximationStateLimit.get() << '\n';
                     }
-                    stream << "# Time spend for building the under-approx grid MDP(s): " << statistics.underApproximationBuildTime << std::endl;
-                    stream << "# Time spend for checking the under-approx grid MDP(s): " << statistics.underApproximationCheckTime << std::endl;
+                    stream << "# Time spend for building the under-approx grid MDP(s): " << statistics.underApproximationBuildTime << '\n';
+                    stream << "# Time spend for checking the under-approx grid MDP(s): " << statistics.underApproximationCheckTime << '\n';
                 }
 
-                stream << "##########################################" << std::endl;
+                stream << "##########################################\n";
             }
             
             template<typename PomdpModelType, typename BeliefValueType>
@@ -228,7 +228,7 @@ namespace storm {
                     if (approx->hasComputedValues()) {
                         auto printInfo = [&approx]() {
                             std::stringstream str;
-                            str << "Explored and checked Over-Approximation MDP:" << std::endl;
+                            str << "Explored and checked Over-Approximation MDP:\n";
                             approx->getExploredMdp()->printModelInformationToStream(str);
                             return str.str();
                         };
@@ -259,7 +259,7 @@ namespace storm {
                     if (approx->hasComputedValues()) {
                         auto printInfo = [&approx]() {
                             std::stringstream str;
-                            str << "Explored and checked Under-Approximation MDP:" << std::endl;
+                            str << "Explored and checked Under-Approximation MDP:\n";
                             approx->getExploredMdp()->printModelInformationToStream(str);
                             return str.str();
                         };
@@ -297,7 +297,7 @@ namespace storm {
                     ValueType const& newValue = overApproximation->getComputedValueAtInitialState();
                     bool betterBound = min ? result.updateLowerBound(newValue) : result.updateUpperBound(newValue);
                     if (betterBound) {
-                        STORM_LOG_INFO("Over-approx result for refinement improved after " << statistics.totalTime << " seconds in refinement step #" << statistics.refinementSteps.get() << ". New value is '" << newValue << "'." << std::endl);
+                        STORM_LOG_INFO("Over-approx result for refinement improved after " << statistics.totalTime << " seconds in refinement step #" << statistics.refinementSteps.get() << ". New value is '" << newValue << "'.\n");
                     }
                 }
                 
@@ -324,7 +324,7 @@ namespace storm {
                     ValueType const& newValue = underApproximation->getComputedValueAtInitialState();
                     bool betterBound = min ? result.updateUpperBound(newValue) : result.updateLowerBound(newValue);
                     if (betterBound) {
-                        STORM_LOG_INFO("Under-approx result for refinement improved after " << statistics.totalTime << " seconds in refinement step #" << statistics.refinementSteps.get() << ". New value is '" << newValue << "'." << std::endl);
+                        STORM_LOG_INFO("Under-approx result for refinement improved after " << statistics.totalTime << " seconds in refinement step #" << statistics.refinementSteps.get() << ". New value is '" << newValue << "'.\n");
                     }
                 }
                 
@@ -422,7 +422,7 @@ namespace storm {
                         }
                     }
                     if (overApproxFixPoint && underApproxFixPoint) {
-                        STORM_LOG_INFO("Refinement fixpoint reached after " << statistics.refinementSteps.get() << " iterations." << std::endl);
+                        STORM_LOG_INFO("Refinement fixpoint reached after " << statistics.refinementSteps.get() << " iterations.\n");
                         statistics.refinementFixpointDetected = true;
                         break;
                     }

--- a/src/storm-pomdp/transformer/MakePOMDPCanonic.cpp
+++ b/src/storm-pomdp/transformer/MakePOMDPCanonic.cpp
@@ -273,10 +273,10 @@ namespace storm {
 
                         std::cout << "Observation " << observation << ": ";
                         detail::actionIdentifiersToStream(std::cout, observationActionIdentifiers[observation], labelStorage);
-                        std::cout << " according to state " << actionIdentifierDefinition[observation] << "." <<  std::endl;
+                        std::cout << " according to state " << actionIdentifierDefinition[observation] << ".\n";
                         std::cout << "Observation " << observation << ": ";
                         detail::actionIdentifiersToStream(std::cout, actionIdentifiers, labelStorage);
-                        std::cout << " according to state " << state << "." <<  std::endl;
+                        std::cout << " according to state " << state << ".\n";
 
                         STORM_LOG_THROW(false, storm::exceptions::AmbiguousModelException, "Actions identifiers do not align between states \n\t" <<  getStateInformation(state) << "\nand\n\t" << getStateInformation(actionIdentifierDefinition[observation]) << "\nboth having observation " << observation  << ". See output above for more information.");
                     }

--- a/src/storm-pomdp/transformer/ObservationTraceUnfolder.cpp
+++ b/src/storm-pomdp/transformer/ObservationTraceUnfolder.cpp
@@ -37,7 +37,7 @@ namespace storm {
             statesPerObservation[model.getNrObservations()] = actualInitialStates;
 
 #ifdef _VERBOSE_OBSERVATION_UNFOLDING
-            std::cout << "build valution builder.." << std::endl;
+            std::cout << "build valution builder..\n";
 #endif
             storm::storage::sparse::StateValuationsBuilder svbuilder;
             svbuilder.addVariable(svvar);
@@ -47,7 +47,7 @@ namespace storm {
             std::map<uint64_t,uint64_t> oldToUnfolded;
 
 #ifdef _VERBOSE_OBSERVATION_UNFOLDING
-            std::cout << "start buildiing matrix..." << std::endl;
+            std::cout << "start buildiing matrix...\n";
 #endif
 
             // Add this initial state state:
@@ -67,7 +67,7 @@ namespace storm {
                 for (auto const& unfoldedToOldEntry : unfoldedToOld) {
                     transitionMatrixBuilder.newRowGroup(newRowGroupStart);
 #ifdef _VERBOSE_OBSERVATION_UNFOLDING
-                    std::cout << "\tconsider new state " << unfoldedToOldEntry.first << std::endl;
+                    std::cout << "\tconsider new state " << unfoldedToOldEntry.first << '\n';
 #endif
                     assert(step == 0 || newRowCount == transitionMatrixBuilder.getLastRow() + 1);
                     svbuilder.addState(unfoldedToOldEntry.first, {}, {static_cast<int64_t>(unfoldedToOldEntry.second)});
@@ -76,8 +76,8 @@ namespace storm {
 
                     for (uint64_t oldRowIndex = oldRowIndexStart; oldRowIndex != oldRowIndexEnd; oldRowIndex++) {
 #ifdef _VERBOSE_OBSERVATION_UNFOLDING
-                        std::cout << "\t\tconsider old action " << oldRowIndex << std::endl;
-                        std::cout << "\t\tconsider new row nr " << newRowCount << std::endl;
+                        std::cout << "\t\tconsider old action " << oldRowIndex << '\n';
+                        std::cout << "\t\tconsider new row nr " << newRowCount << '\n';
 #endif
 
                         ValueType resetProb = storm::utility::zero<ValueType>();
@@ -88,7 +88,7 @@ namespace storm {
                             }
                         }
 #ifdef _VERBOSE_OBSERVATION_UNFOLDING
-                        std::cout << "\t\t\t add reset with probability " << resetProb << std::endl;
+                        std::cout << "\t\t\t add reset with probability " << resetProb << '\n';
 #endif
 
                         // Add the resets
@@ -96,7 +96,7 @@ namespace storm {
                             transitionMatrixBuilder.addNextValue(newRowCount, 0, resetProb);
                         }
 #ifdef _VERBOSE_OBSERVATION_UNFOLDING
-                        std::cout << "\t\t\t add other transitions..." << std::endl;
+                        std::cout << "\t\t\t add other transitions...\n";
 #endif
 
                         // Now, we build the outgoing transitions.
@@ -116,7 +116,7 @@ namespace storm {
                                 column = entryIt->second;
                             }
 #ifdef _VERBOSE_OBSERVATION_UNFOLDING
-                            std::cout << "\t\t\t\t transition to " << column << "with probability " << oldRowEntry.getValue()  << std::endl;
+                            std::cout << "\t\t\t\t transition to " << column << "with probability " << oldRowEntry.getValue()  << '\n';
 #endif
                             transitionMatrixBuilder.addNextValue(newRowCount, column,
                                                                    oldRowEntry.getValue());
@@ -139,7 +139,7 @@ namespace storm {
                 STORM_LOG_ASSERT(risk.size() > unfoldedToOldEntry.second, "Must be a state");
                 STORM_LOG_ASSERT(!cc.isLess(storm::utility::one<ValueType>(), risk[unfoldedToOldEntry.second]), "Risk must be a probability");
                 STORM_LOG_ASSERT(!cc.isLess(risk[unfoldedToOldEntry.second], storm::utility::zero<ValueType>()), "Risk must be a probability");
-                //std::cout << "risk is" <<  risk[unfoldedToOldEntry.second] << std::endl;
+                //std::cout << "risk is" <<  risk[unfoldedToOldEntry.second] << '\n';
                 if (!storm::utility::isOne(risk[unfoldedToOldEntry.second])) {
                     transitionMatrixBuilder.addNextValue(newRowGroupStart, sinkState,
                                                          storm::utility::one<ValueType>() - risk[unfoldedToOldEntry.second]);
@@ -161,13 +161,13 @@ namespace storm {
             transitionMatrixBuilder.addNextValue(newRowGroupStart, targetState, storm::utility::one<ValueType>());
             svbuilder.addState(targetState, {}, {-1});
 #ifdef _VERBOSE_OBSERVATION_UNFOLDING
-            std::cout << "build matrix..." << std::endl;
+            std::cout << "build matrix...\n";
 #endif
 
             storm::storage::sparse::ModelComponents<ValueType> components;
             components.transitionMatrix = transitionMatrixBuilder.build();
 #ifdef _VERBOSE_OBSERVATION_UNFOLDING
-            std::cout << components.transitionMatrix << std::endl;
+            std::cout << components.transitionMatrix << '\n';
 #endif
             STORM_LOG_ASSERT(components.transitionMatrix.getRowGroupCount() == targetState + 1, "Expect row group count (" << components.transitionMatrix.getRowGroupCount() << ") one more as target state index " << targetState << ")");
 

--- a/src/storm/abstraction/ExplicitGameStrategy.cpp
+++ b/src/storm/abstraction/ExplicitGameStrategy.cpp
@@ -49,14 +49,14 @@ std::ostream& operator<<(std::ostream& out, ExplicitGameStrategy const& strategy
         if (choice == ExplicitGameStrategy::UNDEFINED) {
             undefinedStates.emplace_back(state);
         } else {
-            out << state << " -> " << choice << std::endl;
+            out << state << " -> " << choice << '\n';
         }
     }
     out << "undefined states: ";
     for (auto state : undefinedStates) {
         out << state << ", ";
     }
-    out << std::endl;
+    out << '\n';
 
     return out;
 }

--- a/src/storm/abstraction/ExplicitGameStrategyPair.cpp
+++ b/src/storm/abstraction/ExplicitGameStrategyPair.cpp
@@ -38,8 +38,8 @@ uint64_t ExplicitGameStrategyPair::getNumberOfUndefinedPlayer2States() const {
 }
 
 std::ostream& operator<<(std::ostream& out, ExplicitGameStrategyPair const& strategyPair) {
-    out << "player 1 strategy: " << std::endl << strategyPair.getPlayer1Strategy() << std::endl;
-    out << "player 2 strategy: " << std::endl << strategyPair.getPlayer2Strategy() << std::endl;
+    out << "player 1 strategy: \n" << strategyPair.getPlayer1Strategy() << '\n';
+    out << "player 2 strategy: \n" << strategyPair.getPlayer2Strategy() << '\n';
     return out;
 }
 

--- a/src/storm/abstraction/MenuGameAbstractor.cpp
+++ b/src/storm/abstraction/MenuGameAbstractor.cpp
@@ -101,7 +101,7 @@ void MenuGameAbstractor<DdType, ValueType>::exportToDot(storm::abstraction::Menu
                                             abstractionInformation.getSourcePredicateVariables(), abstractionInformation.getBottomStateVariable(true)));
     }
 
-    out << "digraph game {" << std::endl;
+    out << "digraph game {\n";
 
     // Create the player 1 nodes.
     storm::dd::Add<DdType, ValueType> statesAsAdd = filteredReachableStates.template toAdd<ValueType>();
@@ -125,7 +125,7 @@ void MenuGameAbstractor<DdType, ValueType>::exportToDot(storm::abstraction::Menu
         } else if (isHighlight) {
             out << ", style=\"filled\", fillcolor=\"red\"";
         }
-        out << " ];" << std::endl;
+        out << " ];\n";
     }
 
     // Create the nodes of the second player.
@@ -139,9 +139,9 @@ void MenuGameAbstractor<DdType, ValueType>::exportToDot(storm::abstraction::Menu
                                              abstractionInformation.getSourcePredicateVariables(), abstractionInformation.getBottomStateVariable(true));
         uint_fast64_t index = abstractionInformation.decodePlayer1Choice(stateValue.first, abstractionInformation.getPlayer1VariableCount());
         out << stateName << "_" << index;
-        out << " [ shape=\"square\", width=0, height=0, margin=0, label=\"" << index << "\" ];" << std::endl;
+        out << " [ shape=\"square\", width=0, height=0, margin=0, label=\"" << index << "\" ];\n";
         out << "\tpl1_" << stateName << " -> "
-            << "pl2_" << stateName << "_" << index << " [ label=\"" << index << "\" ];" << std::endl;
+            << "pl2_" << stateName << "_" << index << " [ label=\"" << index << "\" ];\n";
     }
 
     // Create the nodes of the probabilistic player.
@@ -156,9 +156,9 @@ void MenuGameAbstractor<DdType, ValueType>::exportToDot(storm::abstraction::Menu
         std::string stateName = stateNameStream.str();
         index = abstractionInformation.decodePlayer2Choice(stateValue.first, currentGame.getPlayer2Variables().size());
         out << stateName << "_" << index;
-        out << " [ shape=\"point\", label=\"\" ];" << std::endl;
+        out << " [ shape=\"point\", label=\"\" ];\n";
         out << "\tpl2_" << stateName << " -> "
-            << "plp_" << stateName << "_" << index << " [ label=\"" << index << "\" ];" << std::endl;
+            << "plp_" << stateName << "_" << index << " [ label=\"" << index << "\" ];\n";
     }
 
     for (auto stateValue : filteredTransitions) {
@@ -170,10 +170,10 @@ void MenuGameAbstractor<DdType, ValueType>::exportToDot(storm::abstraction::Menu
         uint_fast64_t pl1Index = abstractionInformation.decodePlayer1Choice(stateValue.first, abstractionInformation.getPlayer1VariableCount());
         uint_fast64_t pl2Index = abstractionInformation.decodePlayer2Choice(stateValue.first, currentGame.getPlayer2Variables().size());
         out << "\tplp_" << sourceStateName << "_" << pl1Index << "_" << pl2Index << " -> pl1_" << successorStateName << " [ label=\"" << stateValue.second
-            << "\"];" << std::endl;
+            << "\"];\n";
     }
 
-    out << "}" << std::endl;
+    out << "}\n";
     storm::utility::closeFile(out);
 }
 

--- a/src/storm/abstraction/MenuGameRefiner.cpp
+++ b/src/storm/abstraction/MenuGameRefiner.cpp
@@ -1098,23 +1098,23 @@ bool MenuGameRefiner<Type, ValueType>::refine(storm::abstraction::MenuGame<Type,
     //            bool min1ChoiceInPivotIsProb0Max = !(min1ChoiceInPivot && qualitativeResult.prob0Max.getPlayer2States()).isZero();
     //            bool min1ChoiceInPivotIsProb1Min = !(min1ChoiceInPivot && qualitativeResult.prob1Min.getPlayer2States()).isZero();
     //            bool min1ChoiceInPivotIsProb1Max = !(min1ChoiceInPivot && qualitativeResult.prob1Max.getPlayer2States()).isZero();
-    //            std::cout << "after redirection (min)" << std::endl;
-    //            std::cout << "min choice is prob0 in min? " << min1ChoiceInPivotIsProb0Min << ", max? " << min1ChoiceInPivotIsProb0Max << std::endl;
-    //            std::cout << "min choice is prob1 in min? " << min1ChoiceInPivotIsProb1Min << ", max? " << min1ChoiceInPivotIsProb1Max << std::endl;
-    //            std::cout << "min" << std::endl;
+    //            std::cout << "after redirection (min)\n";
+    //            std::cout << "min choice is prob0 in min? " << min1ChoiceInPivotIsProb0Min << ", max? " << min1ChoiceInPivotIsProb0Max << '\n';
+    //            std::cout << "min choice is prob1 in min? " << min1ChoiceInPivotIsProb1Min << ", max? " << min1ChoiceInPivotIsProb1Max << '\n';
+    //            std::cout << "min\n";
     //            for (auto const& e : (min1ChoiceInPivot && minPlayer2Strategy).template toAdd<ValueType>()) {
-    //                std::cout << e.first << " -> " << e.second << std::endl;
+    //                std::cout << e.first << " -> " << e.second << '\n';
     //            }
-    //            std::cout << "max" << std::endl;
+    //            std::cout << "max\n";
     //            for (auto const& e : (min1ChoiceInPivot && maxPlayer2Strategy).template toAdd<ValueType>()) {
-    //                std::cout << e.first << " -> " << e.second << std::endl;
+    //                std::cout << e.first << " -> " << e.second << '\n';
     //            }
     //            bool different = (min1ChoiceInPivot && minPlayer2Strategy) != (min1ChoiceInPivot && maxPlayer2Strategy);
-    //            std::cout << "min/max choice of player 2 is different? " << different << std::endl;
+    //            std::cout << "min/max choice of player 2 is different? " << different << '\n';
     //            bool min1MinPlayer2Choice = !(min1ChoiceInPivot && minPlayer2Strategy).isZero();
     //            bool min1MaxPlayer2Choice = !(min1ChoiceInPivot && maxPlayer2Strategy).isZero();
-    //            std::cout << "max/min choice there? " << min1MinPlayer2Choice << std::endl;
-    //            std::cout << "max/max choice there? " << min1MaxPlayer2Choice << std::endl;
+    //            std::cout << "max/min choice there? " << min1MinPlayer2Choice << '\n';
+    //            std::cout << "max/max choice there? " << min1MaxPlayer2Choice << '\n';
     //
     //            auto max1ChoiceInPivot = SymbolicPivotStateResult.pivotState && game.getExtendedTransitionMatrix().toBdd() && maxPlayer1Strategy;
     //            STORM_LOG_ASSERT(!max1ChoiceInPivot.isZero(), "wth?");
@@ -1122,15 +1122,15 @@ bool MenuGameRefiner<Type, ValueType>::refine(storm::abstraction::MenuGame<Type,
     //            bool max1ChoiceInPivotIsProb0Max = !(max1ChoiceInPivot && qualitativeResult.prob0Max.getPlayer2States()).isZero();
     //            bool max1ChoiceInPivotIsProb1Min = !(max1ChoiceInPivot && qualitativeResult.prob1Min.getPlayer2States()).isZero();
     //            bool max1ChoiceInPivotIsProb1Max = !(max1ChoiceInPivot && qualitativeResult.prob1Max.getPlayer2States()).isZero();
-    //            std::cout << "after redirection (max)" << std::endl;
-    //            std::cout << "max choice is prob0 in min? " << max1ChoiceInPivotIsProb0Min << ", max? " << max1ChoiceInPivotIsProb0Max << std::endl;
-    //            std::cout << "max choice is prob1 in min? " << max1ChoiceInPivotIsProb1Min << ", max? " << max1ChoiceInPivotIsProb1Max << std::endl;
+    //            std::cout << "after redirection (max)\n";
+    //            std::cout << "max choice is prob0 in min? " << max1ChoiceInPivotIsProb0Min << ", max? " << max1ChoiceInPivotIsProb0Max << '\n';
+    //            std::cout << "max choice is prob1 in min? " << max1ChoiceInPivotIsProb1Min << ", max? " << max1ChoiceInPivotIsProb1Max << '\n';
     //            different = (max1ChoiceInPivot && minPlayer2Strategy) != (max1ChoiceInPivot && maxPlayer2Strategy);
-    //            std::cout << "min/max choice of player 2 is different? " << different << std::endl;
+    //            std::cout << "min/max choice of player 2 is different? " << different << '\n';
     //            bool max1MinPlayer2Choice = !(max1ChoiceInPivot && minPlayer2Strategy).isZero();
     //            bool max1MaxPlayer2Choice = !(max1ChoiceInPivot && maxPlayer2Strategy).isZero();
-    //            std::cout << "max/min choice there? " << max1MinPlayer2Choice << std::endl;
-    //            std::cout << "max/max choice there? " << max1MaxPlayer2Choice << std::endl;
+    //            std::cout << "max/min choice there? " << max1MinPlayer2Choice << '\n';
+    //            std::cout << "max/max choice there? " << max1MaxPlayer2Choice << '\n';
 
     boost::optional<RefinementPredicates> predicates;
     if (useInterpolation) {

--- a/src/storm/abstraction/prism/CommandAbstractor.cpp
+++ b/src/storm/abstraction/prism/CommandAbstractor.cpp
@@ -554,15 +554,15 @@ std::pair<std::set<uint_fast64_t>, std::vector<std::set<uint_fast64_t>>> Command
         result.second.push_back(relevantUpdatePredicates.second);
     }
 
-    //                std::cout << "relevant predicates for command " << command.get().getGlobalIndex() << std::endl;
-    //                std::cout << "source predicates" << std::endl;
+    //                std::cout << "relevant predicates for command " << command.get().getGlobalIndex() << '\n';
+    //                std::cout << "source predicates\n";
     //                for (auto const& i : result.first) {
-    //                    std::cout << this->getAbstractionInformation().getPredicateByIndex(i) << std::endl;
+    //                    std::cout << this->getAbstractionInformation().getPredicateByIndex(i) << '\n';
     //                }
     //                for (uint64_t i = 0; i < result.second.size(); ++i) {
-    //                    std::cout << "destination " << i << std::endl;
+    //                    std::cout << "destination " << i << '\n';
     //                    for (auto const& j : result.second[i]) {
-    //                        std::cout << this->getAbstractionInformation().getPredicateByIndex(j) << std::endl;
+    //                        std::cout << this->getAbstractionInformation().getPredicateByIndex(j) << '\n';
     //                    }
     //                }
 

--- a/src/storm/automata/HOAConsumerDA.h
+++ b/src/storm/automata/HOAConsumerDA.h
@@ -155,7 +155,7 @@ class HOAConsumerDA : public HOAConsumerDAHeader {
                             storm::exceptions::InvalidOperationException,
                             "HOA automaton: multiple definitions of successor for state " << stateId << " and edge " << edgeIndex);
 
-            // std::cout << stateId << " -(" << edgeIndex << ")-> " << successor << std::endl;
+            // std::cout << stateId << " -(" << edgeIndex << ")-> " << successor << '\n';
             da->setSuccessor(stateId, edgeIndex, successor);
             markEdgeAsSeen(stateId, edgeIndex);
 

--- a/src/storm/automata/LTL2DeterministicAutomaton.cpp
+++ b/src/storm/automata/LTL2DeterministicAutomaton.cpp
@@ -75,7 +75,7 @@ std::shared_ptr<DeterministicAutomaton> LTL2DeterministicAutomaton::ltl2daExtern
     if (pid == 0) {
         // we are in the child process
         if (execlp(ltl2daTool.c_str(), ltl2daTool.c_str(), prefixLtl.c_str(), "da.hoa", NULL) < 0) {
-            std::cerr << "ERROR: exec failed: " << strerror(errno) << std::endl;
+            std::cerr << "ERROR: exec failed: " << strerror(errno) << '\n';
             std::exit(1);
         }
         // never reached

--- a/src/storm/builder/DdJaniModelBuilder.cpp
+++ b/src/storm/builder/DdJaniModelBuilder.cpp
@@ -2212,7 +2212,7 @@ storm::dd::Bdd<Type> fixDeadlocks(storm::jani::ModelType const& modelType, storm
             storm::dd::Add<Type, ValueType> deadlockStatesAdd = deadlockStates.template toAdd<ValueType>();
             uint_fast64_t count = 0;
             for (auto it = deadlockStatesAdd.begin(), ite = deadlockStatesAdd.end(); it != ite && count < 3; ++it, ++count) {
-                STORM_LOG_INFO((*it).first.toPrettyString(variables.rowMetaVariables) << std::endl);
+                STORM_LOG_INFO((*it).first.toPrettyString(variables.rowMetaVariables) << '\n');
             }
 
             // Create a global identity DD.

--- a/src/storm/builder/DdPrismModelBuilder.cpp
+++ b/src/storm/builder/DdPrismModelBuilder.cpp
@@ -1438,7 +1438,7 @@ std::shared_ptr<storm::models::symbolic::Model<Type, ValueType>> DdPrismModelBui
     STORM_LOG_THROW(!program.hasUnboundedVariables(), storm::exceptions::InvalidArgumentException,
                     "Program contains unbounded variables which is not supported by the DD engine.");
 
-    STORM_LOG_TRACE("Building representation of program:" << std::endl << program << std::endl);
+    STORM_LOG_TRACE("Building representation of program:\n" << program << '\n');
 
     // Start by initializing the structure used for storing all information needed during the model generation.
     // In particular, this creates the meta variables used to encode the model.
@@ -1497,7 +1497,7 @@ std::shared_ptr<storm::models::symbolic::Model<Type, ValueType>> DdPrismModelBui
             storm::dd::Add<Type, ValueType> deadlockStatesAdd = deadlockStates.template toAdd<ValueType>();
             uint_fast64_t count = 0;
             for (auto it = deadlockStatesAdd.begin(), ite = deadlockStatesAdd.end(); it != ite && count < 3; ++it, ++count) {
-                STORM_LOG_INFO((*it).first.toPrettyString(generationInfo.rowMetaVariables) << std::endl);
+                STORM_LOG_INFO((*it).first.toPrettyString(generationInfo.rowMetaVariables) << '\n');
             }
 
             if (program.getModelType() == storm::prism::Program::ModelType::DTMC || program.getModelType() == storm::prism::Program::ModelType::CTMC) {

--- a/src/storm/builder/ExplicitModelBuilder.cpp
+++ b/src/storm/builder/ExplicitModelBuilder.cpp
@@ -300,7 +300,7 @@ void ExplicitModelBuilder<ValueType, RewardModelType, StateType>::buildMatrices(
                 auto statesPerSecond = numberOfExploredStatesSinceLastMessage / durationSinceLastMessage;
                 auto durationSinceStart = std::chrono::duration_cast<std::chrono::seconds>(now - timeOfStart).count();
                 std::cout << "Explored " << numberOfExploredStates << " states in " << durationSinceStart << " seconds (currently " << statesPerSecond
-                          << " states per second)." << std::endl;
+                          << " states per second).\n";
                 timeOfLastMessage = std::chrono::high_resolution_clock::now();
                 numberOfExploredStatesSinceLastMessage = 0;
             }
@@ -308,7 +308,7 @@ void ExplicitModelBuilder<ValueType, RewardModelType, StateType>::buildMatrices(
 
         if (storm::utility::resources::isTerminate()) {
             auto durationSinceStart = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - timeOfStart).count();
-            std::cout << "Explored " << numberOfExploredStates << " states in " << durationSinceStart << " seconds before abort." << std::endl;
+            std::cout << "Explored " << numberOfExploredStates << " states in " << durationSinceStart << " seconds before abort.\n";
             STORM_LOG_THROW(false, storm::exceptions::AbortException, "Aborted in state space exploration.");
             break;
         }

--- a/src/storm/builder/ParallelCompositionBuilder.cpp
+++ b/src/storm/builder/ParallelCompositionBuilder.cpp
@@ -124,37 +124,37 @@ std::shared_ptr<storm::models::sparse::Ctmc<ValueType>> ParallelCompositionBuild
     std::shared_ptr<storm::models::sparse::Ctmc<ValueType>> composedCtmc = std::make_shared<storm::models::sparse::Ctmc<ValueType>>(matrixComposed, labeling);
 
     // Print for debugging
-    /*std::cout << "Matrix A:" << std::endl;
-    std::cout << matrixA << std::endl;
-    std::cout << "Matrix B:" << std::endl;
-    std::cout << matrixB << std::endl;
-    std::cout << "Composed matrix: " << std::endl << matrixComposed;
-    std::cout << "Labeling A" << std::endl;
+    /*std::cout << "Matrix A:\n";
+    std::cout << matrixA << '\n';
+    std::cout << "Matrix B:\n";
+    std::cout << matrixB << '\n';
+    std::cout << "Composed matrix: \n" << matrixComposed;
+    std::cout << "Labeling A\n";
     labelingA.printLabelingInformationToStream(std::cout);
     for (size_t stateA = 0; stateA < sizeA; ++stateA) {
         std::cout << "State " << stateA << ": ";
         for (auto label : labelingA.getLabelsOfState(stateA)) {
             std::cout << label << ", ";
         }
-        std::cout << std::endl;
+        std::cout << '\n';
     }
-    std::cout << "Labeling B" << std::endl;
+    std::cout << "Labeling B\n";
     labelingB.printLabelingInformationToStream(std::cout);
     for (size_t stateB = 0; stateB < sizeB; ++stateB) {
         std::cout << "State " << stateB << ": ";
         for (auto label : labelingB.getLabelsOfState(stateB)) {
             std::cout << label << ", ";
         }
-        std::cout << std::endl;
+        std::cout << '\n';
     }
-    std::cout << "Labeling Composed" << std::endl;
+    std::cout << "Labeling Composed\n";
     labeling.printLabelingInformationToStream(std::cout);
     for (size_t state = 0; state < size; ++state) {
         std::cout << "State " << state << ": ";
         for (auto label : labeling.getLabelsOfState(state)) {
             std::cout << label << ", ";
         }
-        std::cout << std::endl;
+        std::cout << '\n';
     }*/
 
     return composedCtmc;

--- a/src/storm/builder/jit/ExplicitJitJaniModelBuilder.cpp
+++ b/src/storm/builder/jit/ExplicitJitJaniModelBuilder.cpp
@@ -232,7 +232,7 @@ template<typename ValueType, typename RewardModelType>
 boost::filesystem::path ExplicitJitJaniModelBuilder<ValueType, RewardModelType>::writeToTemporaryFile(std::string const& content, std::string const& suffix) {
     boost::filesystem::path temporaryFile = boost::filesystem::unique_path("%%%%-%%%%-%%%%-%%%%" + suffix);
     std::ofstream out(temporaryFile.native());
-    out << content << std::endl;
+    out << content << '\n';
     out.close();
     return temporaryFile;
 }
@@ -1116,16 +1116,16 @@ cpptempl::data_map ExplicitJitJaniModelBuilder<ValueType, RewardModelType>::gene
     if (generateLevelCode) {
         vectorSource << "int64_t lowestLevel, int64_t highestLevel, ";
     }
-    vectorSource << "ValueType const& rate, Choice<IndexType, ValueType>& choice) {" << std::endl;
+    vectorSource << "ValueType const& rate, Choice<IndexType, ValueType>& choice) {\n";
     if (options.isExplorationChecksSet()) {
-        indent(vectorSource, indentLevel + 1) << "VariableWrites variableWrites;" << std::endl;
+        indent(vectorSource, indentLevel + 1) << "VariableWrites variableWrites;\n";
     }
-    indent(vectorSource, indentLevel + 1) << "StateType out(in);" << std::endl;
-    indent(vectorSource, indentLevel + 1) << "TransientVariables transientIn;" << std::endl;
-    indent(vectorSource, indentLevel + 1) << "TransientVariables transientOut;" << std::endl;
+    indent(vectorSource, indentLevel + 1) << "StateType out(in);\n";
+    indent(vectorSource, indentLevel + 1) << "TransientVariables transientIn;\n";
+    indent(vectorSource, indentLevel + 1) << "TransientVariables transientOut;\n";
 
     if (generateLevelCode) {
-        indent(vectorSource, indentLevel + 1) << "for (int64_t level = lowestLevel; level <= highestLevel; ++level) {" << std::endl;
+        indent(vectorSource, indentLevel + 1) << "for (int64_t level = lowestLevel; level <= highestLevel; ++level) {\n";
         ++indentLevel;
     }
     for (uint64_t index = 0; index < numberOfActionInputs; ++index) {
@@ -1137,13 +1137,13 @@ cpptempl::data_map ExplicitJitJaniModelBuilder<ValueType, RewardModelType>::gene
         if (options.isExplorationChecksSet()) {
             vectorSource << ", variableWrites";
         }
-        vectorSource << ");" << std::endl;
+        vectorSource << ");\n";
     }
     if (generateLevelCode) {
         --indentLevel;
-        indent(vectorSource, indentLevel + 1) << "}" << std::endl;
+        indent(vectorSource, indentLevel + 1) << "}\n";
     }
-    indent(vectorSource, indentLevel + 1) << "IndexType outStateIndex = getOrAddIndex(out, statesToExplore);" << std::endl;
+    indent(vectorSource, indentLevel + 1) << "IndexType outStateIndex = getOrAddIndex(out, statesToExplore);\n";
     indent(vectorSource, indentLevel + 1) << "ValueType probability = ";
     for (uint64_t index = 0; index < numberOfActionInputs; ++index) {
         vectorSource << "destination" << index << ".probability(in)";
@@ -1151,36 +1151,35 @@ cpptempl::data_map ExplicitJitJaniModelBuilder<ValueType, RewardModelType>::gene
             vectorSource << " * ";
         }
     }
-    vectorSource << ";" << std::endl;
-    indent(vectorSource, indentLevel + 1) << "ValueType value = rate * probability;" << std::endl;
-    indent(vectorSource, indentLevel + 1) << "choice.add(outStateIndex, value);" << std::endl;
+    vectorSource << ";\n";
+    indent(vectorSource, indentLevel + 1) << "ValueType value = rate * probability;\n";
+    indent(vectorSource, indentLevel + 1) << "choice.add(outStateIndex, value);\n";
 
     std::stringstream tmp;
-    indent(tmp, indentLevel + 1) << "{% for reward in destination_rewards %}choice.addReward({$reward.index}, probability * transientOut.{$reward.variable});"
-                                 << std::endl;
-    indent(tmp, indentLevel + 1) << "{% endfor %}" << std::endl;
+    indent(tmp, indentLevel + 1)
+        << "{% for reward in destination_rewards %}choice.addReward({$reward.index}, probability * transientOut.{$reward.variable});\n";
+    indent(tmp, indentLevel + 1) << "{% endfor %}\n";
     vectorSource << cpptempl::parse(tmp.str(), modelData);
-    indent(vectorSource, indentLevel) << "}" << std::endl << std::endl;
+    indent(vectorSource, indentLevel) << "}\n\n";
 
     indent(vectorSource, indentLevel) << "void performSynchronizedDestinations_" << synchronizationVectorIndex
                                       << "(StateType const& in, StateBehaviour<IndexType, ValueType>& behaviour, StateSet<StateType>& statesToExplore, ";
     for (uint64_t index = 0; index < numberOfActionInputs; ++index) {
         vectorSource << "Edge const& edge" << index << ", ";
     }
-    vectorSource << "ValueType const& rate, Choice<IndexType, ValueType>& choice) {" << std::endl;
+    vectorSource << "ValueType const& rate, Choice<IndexType, ValueType>& choice) {\n";
     if (generateLevelCode) {
         indent(vectorSource, indentLevel + 1) << "int64_t lowestLevel; int64_t highestLevel;";
     }
     for (uint64_t index = 0; index < numberOfActionInputs; ++index) {
-        indent(vectorSource, indentLevel + 1 + index) << "for (auto const& destination" << index << " : edge" << index << ") {" << std::endl;
+        indent(vectorSource, indentLevel + 1 + index) << "for (auto const& destination" << index << " : edge" << index << ") {\n";
         if (generateLevelCode) {
             if (index == 0) {
-                indent(vectorSource, indentLevel + 2 + index) << "lowestLevel = destination" << index << ".lowestLevel();" << std::endl;
-                indent(vectorSource, indentLevel + 2 + index) << "highestLevel = destination" << index << ".highestLevel();" << std::endl;
+                indent(vectorSource, indentLevel + 2 + index) << "lowestLevel = destination" << index << ".lowestLevel();\n";
+                indent(vectorSource, indentLevel + 2 + index) << "highestLevel = destination" << index << ".highestLevel();\n";
             } else {
-                indent(vectorSource, indentLevel + 2 + index) << "lowestLevel = std::min(lowestLevel, destination" << index << ".lowestLevel());" << std::endl;
-                indent(vectorSource, indentLevel + 2 + index)
-                    << "highestLevel = std::max(highestLevel, destination" << index << ".highestLevel());" << std::endl;
+                indent(vectorSource, indentLevel + 2 + index) << "lowestLevel = std::min(lowestLevel, destination" << index << ".lowestLevel());\n";
+                indent(vectorSource, indentLevel + 2 + index) << "highestLevel = std::max(highestLevel, destination" << index << ".highestLevel());\n";
             }
         }
     }
@@ -1192,11 +1191,11 @@ cpptempl::data_map ExplicitJitJaniModelBuilder<ValueType, RewardModelType>::gene
     if (generateLevelCode) {
         vectorSource << "lowestLevel, highestLevel, ";
     }
-    vectorSource << "rate, choice);" << std::endl;
+    vectorSource << "rate, choice);\n";
     for (uint64_t index = 0; index < numberOfActionInputs; ++index) {
-        indent(vectorSource, indentLevel + numberOfActionInputs - index) << "}" << std::endl;
+        indent(vectorSource, indentLevel + numberOfActionInputs - index) << "}\n";
     }
-    indent(vectorSource, indentLevel) << "}" << std::endl << std::endl;
+    indent(vectorSource, indentLevel) << "}\n\n";
 
     for (uint64_t index = 0; index < numberOfActionInputs; ++index) {
         indent(vectorSource, indentLevel) << "void performSynchronizedEdges_" << synchronizationVectorIndex << "_" << index
@@ -1217,20 +1216,20 @@ cpptempl::data_map ExplicitJitJaniModelBuilder<ValueType, RewardModelType>::gene
                 vectorSource << ", VariableWrites& variableWrites";
             }
         }
-        vectorSource << ", ValueType const& rate) {" << std::endl;
+        vectorSource << ", ValueType const& rate) {\n";
         if (index == 0) {
             if (options.isExplorationChecksSet()) {
-                indent(vectorSource, indentLevel + 1) << "VariableWrites variableWrites;" << std::endl;
+                indent(vectorSource, indentLevel + 1) << "VariableWrites variableWrites;\n";
             }
-            indent(vectorSource, indentLevel + 1) << "TransientVariables transientIn;" << std::endl;
-            indent(vectorSource, indentLevel + 1) << "TransientVariables transientOut;" << std::endl;
+            indent(vectorSource, indentLevel + 1) << "TransientVariables transientIn;\n";
+            indent(vectorSource, indentLevel + 1) << "TransientVariables transientOut;\n";
         }
-        indent(vectorSource, indentLevel + 1) << "for (auto const& edge" << index << " : edges[" << index << "]) {" << std::endl;
+        indent(vectorSource, indentLevel + 1) << "for (auto const& edge" << index << " : edges[" << index << "]) {\n";
         indent(vectorSource, indentLevel + 2) << "edge" << index << ".get().perform(in, transientIn, transientOut";
         if (options.isExplorationChecksSet()) {
             vectorSource << ", variableWrites";
         }
-        vectorSource << ");" << std::endl;
+        vectorSource << ");\n";
         if (index + 1 < numberOfActionInputs) {
             indent(vectorSource, indentLevel + 2) << "performSynchronizedEdges_" << synchronizationVectorIndex << "_" << (index + 1)
                                                   << "(in, edges, behaviour, statesToExplore, ";
@@ -1241,14 +1240,14 @@ cpptempl::data_map ExplicitJitJaniModelBuilder<ValueType, RewardModelType>::gene
             if (options.isExplorationChecksSet()) {
                 vectorSource << "variableWrites, ";
             }
-            vectorSource << "rate * edge" << index << ".get().rate(in));" << std::endl;
+            vectorSource << "rate * edge" << index << ".get().rate(in));\n";
         } else {
-            indent(vectorSource, indentLevel + 2) << "Choice<IndexType, ValueType>& choice = behaviour.addChoice();" << std::endl;
+            indent(vectorSource, indentLevel + 2) << "Choice<IndexType, ValueType>& choice = behaviour.addChoice();\n";
 
             std::stringstream tmp;
-            indent(tmp, indentLevel + 2) << "choice.resizeRewards({$edge_destination_rewards_count});" << std::endl;
-            indent(tmp, indentLevel + 2) << "{% for reward in edge_rewards %}choice.addReward({$reward.index}, transientOut.{$reward.variable});" << std::endl;
-            indent(tmp, indentLevel + 2) << "{% endfor %}" << std::endl;
+            indent(tmp, indentLevel + 2) << "choice.resizeRewards({$edge_destination_rewards_count});\n";
+            indent(tmp, indentLevel + 2) << "{% for reward in edge_rewards %}choice.addReward({$reward.index}, transientOut.{$reward.variable});\n";
+            indent(tmp, indentLevel + 2) << "{% endfor %}\n";
 
             vectorSource << cpptempl::parse(tmp.str(), modelData);
 
@@ -1256,21 +1255,20 @@ cpptempl::data_map ExplicitJitJaniModelBuilder<ValueType, RewardModelType>::gene
             for (uint64_t innerIndex = 0; innerIndex <= index; ++innerIndex) {
                 vectorSource << "edge" << innerIndex << ", ";
             }
-            vectorSource << "rate * edge" << index << ".get().rate(in), choice);" << std::endl;
+            vectorSource << "rate * edge" << index << ".get().rate(in), choice);\n";
         }
-        indent(vectorSource, indentLevel + 1) << "}" << std::endl;
-        indent(vectorSource, indentLevel) << "}" << std::endl << std::endl;
+        indent(vectorSource, indentLevel + 1) << "}\n";
+        indent(vectorSource, indentLevel) << "}\n\n";
     }
 
     indent(vectorSource, indentLevel)
         << "void get_edges_" << synchronizationVectorIndex
-        << "(StateType const& state, TransientVariables const& transientIn, std::vector<std::reference_wrapper<Edge const>>& edges, uint64_t position) {"
-        << std::endl;
+        << "(StateType const& state, TransientVariables const& transientIn, std::vector<std::reference_wrapper<Edge const>>& edges, uint64_t position) {\n";
     position = 0;
     uint64_t participatingPosition = 0;
     for (auto const& inputActionName : synchronizationVector.getInput()) {
         if (!storm::jani::SynchronizationVector::isNoActionInput(inputActionName)) {
-            indent(vectorSource, indentLevel + 1) << "if (position == " << participatingPosition << ") {" << std::endl;
+            indent(vectorSource, indentLevel + 1) << "if (position == " << participatingPosition << ") {\n";
 
             storm::jani::Automaton const& automaton =
                 model.getAutomaton(parallelComposition.getSubcomposition(position).asAutomatonComposition().getAutomatonName());
@@ -1279,45 +1277,43 @@ cpptempl::data_map ExplicitJitJaniModelBuilder<ValueType, RewardModelType>::gene
             for (auto const& edge : automaton.getEdges()) {
                 if (edge.getActionIndex() == actionIndex) {
                     std::string edgeName = automaton.getName() + "_" + std::to_string(edgeIndex);
-                    indent(vectorSource, indentLevel + 2) << "if (edge_enabled_" << edgeName << "(state, transientIn)) {" << std::endl;
-                    indent(vectorSource, indentLevel + 3) << "edges.emplace_back(edge_" << edgeName << ");" << std::endl;
-                    indent(vectorSource, indentLevel + 2) << "}" << std::endl;
+                    indent(vectorSource, indentLevel + 2) << "if (edge_enabled_" << edgeName << "(state, transientIn)) {\n";
+                    indent(vectorSource, indentLevel + 3) << "edges.emplace_back(edge_" << edgeName << ");\n";
+                    indent(vectorSource, indentLevel + 2) << "}\n";
                 }
                 ++edgeIndex;
             }
 
-            indent(vectorSource, indentLevel + 1) << "}" << std::endl;
+            indent(vectorSource, indentLevel + 1) << "}\n";
             ++participatingPosition;
         }
         ++position;
     }
-    indent(vectorSource, indentLevel) << "}" << std::endl << std::endl;
+    indent(vectorSource, indentLevel) << "}\n\n";
 
     indent(vectorSource, indentLevel) << "void exploreSynchronizationVector_" << synchronizationVectorIndex
                                       << "(StateType const& state, TransientVariables const& transientIn, StateBehaviour<IndexType, ValueType>& behaviour, "
-                                         "StateSet<StateType>& statesToExplore) {"
-                                      << std::endl;
-    indent(vectorSource, indentLevel + 1) << "#ifndef NDEBUG" << std::endl;
-    indent(vectorSource, indentLevel + 1) << "std::cout << \"Exploring synchronization vector " << synchronizationVectorIndex << ".\" << std::endl;"
-                                          << std::endl;
-    indent(vectorSource, indentLevel + 1) << "#endif" << std::endl;
+                                         "StateSet<StateType>& statesToExplore) {\n";
+    indent(vectorSource, indentLevel + 1) << "#ifndef NDEBUG\n";
+    indent(vectorSource, indentLevel + 1) << "std::cout << \"Exploring synchronization vector " << synchronizationVectorIndex << ".\\n\";\n";
+    indent(vectorSource, indentLevel + 1) << "#endif\n";
     indent(vectorSource, indentLevel + 1) << "std::vector<std::vector<std::reference_wrapper<Edge const>>> edges("
-                                          << synchronizationVector.getNumberOfActionInputs() << ");" << std::endl;
+                                          << synchronizationVector.getNumberOfActionInputs() << ");\n";
 
     participatingPosition = 0;
     for (auto const& input : synchronizationVector.getInput()) {
         if (!storm::jani::SynchronizationVector::isNoActionInput(input)) {
             indent(vectorSource, indentLevel + 1) << "get_edges_" << synchronizationVectorIndex << "(state, transientIn, edges[" << participatingPosition
-                                                  << "], " << participatingPosition << ");" << std::endl;
-            indent(vectorSource, indentLevel + 1) << "if (edges[" << participatingPosition << "].empty()) {" << std::endl;
-            indent(vectorSource, indentLevel + 2) << "return;" << std::endl;
-            indent(vectorSource, indentLevel + 1) << "}" << std::endl;
+                                                  << "], " << participatingPosition << ");\n";
+            indent(vectorSource, indentLevel + 1) << "if (edges[" << participatingPosition << "].empty()) {\n";
+            indent(vectorSource, indentLevel + 2) << "return;\n";
+            indent(vectorSource, indentLevel + 1) << "}\n";
             ++participatingPosition;
         }
     }
     indent(vectorSource, indentLevel + 1) << "performSynchronizedEdges_" << synchronizationVectorIndex
-                                          << "_0(state, edges, behaviour, statesToExplore, storm::utility::one<ValueType>());" << std::endl;
-    indent(vectorSource, indentLevel) << "}" << std::endl << std::endl;
+                                          << "_0(state, edges, behaviour, statesToExplore, storm::utility::one<ValueType>());\n";
+    indent(vectorSource, indentLevel) << "}\n\n";
 
     cpptempl::data_map vector;
     vector["functions"] = vectorSource.str();
@@ -2053,7 +2049,7 @@ std::string ExplicitJitJaniModelBuilder<ValueType, RewardModelType>::createSourc
                             
                             void initialize_parameters(std::vector<storm::RationalFunction> const& parameters) {
 #ifndef NDEBUG
-                                std::cout << "initializing parameters" << std::endl;
+                                std::cout << "initializing parameters\n";
 #endif
                                 {% for parameter in parameters %}{$parameter.name} = parameters[{$loop.index} - 1];
                                 {% endfor %}
@@ -2374,19 +2370,19 @@ std::string ExplicitJitJaniModelBuilder<ValueType, RewardModelType>::createSourc
                                 
                                 virtual storm::models::sparse::Model<ValueType, storm::models::sparse::StandardRewardModel<ValueType>>* build() override {
 #ifndef NDEBUG
-                                    std::cout << "starting building process" << std::endl;
+                                    std::cout << "starting building process\n";
 #endif
                                     explore(initialStates);
 #ifndef NDEBUG
-                                    std::cout << "finished building process with " << stateIds.size() << " states" << std::endl;
+                                    std::cout << "finished building process with " << stateIds.size() << " states\n";
 #endif
                                     
 #ifndef NDEBUG
-                                    std::cout << "building labeling" << std::endl;
+                                    std::cout << "building labeling\n";
 #endif
                                     label();
 #ifndef NDEBUG
-                                    std::cout << "finished building labeling" << std::endl;
+                                    std::cout << "finished building labeling\n";
 #endif
                                     
                                     return this->modelComponentsBuilder.build(stateIds.size());
@@ -2438,7 +2434,7 @@ std::string ExplicitJitJaniModelBuilder<ValueType, RewardModelType>::createSourc
                                         
                                         if (!isTerminalState(currentState)) {
 #ifndef NDEBUG
-                                            std::cout << "Exploring state " << currentState << ", id " << currentIndex << std::endl;
+                                            std::cout << "Exploring state " << currentState << ", id " << currentIndex << '\n';
 #endif
                                             
                                             behaviour.setExpanded();
@@ -2463,7 +2459,7 @@ std::string ExplicitJitJaniModelBuilder<ValueType, RewardModelType>::createSourc
 
                                         {% if dontFixDeadlocks %}
                                         if (behaviour.empty() && behaviour.isExpanded() ) {
-                                            std::cout << "found deadlock state: " << currentState << std::endl;
+                                            std::cout << "found deadlock state: " << currentState << '\n';
                                             throw storm::exceptions::WrongFormatException("Error while creating sparse matrix from JANI model: found deadlock state and fixing deadlocks was explicitly disabled.");
                                         }
                                         {% endif %}
@@ -2480,7 +2476,7 @@ std::string ExplicitJitJaniModelBuilder<ValueType, RewardModelType>::createSourc
                                         if (static_cast<uint64_t>(durationSinceLastMessage) >= {$expl_progress_interval}) {
                                             auto statesPerSecond = numberOfExploredStatesSinceLastMessage / durationSinceLastMessage;
                                             auto durationSinceStart = std::chrono::duration_cast<std::chrono::seconds>(now - timeOfStart).count();
-                                            std::cout << "Explored " << numberOfExploredStates << " states in " << durationSinceStart << " seconds (currently " << statesPerSecond << " states per second)." << std::endl;
+                                            std::cout << "Explored " << numberOfExploredStates << " states in " << durationSinceStart << " seconds (currently " << statesPerSecond << " states per second).\n";
                                             timeOfLastMessage = std::chrono::high_resolution_clock::now();
                                             numberOfExploredStatesSinceLastMessage = 0;
                                         }
@@ -2499,7 +2495,7 @@ std::string ExplicitJitJaniModelBuilder<ValueType, RewardModelType>::createSourc
                                 void exploreNonSynchronizingEdges(StateType const& in, TransientVariables const& transientIn, StateBehaviour<IndexType, ValueType>& behaviour, StateSet<StateType>& statesToExplore) {
                                     {% for edge in nonsynch_edges %}{
 #ifndef NDEBUG
-                                        std::cout << "Exploring non-synchronizing edge {$edge.name}." << std::endl;
+                                        std::cout << "Exploring non-synchronizing edge {$edge.name}.\n";
 #endif
                                         if ({$edge.guard}) {
                                             Choice<IndexType, ValueType>& choice = behaviour.addChoice(!model_is_deterministic() && !model_is_discrete_time() && {$edge.markovian});

--- a/src/storm/io/DDEncodingExporter.cpp
+++ b/src/storm/io/DDEncodingExporter.cpp
@@ -9,17 +9,17 @@ template<storm::dd::DdType Type, typename ValueType>
 void explicitExportSymbolicModel(std::string const& filename, std::shared_ptr<storm::models::symbolic::Model<Type, ValueType>> symbolicModel) {
     std::ofstream filestream;
     storm::utility::openFile(filename, filestream);
-    filestream << "// storm exported dd" << std::endl;
-    filestream << "%transitions" << std::endl;
+    filestream << "// storm exported dd\n";
+    filestream << "%transitions\n";
     storm::utility::closeFile(filestream);
     symbolicModel->getTransitionMatrix().exportToText(filename);
     storm::utility::openFile(filename, filestream, true, true);
-    filestream << "%initial" << std::endl;
+    filestream << "%initial\n";
     storm::utility::closeFile(filestream);
     symbolicModel->getInitialStates().template toAdd<ValueType>().exportToText(filename);
     for (auto const& label : symbolicModel->getLabels()) {
         storm::utility::openFile(filename, filestream, true, true);
-        filestream << std::endl << "%label " << label << std::endl;
+        filestream << "\n%label " << label << '\n';
         storm::utility::closeFile(filestream);
         symbolicModel->getStates(label).template toAdd<ValueType>().exportToText(filename);
     }

--- a/src/storm/io/DirectEncodingExporter.cpp
+++ b/src/storm/io/DirectEncodingExporter.cpp
@@ -30,10 +30,10 @@ void explicitExportSparseModel(std::ostream& os, std::shared_ptr<storm::models::
     }
 
     // Write header
-    os << "// Exported by storm" << std::endl;
-    os << "// Original model type: " << sparseModel->getType() << std::endl;
-    os << "@type: " << sparseModel->getType() << std::endl;
-    os << "@parameters" << std::endl;
+    os << "// Exported by storm\n";
+    os << "// Original model type: " << sparseModel->getType() << '\n';
+    os << "@type: " << sparseModel->getType() << '\n';
+    os << "@parameters\n";
     if (parameters.empty()) {
         for (std::string const& parameter : getParameters(sparseModel)) {
             os << parameter << " ";
@@ -43,7 +43,7 @@ void explicitExportSparseModel(std::ostream& os, std::shared_ptr<storm::models::
             os << parameter << " ";
         }
     }
-    os << std::endl;
+    os << '\n';
 
     // Optionally write placeholders which only need to be parsed once
     // This is used to reduce the parsing effort for rational functions
@@ -53,20 +53,20 @@ void explicitExportSparseModel(std::ostream& os, std::shared_ptr<storm::models::
         placeholders = generatePlaceholders(sparseModel, exitRates);
     }
     if (!placeholders.empty()) {
-        os << "@placeholders" << std::endl;
+        os << "@placeholders\n";
         for (auto const& entry : placeholders) {
-            os << "$" << entry.second << " : " << entry.first << std::endl;
+            os << "$" << entry.second << " : " << entry.first << '\n';
         }
     }
 
-    os << "@reward_models" << std::endl;
+    os << "@reward_models\n";
     for (auto const& rewardModel : sparseModel->getRewardModels()) {
         os << rewardModel.first << " ";
     }
-    os << std::endl;
-    os << "@nr_states" << std::endl << sparseModel->getNumberOfStates() << std::endl;
-    os << "@nr_choices" << std::endl << sparseModel->getNumberOfChoices() << std::endl;
-    os << "@model" << std::endl;
+    os << '\n';
+    os << "@nr_states\n" << sparseModel->getNumberOfStates() << '\n';
+    os << "@nr_choices\n" << sparseModel->getNumberOfChoices() << '\n';
+    os << "@model\n";
 
     storm::storage::SparseMatrix<ValueType> const& matrix = sparseModel->getTransitionMatrix();
 
@@ -116,10 +116,10 @@ void explicitExportSparseModel(std::ostream& os, std::shared_ptr<storm::models::
                 os << " " << label;
             }
         }
-        os << std::endl;
+        os << '\n';
         // Write state valuations as comments
         if (sparseModel->hasStateValuations()) {
-            os << "//" << sparseModel->getStateValuations().getStateInfo(group) << std::endl;
+            os << "//" << sparseModel->getStateValuations().getStateInfo(group) << '\n';
         }
 
         // Write probabilities
@@ -165,14 +165,14 @@ void explicitExportSparseModel(std::ostream& os, std::shared_ptr<storm::models::
             if (!first) {
                 os << "]";
             }
-            os << std::endl;
+            os << '\n';
 
             // Write transitions
             for (auto it = matrix.begin(row); it != matrix.end(row); ++it) {
                 ValueType prob = it->getValue();
                 os << "\t\t" << it->getColumn() << " : ";
                 writeValue(os, prob, placeholders);
-                os << std::endl;
+                os << '\n';
             }
         }
     }  // end state iteration

--- a/src/storm/io/export.h
+++ b/src/storm/io/export.h
@@ -24,7 +24,7 @@ inline void exportDataToCSVFile(std::string filepath, std::vector<std::vector<Da
             }
             filestream << *columnIt;
         }
-        filestream << std::endl;
+        filestream << '\n';
     }
 
     if (header2) {
@@ -34,7 +34,7 @@ inline void exportDataToCSVFile(std::string filepath, std::vector<std::vector<Da
             }
             filestream << *columnIt;
         }
-        filestream << std::endl;
+        filestream << '\n';
     }
 
     for (auto const& row : data) {
@@ -44,7 +44,7 @@ inline void exportDataToCSVFile(std::string filepath, std::vector<std::vector<Da
             }
             filestream << *columnIt;
         }
-        filestream << std::endl;
+        filestream << '\n';
     }
     storm::utility::closeFile(filestream);
 }
@@ -68,7 +68,7 @@ inline void outputFixedWidth(std::ostream& stream, Container const& output, size
         stream << s;
         curLength += s.length();
         if (maxWidth > 0 && curLength >= maxWidth) {
-            stream << std::endl;
+            stream << '\n';
             curLength = 0;
         }
     }

--- a/src/storm/io/file.h
+++ b/src/storm/io/file.h
@@ -24,7 +24,7 @@ inline void openFile(std::string const& filepath, std::ofstream& filestream, boo
     STORM_LOG_THROW(filestream, storm::exceptions::FileIoException, "Could not open file " << filepath << ".");
     filestream.precision(std::cout.precision());
     if (!silent) {
-        STORM_PRINT_AND_LOG("Write to file " << filepath << "." << std::endl);
+        STORM_PRINT_AND_LOG("Write to file " << filepath << ".\n");
     }
 }
 

--- a/src/storm/modelchecker/abstraction/GameBasedMdpModelChecker.cpp
+++ b/src/storm/modelchecker/abstraction/GameBasedMdpModelChecker.cpp
@@ -1017,21 +1017,21 @@ class ExplicitGameExporter {
 
     void exportEdge(std::ofstream& out, EdgeData const& data, bool& first) {
         if (!first) {
-            out << "," << std::endl;
+            out << ",\n";
         } else {
             first = false;
         }
-        out << "\t\t{" << std::endl;
-        out << "\t\t\t\"data\": {" << std::endl;
-        out << "\t\t\t\t\"id\": \"" << data.id << "\"," << std::endl;
+        out << "\t\t{\n";
+        out << "\t\t\t\"data\": {\n";
+        out << "\t\t\t\t\"id\": \"" << data.id << "\",\n";
         if (data.probability != storm::utility::zero<ValueType>()) {
-            out << "\t\t\t\t\"name\": \"" << data.probability << "\"," << std::endl;
+            out << "\t\t\t\t\"name\": \"" << data.probability << "\",\n";
         } else {
-            out << "\t\t\t\t\"name\": \"" << data.label << "\"," << std::endl;
+            out << "\t\t\t\t\"name\": \"" << data.label << "\",\n";
         }
-        out << "\t\t\t\t\"source\": \"" << data.source << "\"," << std::endl;
-        out << "\t\t\t\t\"target\": \"" << data.target << "\"" << std::endl;
-        out << "\t\t\t}," << std::endl;
+        out << "\t\t\t\t\"source\": \"" << data.source << "\",\n";
+        out << "\t\t\t\t\"target\": \"" << data.target << "\"\n";
+        out << "\t\t\t},\n";
         out << "\t\t\t\"classes\": \"";
         if (data.min && data.max) {
             out << "minMaxEdge";
@@ -1042,26 +1042,26 @@ class ExplicitGameExporter {
         } else {
             out << "edge";
         }
-        out << "\"" << std::endl;
+        out << "\"\n";
         out << "\t\t}";
     }
 
     void exportNode(std::ofstream& out, NodeData const& data, ExplicitQuantitativeResultMinMax<ValueType> const* quantitativeResult, bool& first) {
         if (!first) {
-            out << "," << std::endl;
+            out << ",\n";
         } else {
             first = false;
         }
-        out << "\t\t{" << std::endl;
-        out << "\t\t\t\"data\": {" << std::endl;
-        out << "\t\t\t\t\"id\": \"" << data.id << "\"," << std::endl;
+        out << "\t\t{\n";
+        out << "\t\t\t\"data\": {\n";
+        out << "\t\t\t\t\"id\": \"" << data.id << "\",\n";
         out << "\t\t\t\t\"name\": \"" << data.id;
         if (quantitativeResult && data.player == 1) {
             out << " [" << quantitativeResult->getMin().getValues()[data.id] << ", " << quantitativeResult->getMax().getValues()[data.id] << "]";
         }
-        out << "\"" << std::endl;
-        out << "\t\t\t}," << std::endl;
-        out << "\t\t\t\"group\": \"nodes\"," << std::endl;
+        out << "\"\n";
+        out << "\t\t\t},\n";
+        out << "\t\t\t\"group\": \"nodes\",\n";
         out << "\t\t\t\"classes\": \"";
         if (data.player == 1) {
             if (data.initial) {
@@ -1076,7 +1076,7 @@ class ExplicitGameExporter {
         } else if (data.player == 0) {
             out << "plpnode";
         }
-        out << "\"" << std::endl;
+        out << "\"\n";
         out << "\t\t}";
     }
 
@@ -1162,20 +1162,20 @@ class ExplicitGameExporter {
         // Finally, export the data structures we built.
 
         // Export nodes.
-        out << "{\n\t\"nodes\": [" << std::endl;
+        out << "{\n\t\"nodes\": [\n";
         bool first = true;
         for (auto const& node : nodes) {
             exportNode(out, node, &quantitativeResult, first);
         }
-        out << "\n\t]," << std::endl;
+        out << "\n\t],\n";
 
         // Export edges.
         first = true;
-        out << "\t\"edges\": [" << std::endl;
+        out << "\t\"edges\": [\n";
         for (auto const& edge : edges) {
             exportEdge(out, edge, first);
         }
-        out << "\n\t]\n}" << std::endl;
+        out << "\n\t]\n}\n";
     }
 
     bool showNonStrategyAlternatives;
@@ -1758,13 +1758,13 @@ void GameBasedMdpModelChecker<Type, ModelType>::printStatistics(storm::abstracti
         std::streamsize originalPrecision = std::cout.precision();
         std::cout << std::fixed << std::setprecision(2);
 
-        std::cout << std::endl;
-        std::cout << "Statistics:" << std::endl;
+        std::cout << '\n';
+        std::cout << "Statistics:\n";
         std::cout << "    * size of final game: " << game.getReachableStates().getNonZeroCount() << " player 1 states, "
-                  << game.getTransitionMatrix().getNonZeroCount() << " transitions" << std::endl;
-        std::cout << "    * peak size of game: " << peakPlayer1States << " player 1 states, " << peakTransitions << " transitions" << std::endl;
-        std::cout << "    * refinements: " << refinements << std::endl;
-        std::cout << "    * predicates: " << abstractionInformation.getNumberOfPredicates() << std::endl << std::endl;
+                  << game.getTransitionMatrix().getNonZeroCount() << " transitions\n";
+        std::cout << "    * peak size of game: " << peakPlayer1States << " player 1 states, " << peakTransitions << " transitions\n";
+        std::cout << "    * refinements: " << refinements << '\n';
+        std::cout << "    * predicates: " << abstractionInformation.getNumberOfPredicates() << "\n\n";
 
         uint64_t totalAbstractionTimeMillis = totalAbstractionWatch.getTimeInMilliseconds();
         uint64_t totalTranslationTimeMillis = totalTranslationWatch.getTimeInMilliseconds();
@@ -1774,24 +1774,23 @@ void GameBasedMdpModelChecker<Type, ModelType>::printStatistics(storm::abstracti
         uint64_t setupTime = setupWatch.getTimeInMilliseconds();
         uint64_t totalTimeMillis = totalWatch.getTimeInMilliseconds();
 
-        std::cout << "Time breakdown:" << std::endl;
-        std::cout << "    * setup: " << setupTime << "ms (" << 100 * static_cast<double>(setupTime) / totalTimeMillis << "%)" << std::endl;
+        std::cout << "Time breakdown:\n";
+        std::cout << "    * setup: " << setupTime << "ms (" << 100 * static_cast<double>(setupTime) / totalTimeMillis << "%)\n";
         std::cout << "    * abstraction: " << totalAbstractionTimeMillis << "ms (" << 100 * static_cast<double>(totalAbstractionTimeMillis) / totalTimeMillis
-                  << "%)" << std::endl;
+                  << "%)\n";
         if (this->solveMode == storm::settings::modules::AbstractionSettings::SolveMode::Sparse) {
             std::cout << "    * translation: " << totalTranslationTimeMillis << "ms ("
-                      << 100 * static_cast<double>(totalTranslationTimeMillis) / totalTimeMillis << "%)" << std::endl;
+                      << 100 * static_cast<double>(totalTranslationTimeMillis) / totalTimeMillis << "%)\n";
             if (fixPlayer1Strategy || fixPlayer2Strategy) {
                 std::cout << "    * strategy processing: " << totalStrategyProcessingTimeMillis << "ms ("
-                          << 100 * static_cast<double>(totalStrategyProcessingTimeMillis) / totalTimeMillis << "%)" << std::endl;
+                          << 100 * static_cast<double>(totalStrategyProcessingTimeMillis) / totalTimeMillis << "%)\n";
             }
         }
-        std::cout << "    * solution: " << totalSolutionTimeMillis << "ms (" << 100 * static_cast<double>(totalSolutionTimeMillis) / totalTimeMillis << "%)"
-                  << std::endl;
+        std::cout << "    * solution: " << totalSolutionTimeMillis << "ms (" << 100 * static_cast<double>(totalSolutionTimeMillis) / totalTimeMillis << "%)\n";
         std::cout << "    * refinement: " << totalRefinementTimeMillis << "ms (" << 100 * static_cast<double>(totalRefinementTimeMillis) / totalTimeMillis
-                  << "%)" << std::endl;
-        std::cout << "    ---------------------------------------------" << std::endl;
-        std::cout << "    * total: " << totalTimeMillis << "ms" << std::endl << std::endl;
+                  << "%)\n";
+        std::cout << "    ---------------------------------------------\n";
+        std::cout << "    * total: " << totalTimeMillis << "ms\n\n";
 
         std::cout << std::defaultfloat << std::setprecision(originalPrecision);
     }

--- a/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
@@ -590,7 +590,7 @@ std::vector<ValueType> SparseCtmcCslHelper::computeAllTransientProbabilities(Env
         /*std::vector<ValueType> b = transposedMatrix.getConstrainedRowSumVector(relevantStates, initialStates);
         for (auto& element : b) {
             element /= uniformizationRate;
-            std::cout << element << std::endl;
+            std::cout << element << '\n';
         }*/
 
         ValueType epsilon = storm::utility::convertNumber<ValueType>(env.solver().timeBounded().getPrecision()) / 8.0;

--- a/src/storm/modelchecker/csl/helper/SparseMarkovAutomatonCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/SparseMarkovAutomatonCslHelper.cpp
@@ -632,8 +632,7 @@ std::vector<ValueType> computeBoundedUntilProbabilitiesImca(Environment const& e
 
     // (2) Compute the number of steps we need to make for the interval.
     uint64_t numberOfSteps = static_cast<uint64_t>(std::ceil((upperBound - lowerBound) / delta));
-    STORM_LOG_INFO("Performing " << numberOfSteps << " iterations (delta=" << delta << ") for interval [" << lowerBound << ", " << upperBound << "]."
-                                 << std::endl);
+    STORM_LOG_INFO("Performing " << numberOfSteps << " iterations (delta=" << delta << ") for interval [" << lowerBound << ", " << upperBound << "].\n");
 
     // (3) Compute the non-goal states and initialize two vectors
     // * vProbabilistic holds the probability values of probabilistic non-goal states.
@@ -659,7 +658,7 @@ std::vector<ValueType> computeBoundedUntilProbabilitiesImca(Environment const& e
 
         // Compute the number of steps to reach the target interval.
         numberOfSteps = static_cast<uint64_t>(std::ceil(lowerBound / delta));
-        STORM_LOG_INFO("Performing " << numberOfSteps << " iterations (delta=" << delta << ") for interval [0, " << lowerBound << "]." << std::endl);
+        STORM_LOG_INFO("Performing " << numberOfSteps << " iterations (delta=" << delta << ") for interval [0, " << lowerBound << "].\n");
 
         // Compute the bounded reachability for interval [0, b-a].
         computeBoundedReachabilityProbabilitiesImca(env, dir, transitionMatrix, exitRateVector, storm::storage::BitVector(numberOfStates), markovianStates,

--- a/src/storm/modelchecker/exploration/Statistics.cpp
+++ b/src/storm/modelchecker/exploration/Statistics.cpp
@@ -41,14 +41,14 @@ void Statistics<StateType, ValueType>::updateMaxPathLength(std::size_t const& cu
 
 template<typename StateType, typename ValueType>
 void Statistics<StateType, ValueType>::printToStream(std::ostream& out, ExplorationInformation<StateType, ValueType> const& explorationInformation) const {
-    out << std::endl << "Exploration statistics:" << std::endl;
+    out << "\nExploration statistics:\n";
     out << "Discovered states: " << explorationInformation.getNumberOfDiscoveredStates() << " (" << numberOfExploredStates << " explored, "
-        << explorationInformation.getNumberOfUnexploredStates() << " unexplored, " << numberOfTargetStates << " target)" << std::endl;
-    out << "Exploration steps: " << explorationSteps << std::endl;
-    out << "Sampled paths: " << pathsSampled << std::endl;
-    out << "Maximal path length: " << maxPathLength << std::endl;
-    out << "Precomputations: " << numberOfPrecomputations << std::endl;
-    out << "EC detections: " << ecDetections << " (" << failedEcDetections << " failed, " << totalNumberOfEcDetected << " EC(s) detected)" << std::endl;
+        << explorationInformation.getNumberOfUnexploredStates() << " unexplored, " << numberOfTargetStates << " target)\n";
+    out << "Exploration steps: " << explorationSteps << '\n';
+    out << "Sampled paths: " << pathsSampled << '\n';
+    out << "Maximal path length: " << maxPathLength << '\n';
+    out << "Precomputations: " << numberOfPrecomputations << '\n';
+    out << "EC detections: " << ecDetections << " (" << failedEcDetections << " failed, " << totalNumberOfEcDetected << " EC(s) detected)\n";
 }
 
 template struct Statistics<uint32_t, double>;

--- a/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
+++ b/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
@@ -327,7 +327,7 @@ std::vector<ValueType> SparseLTLHelper<ValueType, Nondeterministic>::computeLTLP
 
     STORM_LOG_INFO("Deterministic automaton for LTL formula has " << da->getNumberOfStates() << " states, " << da->getAPSet().size()
                                                                   << " atomic propositions and " << *da->getAcceptance()->getAcceptanceExpression()
-                                                                  << " as acceptance condition." << std::endl);
+                                                                  << " as acceptance condition.\n");
 
     std::vector<ValueType> numericResult = computeDAProductProbabilities(env, *da, apSatSets);
 

--- a/src/storm/modelchecker/multiobjective/constraintbased/SparseCbAchievabilityQuery.cpp
+++ b/src/storm/modelchecker/multiobjective/constraintbased/SparseCbAchievabilityQuery.cpp
@@ -55,20 +55,20 @@ bool SparseCbAchievabilityQuery<SparseModelType>::checkAchievability() {
     swCheck.stop();
 
     if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-        STORM_PRINT_AND_LOG("Building the constraintsystem took " << swInitialization << " seconds and checking the SMT formula took " << swCheck << " seconds."
-                                                                  << std::endl);
+        STORM_PRINT_AND_LOG("Building the constraintsystem took " << swInitialization << " seconds and checking the SMT formula took " << swCheck
+                                                                  << " seconds.\n");
     }
 
     switch (result) {
         case storm::solver::SmtSolver::CheckResult::Sat:
-            // std::cout << std::endl << "Satisfying assignment: " << std::endl << solver->getModelAsValuation().toString(true) << std::endl;
+            // std::cout << "\nSatisfying assignment: \n" << solver->getModelAsValuation().toString(true) << '\n';
             return true;
         case storm::solver::SmtSolver::CheckResult::Unsat:
-            // std::cout << std::endl << "Unsatisfiability core: {" << std::endl;
+            // std::cout << "\nUnsatisfiability core: {\n";
             // for (auto const& expr : solver->getUnsatCore()) {
-            //    std::cout << "\t " << expr << std::endl;
+            //    std::cout << "\t " << expr << '\n';
             // }
-            // std::cout << "}" << std::endl;
+            // std::cout << "}\n";
             return false;
         default:
             STORM_LOG_THROW(false, storm::exceptions::UnexpectedException, "SMT solver yielded an unexpected result");

--- a/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsLpChecker.cpp
+++ b/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsLpChecker.cpp
@@ -42,12 +42,12 @@ void DeterministicSchedsLpChecker<ModelType, GeometryValueType>::initialize(Envi
 template<typename ModelType, typename GeometryValueType>
 std::string DeterministicSchedsLpChecker<ModelType, GeometryValueType>::getStatistics(std::string const& prefix) const {
     std::stringstream out;
-    out << prefix << swAll << " seconds for LP Checker including... " << std::endl;
-    out << prefix << "  " << swInit << " seconds for LP initialization" << std::endl;
-    out << prefix << "  " << swCheckWeightVectors << " seconds for checking weight vectors" << std::endl;
-    out << prefix << "  " << swCheckAreas << " seconds for checking areas" << std::endl;
-    out << prefix << "  " << swValidate << " seconds for validating LP solutions" << std::endl;
-    out << prefix << "  " << numLpQueries << " calls to LP optimization" << std::endl;
+    out << prefix << swAll << " seconds for LP Checker including... \n";
+    out << prefix << "  " << swInit << " seconds for LP initialization\n";
+    out << prefix << "  " << swCheckWeightVectors << " seconds for checking weight vectors\n";
+    out << prefix << "  " << swCheckAreas << " seconds for checking areas\n";
+    out << prefix << "  " << swValidate << " seconds for validating LP solutions\n";
+    out << prefix << "  " << numLpQueries << " calls to LP optimization\n";
     return out.str();
 }
 
@@ -98,7 +98,7 @@ boost::optional<std::vector<GeometryValueType>> DeterministicSchedsLpChecker<Mod
     lpModel->optimize();
     swCheckWeightVectors.stop();
     ++numLpQueries;
-    // STORM_PRINT_AND_LOG("Writing model to file '" << std::to_string(numLpQueries) << ".lp'" << std::endl;);
+    // STORM_PRINT_AND_LOG("Writing model to file '" << std::to_string(numLpQueries) << ".lp'\n";);
     // lpModel->writeModelToFile(std::to_string(numLpQueries) + ".lp");
     boost::optional<Point> result;
     if (!lpModel->isInfeasible()) {
@@ -363,7 +363,7 @@ void DeterministicSchedsLpChecker<ModelType, GeometryValueType>::initializeLpMod
     } else {
         flowEncoding = env.modelchecker().multi().getEncodingType() == storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow;
     }
-    STORM_LOG_INFO("Using " << (flowEncoding ? "flow" : "classical") << " encoding." << std::endl);
+    STORM_LOG_INFO("Using " << (flowEncoding ? "flow" : "classical") << " encoding.\n");
 
     uint64_t numStates = model.getNumberOfStates();
     uint64_t initialState = *model.getInitialStates().begin();
@@ -681,7 +681,7 @@ void DeterministicSchedsLpChecker<ModelType, GeometryValueType>::checkRecursive(
             ++numLpQueries;
             STORM_LOG_TRACE("\tDone solving MILP...");
 
-            // STORM_PRINT_AND_LOG("Writing model to file '" << polytopeTree.toId() << ".lp'" << std::endl;);
+            // STORM_PRINT_AND_LOG("Writing model to file '" << polytopeTree.toId() << ".lp'\n";);
             // lpModel->writeModelToFile(polytopeTree.toId() + ".lp");
 
             if (lpModel->isInfeasible()) {

--- a/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsObjectiveHelper.cpp
+++ b/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsObjectiveHelper.cpp
@@ -270,7 +270,7 @@ storm::storage::SparseMatrix<ValueType> const& transitions, uint64_t& counter) {
     // exhausive dfs
     if (visited.get(currentState)) {
         if (++counter % 1000000 == 0) {
-            std::cout << "\t\t checked " << counter << " paths" << std::endl;
+            std::cout << "\t\t checked " << counter << " paths\n";
         }
         return currentValue;
     } else {
@@ -399,7 +399,7 @@ std::vector<typename ModelType::ValueType> DeterministicSchedsObjectiveHelper<Mo
                     numChoices += modelTransitions.getRowGroupSize(stateChoices.first);
                 }
                 std::cout << "Checking a mec with " << mecStates.getNumberOfSetBits() << " states " << numChoices << " choices and " << numTransitions << "
-            transitions." << std::endl; lpath = storm::utility::one<ValueType>() / getExpVisitsUpperBoundForMec(mecStates, modelTransitions);
+            transitions.\n"; lpath = storm::utility::one<ValueType>() / getExpVisitsUpperBoundForMec(mecStates, modelTransitions);
             }*/
             // We multiply the smallest transition probabilities occurring at each state and MEC-Choice
             // as well as the smallest 'exit' probability
@@ -459,10 +459,10 @@ std::vector<typename ModelType::ValueType> DeterministicSchedsObjectiveHelper<Mo
                     numChoices += modelTransitions.getRowGroupSize(stateChoices.first);
                 }
                 std::cout << "Checking a mec with " << mecStates.getNumberOfSetBits() << " states " << numChoices << " choices and " << numTransitions << "
-            transitions." << std::endl; lpath = storm::utility::one<ValueType>(); for (auto const& stateChoices : mec) { storm::storage::BitVector visited =
+            transitions.\n"; lpath = storm::utility::one<ValueType>(); for (auto const& stateChoices : mec) { storm::storage::BitVector visited =
             ~mecStates; uint64_t counter = 0; ValueType lpathOld = lpath; lpath = std::min(lpath, getLpathDfs(stateChoices.first,
             storm::utility::one<ValueType>(), visited, mecStates, modelTransitions, counter)); if (lpathOld > lpath) { std::cout << "\tnew lpath is " <<
-            storm::utility::convertNumber<double>(lpath) << ". checked " << counter << " paths." << std::endl;
+            storm::utility::convertNumber<double>(lpath) << ". checked " << counter << " paths.\n";
                     }
                 }
             }*/

--- a/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsParetoExplorer.cpp
+++ b/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsParetoExplorer.cpp
@@ -169,7 +169,7 @@ DeterministicSchedsParetoExplorer<SparseModelType, GeometryValueType>::Pointset:
     point.setParetoOptimal(true);
 
     if (env.modelchecker().multi().isPrintResultsSet()) {
-        std::cout << "## achievable point: [" << point.toString(true) << "]" << std::endl;
+        std::cout << "## achievable point: [" << point.toString(true) << "]\n";
     }
     points.emplace_hint(points.end(), currId, std::move(point));
     return currId++;
@@ -223,9 +223,9 @@ template<class SparseModelType, typename GeometryValueType>
 void DeterministicSchedsParetoExplorer<SparseModelType, GeometryValueType>::Pointset::printToStream(std::ostream& out, bool includeIDs, bool convertToDouble) {
     for (auto const& p : this->points) {
         if (includeIDs) {
-            out << p.first << ": [" << p.second.toString(convertToDouble) << "]" << std::endl;
+            out << p.first << ": [" << p.second.toString(convertToDouble) << "]\n";
         } else {
-            out << p.second.toString(convertToDouble) << std::endl;
+            out << p.second.toString(convertToDouble) << '\n';
         }
     }
 }
@@ -316,9 +316,9 @@ DeterministicSchedsParetoExplorer<SparseModelType, GeometryValueType>::Determini
         models.push_back(&preprocessorResult.originalModel);
         models.push_back(model.get());
         for (SparseModelType const* m : models) {
-            STORM_PRINT_AND_LOG("#STATS " << m->getNumberOfStates() << " states in " << modelname << std::endl);
-            STORM_PRINT_AND_LOG("#STATS " << m->getNumberOfChoices() << " choices in " << modelname << std::endl);
-            STORM_PRINT_AND_LOG("#STATS " << m->getNumberOfTransitions() << " transitions in " << modelname << std::endl);
+            STORM_PRINT_AND_LOG("#STATS " << m->getNumberOfStates() << " states in " << modelname << '\n');
+            STORM_PRINT_AND_LOG("#STATS " << m->getNumberOfChoices() << " choices in " << modelname << '\n');
+            STORM_PRINT_AND_LOG("#STATS " << m->getNumberOfTransitions() << " transitions in " << modelname << '\n');
             storm::RationalNumber numScheds = storm::utility::one<storm::RationalNumber>();
             for (uint64_t state = 0; state < m->getNumberOfStates(); ++state) {
                 storm::RationalNumber numChoices = storm::utility::convertNumber<storm::RationalNumber, uint64_t>(m->getNumberOfChoices(state));
@@ -326,7 +326,7 @@ DeterministicSchedsParetoExplorer<SparseModelType, GeometryValueType>::Determini
             }
             auto numSchedsStr = storm::utility::to_string(numScheds);
             STORM_PRINT_AND_LOG("#STATS " << numSchedsStr.front() << "e" << (numSchedsStr.size() - 1) << " memoryless deterministic schedulers in " << modelname
-                                          << std::endl);
+                                          << '\n');
             storm::storage::MaximalEndComponentDecomposition<ModelValueType> mecs(*m);
             uint64_t nonConstMecCounter = 0;
             uint64_t nonConstMecStateCounter = 0;
@@ -344,13 +344,13 @@ DeterministicSchedsParetoExplorer<SparseModelType, GeometryValueType>::Determini
                 if (mecHasNonConstValue)
                     ++nonConstMecCounter;
             }
-            STORM_PRINT_AND_LOG("#STATS " << nonConstMecCounter << " non-constant MECS in " << modelname << std::endl);
-            STORM_PRINT_AND_LOG("#STATS " << nonConstMecStateCounter << " non-constant MEC States in " << modelname << std::endl);
+            STORM_PRINT_AND_LOG("#STATS " << nonConstMecCounter << " non-constant MECS in " << modelname << '\n');
+            STORM_PRINT_AND_LOG("#STATS " << nonConstMecStateCounter << " non-constant MEC States in " << modelname << '\n');
             // Print the same statistics for the unfolded model as well.
             modelname = "unfolded-model";
         }
         sw.stop();
-        STORM_PRINT_AND_LOG("#STATS " << sw << " seconds for computing these statistics." << std::endl);
+        STORM_PRINT_AND_LOG("#STATS " << sw << " seconds for computing these statistics.\n");
     }
 }
 
@@ -385,8 +385,7 @@ std::unique_ptr<CheckResult> DeterministicSchedsParetoExplorer<SparseModelType, 
                 eps.back() = storm::utility::convertNumber<GeometryValueType>(1e-8);
             }
         }
-        STORM_PRINT_AND_LOG("Relative precision is " << storm::utility::vector::toString(storm::utility::vector::convertNumericVector<double>(eps))
-                                                     << std::endl);
+        STORM_PRINT_AND_LOG("Relative precision is " << storm::utility::vector::toString(storm::utility::vector::convertNumericVector<double>(eps)) << '\n');
     } else {
         STORM_LOG_THROW(env.modelchecker().multi().getPrecisionType() == MultiObjectiveModelCheckerEnvironment::PrecisionType::Absolute,
                         storm::exceptions::IllegalArgumentException, "Unknown multiobjective precision type.");
@@ -409,9 +408,9 @@ std::unique_ptr<CheckResult> DeterministicSchedsParetoExplorer<SparseModelType, 
         }
     }
     if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-        STORM_PRINT_AND_LOG("#STATS " << paretoPoints.size() << " Pareto points" << std::endl);
-        STORM_PRINT_AND_LOG("#STATS " << unachievableAreas.size() << " unachievable areas" << std::endl);
-        STORM_PRINT_AND_LOG("#STATS " << overApproximation->getHalfspaces().size() << " unachievable halfspaces" << std::endl);
+        STORM_PRINT_AND_LOG("#STATS " << paretoPoints.size() << " Pareto points\n");
+        STORM_PRINT_AND_LOG("#STATS " << unachievableAreas.size() << " unachievable areas\n");
+        STORM_PRINT_AND_LOG("#STATS " << overApproximation->getHalfspaces().size() << " unachievable halfspaces\n");
         STORM_PRINT_AND_LOG(lpChecker->getStatistics("#STATS "));
     }
     return std::make_unique<storm::modelchecker::ExplicitParetoCurveCheckResult<ModelValueType>>(originalModelInitialState, std::move(paretoPoints), nullptr,
@@ -441,7 +440,7 @@ void DeterministicSchedsParetoExplorer<SparseModelType, GeometryValueType>::addH
             }
             std::cout << storm::utility::convertNumber<double>(xi);
         }
-        std::cout << "];[" << storm::utility::convertNumber<double>(offset) << "]" << std::endl;
+        std::cout << "];[" << storm::utility::convertNumber<double>(offset) << "]\n";
     }
     storm::storage::geometry::Halfspace<GeometryValueType> overApproxHalfspace(normalVector, offset);
     overApproximation = overApproximation->intersection(overApproxHalfspace);
@@ -476,7 +475,7 @@ void DeterministicSchedsParetoExplorer<SparseModelType, GeometryValueType>::addU
             }
             std::cout << "]";
         }
-        std::cout << std::endl;
+        std::cout << '\n';
     }
     unachievableAreas.push_back(area);
 }

--- a/src/storm/modelchecker/multiobjective/multiObjectiveModelChecking.cpp
+++ b/src/storm/modelchecker/multiobjective/multiObjectiveModelChecking.cpp
@@ -40,9 +40,11 @@ std::unique_ptr<CheckResult> performMultiObjectiveModelChecking(Environment cons
     auto preprocessorResult = preprocessing::SparseMultiObjectivePreprocessor<SparseModelType>::preprocess(env, model, formula);
     swPreprocessing.stop();
     if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-        STORM_PRINT_AND_LOG("Preprocessing done in " << swPreprocessing << " seconds." << std::endl << " Result: " << preprocessorResult << std::endl);
+        STORM_PRINT_AND_LOG("Preprocessing done in " << swPreprocessing << " seconds.\n"
+                                                     << " Result: " << preprocessorResult << '\n');
     } else {
-        STORM_LOG_INFO("Preprocessing done in " << swPreprocessing << " seconds." << std::endl << " Result: " << preprocessorResult << std::endl);
+        STORM_LOG_INFO("Preprocessing done in " << swPreprocessing << " seconds.\n"
+                                                << " Result: " << preprocessorResult << '\n');
     }
 
     // Invoke the analysis
@@ -119,7 +121,7 @@ std::unique_ptr<CheckResult> performMultiObjectiveModelChecking(Environment cons
     if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
         STORM_PRINT_AND_LOG("Solving multi-objective query took " << swTotal << " seconds (consisting of " << swPreprocessing
                                                                   << " seconds for preprocessing and " << swAnalysis
-                                                                  << " seconds for analyzing the preprocessed model)." << std::endl);
+                                                                  << " seconds for analyzing the preprocessed model).\n");
     }
 
     return result;

--- a/src/storm/modelchecker/multiobjective/pcaa/RewardBoundedMdpPcaaWeightVectorChecker.cpp
+++ b/src/storm/modelchecker/multiobjective/pcaa/RewardBoundedMdpPcaaWeightVectorChecker.cpp
@@ -55,16 +55,16 @@ template<class SparseMdpModelType>
 RewardBoundedMdpPcaaWeightVectorChecker<SparseMdpModelType>::~RewardBoundedMdpPcaaWeightVectorChecker() {
     swAll.stop();
     if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-        STORM_PRINT_AND_LOG("--------------------------------------------------" << std::endl);
-        STORM_PRINT_AND_LOG("Statistics:" << std::endl);
-        STORM_PRINT_AND_LOG("--------------------------------------------------" << std::endl);
-        STORM_PRINT_AND_LOG("           #checked weight vectors: " << numChecks << "." << std::endl);
-        STORM_PRINT_AND_LOG("           #checked epochs overall: " << numCheckedEpochs << "." << std::endl);
-        STORM_PRINT_AND_LOG("# checked epochs per weight vector: " << numCheckedEpochs / numChecks << "." << std::endl);
-        STORM_PRINT_AND_LOG("                      overall Time: " << swAll << "." << std::endl);
-        STORM_PRINT_AND_LOG("         Epoch Model building time: " << swEpochModelBuild << "." << std::endl);
-        STORM_PRINT_AND_LOG("         Epoch Model checking time: " << swEpochModelAnalysis << "." << std::endl);
-        STORM_PRINT_AND_LOG("--------------------------------------------------" << std::endl);
+        STORM_PRINT_AND_LOG("--------------------------------------------------\n");
+        STORM_PRINT_AND_LOG("Statistics:\n");
+        STORM_PRINT_AND_LOG("--------------------------------------------------\n");
+        STORM_PRINT_AND_LOG("           #checked weight vectors: " << numChecks << ".\n");
+        STORM_PRINT_AND_LOG("           #checked epochs overall: " << numCheckedEpochs << ".\n");
+        STORM_PRINT_AND_LOG("# checked epochs per weight vector: " << numCheckedEpochs / numChecks << ".\n");
+        STORM_PRINT_AND_LOG("                      overall Time: " << swAll << ".\n");
+        STORM_PRINT_AND_LOG("         Epoch Model building time: " << swEpochModelBuild << ".\n");
+        STORM_PRINT_AND_LOG("         Epoch Model checking time: " << swEpochModelAnalysis << ".\n");
+        STORM_PRINT_AND_LOG("--------------------------------------------------\n");
     }
 }
 

--- a/src/storm/modelchecker/multiobjective/pcaa/SparsePcaaQuery.cpp
+++ b/src/storm/modelchecker/multiobjective/pcaa/SparsePcaaQuery.cpp
@@ -23,7 +23,7 @@ namespace multiobjective {
 template<class SparseModelType, typename GeometryValueType>
 SparsePcaaQuery<SparseModelType, GeometryValueType>::~SparsePcaaQuery() {
     if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-        STORM_PRINT_AND_LOG("Pareto Curve Approximation Algorithm terminated after " << this->refinementSteps.size() << " refinement steps." << std::endl);
+        STORM_PRINT_AND_LOG("Pareto Curve Approximation Algorithm terminated after " << this->refinementSteps.size() << " refinement steps.\n");
     }
 }
 

--- a/src/storm/modelchecker/multiobjective/pcaa/StandardMaPcaaWeightVectorChecker.cpp
+++ b/src/storm/modelchecker/multiobjective/pcaa/StandardMaPcaaWeightVectorChecker.cpp
@@ -77,7 +77,7 @@ void StandardMaPcaaWeightVectorChecker<SparseMaModelType>::initializeModelTypeSp
     }
     // Print some statistics (if requested)
     if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-        STORM_PRINT_AND_LOG("Final preprocessed model has " << markovianStates.getNumberOfSetBits() << " Markovian states." << std::endl);
+        STORM_PRINT_AND_LOG("Final preprocessed model has " << markovianStates.getNumberOfSetBits() << " Markovian states.\n");
     }
 }
 

--- a/src/storm/modelchecker/multiobjective/pcaa/StandardPcaaWeightVectorChecker.cpp
+++ b/src/storm/modelchecker/multiobjective/pcaa/StandardPcaaWeightVectorChecker.cpp
@@ -121,26 +121,25 @@ void StandardPcaaWeightVectorChecker<SparseModelType>::initialize(
 
     // Print some statistics (if requested)
     if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-        STORM_PRINT_AND_LOG("Weight Vector Checker Statistics:" << std::endl);
-        STORM_PRINT_AND_LOG("Final preprocessed model has " << transitionMatrix.getRowGroupCount() << " states." << std::endl);
-        STORM_PRINT_AND_LOG("Final preprocessed model has " << transitionMatrix.getRowCount() << " actions." << std::endl);
+        STORM_PRINT_AND_LOG("Weight Vector Checker Statistics:\n");
+        STORM_PRINT_AND_LOG("Final preprocessed model has " << transitionMatrix.getRowGroupCount() << " states.\n");
+        STORM_PRINT_AND_LOG("Final preprocessed model has " << transitionMatrix.getRowCount() << " actions.\n");
         if (lraMecDecomposition) {
-            STORM_PRINT_AND_LOG("Found " << lraMecDecomposition->mecs.size() << " end components that are relevant for LRA-analysis." << std::endl);
+            STORM_PRINT_AND_LOG("Found " << lraMecDecomposition->mecs.size() << " end components that are relevant for LRA-analysis.\n");
             uint64_t numLraMecStates = 0;
             for (auto const& mec : this->lraMecDecomposition->mecs) {
                 numLraMecStates += mec.size();
             }
-            STORM_PRINT_AND_LOG(numLraMecStates << " states lie on such an end component." << std::endl);
+            STORM_PRINT_AND_LOG(numLraMecStates << " states lie on such an end component.\n");
         }
-        STORM_PRINT_AND_LOG(std::endl);
+        STORM_PRINT_AND_LOG('\n');
     }
 }
 
 template<class SparseModelType>
 void StandardPcaaWeightVectorChecker<SparseModelType>::check(Environment const& env, std::vector<ValueType> const& weightVector) {
     checkHasBeenCalled = true;
-    STORM_LOG_INFO("Invoked WeightVectorChecker with weights "
-                   << std::endl
+    STORM_LOG_INFO("Invoked WeightVectorChecker with weights \n"
                    << "\t" << storm::utility::vector::toString(storm::utility::vector::convertNumericVector<double>(weightVector)));
 
     // Prepare and invoke weighted infinite horizon (long run average) phase

--- a/src/storm/modelchecker/multiobjective/preprocessing/SparseMultiObjectivePreprocessorResult.h
+++ b/src/storm/modelchecker/multiobjective/preprocessing/SparseMultiObjectivePreprocessorResult.h
@@ -88,35 +88,26 @@ struct SparseMultiObjectivePreprocessorResult {
     }
 
     void printToStream(std::ostream& out) const {
-        out << std::endl;
-        out << "---------------------------------------------------------------------------------------------------------------------------------------"
-            << std::endl;
-        out << "                                                       Multi-objective Query                                              " << std::endl;
-        out << "---------------------------------------------------------------------------------------------------------------------------------------"
-            << std::endl;
-        out << std::endl;
-        out << "Original Formula: " << std::endl;
-        out << "--------------------------------------------------------------" << std::endl;
-        out << "\t" << originalFormula << std::endl;
-        out << std::endl;
-        out << "The query considers " << objectives.size() << " objectives:" << std::endl;
-        out << "--------------------------------------------------------------" << std::endl;
+        out << "\n---------------------------------------------------------------------------------------------------------------------------------------\n";
+        out << "                                                       Multi-objective Query                                              \n";
+        out << "---------------------------------------------------------------------------------------------------------------------------------------\n";
+        out << "\nOriginal Formula: \n";
+        out << "--------------------------------------------------------------\n";
+        out << "\t" << originalFormula << '\n';
+        out << "\nThe query considers " << objectives.size() << " objectives:\n";
+        out << "--------------------------------------------------------------\n";
         for (auto const& obj : objectives) {
             obj.printToStream(out);
-            out << std::endl;
+            out << '\n';
         }
-        out << "Number of Long-Run-Average Reward Objectives (after preprocessing): " << getNumberOfLongRunAverageRewardFormulas() << "." << std::endl;
-        out << "Number of Total Reward Objectives (after preprocessing): " << getNumberOfTotalRewardFormulas() << "." << std::endl;
-        out << "--------------------------------------------------------------" << std::endl;
-        out << std::endl;
-        out << "Original Model Information:" << std::endl;
+        out << "Number of Long-Run-Average Reward Objectives (after preprocessing): " << getNumberOfLongRunAverageRewardFormulas() << ".\n";
+        out << "Number of Total Reward Objectives (after preprocessing): " << getNumberOfTotalRewardFormulas() << ".\n";
+        out << "--------------------------------------------------------------\n";
+        out << "\nOriginal Model Information:\n";
         originalModel.printModelInformationToStream(out);
-        out << std::endl;
-        out << "Preprocessed Model Information:" << std::endl;
+        out << "\nPreprocessed Model Information:\n";
         preprocessedModel->printModelInformationToStream(out);
-        out << std::endl;
-        out << "---------------------------------------------------------------------------------------------------------------------------------------"
-            << std::endl;
+        out << "\n---------------------------------------------------------------------------------------------------------------------------------------\n";
     }
 
     friend std::ostream& operator<<(std::ostream& out, SparseMultiObjectivePreprocessorResult<SparseModelType> const& ret) {

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -130,14 +130,14 @@ std::map<storm::storage::sparse::state_type, ValueType> SparseDtmcPrctlHelper<Va
     }
 
     if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-        STORM_PRINT_AND_LOG("---------------------------------" << std::endl);
-        STORM_PRINT_AND_LOG("Statistics:" << std::endl);
-        STORM_PRINT_AND_LOG("---------------------------------" << std::endl);
-        STORM_PRINT_AND_LOG("          #checked epochs: " << epochOrder.size() << "." << std::endl);
-        STORM_PRINT_AND_LOG("             overall Time: " << swAll << "." << std::endl);
-        STORM_PRINT_AND_LOG("Epoch Model building Time: " << swBuild << "." << std::endl);
-        STORM_PRINT_AND_LOG("Epoch Model checking Time: " << swCheck << "." << std::endl);
-        STORM_PRINT_AND_LOG("---------------------------------" << std::endl);
+        STORM_PRINT_AND_LOG("---------------------------------\n");
+        STORM_PRINT_AND_LOG("Statistics:\n");
+        STORM_PRINT_AND_LOG("---------------------------------\n");
+        STORM_PRINT_AND_LOG("          #checked epochs: " << epochOrder.size() << ".\n");
+        STORM_PRINT_AND_LOG("             overall Time: " << swAll << ".\n");
+        STORM_PRINT_AND_LOG("Epoch Model building Time: " << swBuild << ".\n");
+        STORM_PRINT_AND_LOG("Epoch Model checking Time: " << swCheck << ".\n");
+        STORM_PRINT_AND_LOG("---------------------------------\n");
     }
 
     return result;

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -125,14 +125,14 @@ std::map<storm::storage::sparse::state_type, ValueType> SparseMdpPrctlHelper<Val
     }
 
     if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-        STORM_PRINT_AND_LOG("---------------------------------" << std::endl);
-        STORM_PRINT_AND_LOG("Statistics:" << std::endl);
-        STORM_PRINT_AND_LOG("---------------------------------" << std::endl);
-        STORM_PRINT_AND_LOG("          #checked epochs: " << epochOrder.size() << "." << std::endl);
-        STORM_PRINT_AND_LOG("             overall Time: " << swAll << "." << std::endl);
-        STORM_PRINT_AND_LOG("Epoch Model building Time: " << swBuild << "." << std::endl);
-        STORM_PRINT_AND_LOG("Epoch Model checking Time: " << swCheck << "." << std::endl);
-        STORM_PRINT_AND_LOG("---------------------------------" << std::endl);
+        STORM_PRINT_AND_LOG("---------------------------------\n");
+        STORM_PRINT_AND_LOG("Statistics:\n");
+        STORM_PRINT_AND_LOG("---------------------------------\n");
+        STORM_PRINT_AND_LOG("          #checked epochs: " << epochOrder.size() << ".\n");
+        STORM_PRINT_AND_LOG("             overall Time: " << swAll << ".\n");
+        STORM_PRINT_AND_LOG("Epoch Model building Time: " << swBuild << ".\n");
+        STORM_PRINT_AND_LOG("Epoch Model checking Time: " << swCheck << ".\n");
+        STORM_PRINT_AND_LOG("---------------------------------\n");
     }
 
     return result;

--- a/src/storm/modelchecker/prctl/helper/rewardbounded/MultiDimensionalRewardUnfolding.cpp
+++ b/src/storm/modelchecker/prctl/helper/rewardbounded/MultiDimensionalRewardUnfolding.cpp
@@ -407,7 +407,7 @@ EpochModel<ValueType, SingleObjectiveMode>& MultiDimensionalRewardUnfolding<Valu
         epochModel.epochMatrixChanged = true;
         if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
             if (storm::utility::graph::hasCycle(epochModel.epochMatrix)) {
-                std::cout << "Epoch model for epoch " << epochManager.toString(epoch) << " is cyclic." << std::endl;
+                std::cout << "Epoch model for epoch " << epochManager.toString(epoch) << " is cyclic.\n";
             }
         }
     } else {
@@ -497,15 +497,15 @@ EpochModel<ValueType, SingleObjectiveMode>& MultiDimensionalRewardUnfolding<Valu
 
     currentEpoch = epoch;
     /*
-    std::cout << "Epoch model for epoch " << storm::utility::vector::toString(epoch) << std::endl;
-    std::cout << "Matrix: " << std::endl << epochModel.epochMatrix << std::endl;
-    std::cout << "ObjectiveRewards: " << storm::utility::vector::toString(epochModel.objectiveRewards[0]) << std::endl;
-    std::cout << "steps: " << epochModel.stepChoices << std::endl;
+    std::cout << "Epoch model for epoch " << storm::utility::vector::toString(epoch) << '\n';
+    std::cout << "Matrix: \n" << epochModel.epochMatrix << '\n';
+    std::cout << "ObjectiveRewards: " << storm::utility::vector::toString(epochModel.objectiveRewards[0]) << '\n';
+    std::cout << "steps: " << epochModel.stepChoices << '\n';
     std::cout << "step solutions: ";
     for (int i = 0; i < epochModel.stepSolutions.size(); ++i) {
         std::cout << "   " << epochModel.stepSolutions[i].weightedValue;
     }
-    std::cout << std::endl;
+    std::cout << '\n';
     */
     return epochModel;
 }
@@ -513,7 +513,7 @@ EpochModel<ValueType, SingleObjectiveMode>& MultiDimensionalRewardUnfolding<Valu
 template<typename ValueType, bool SingleObjectiveMode>
 void MultiDimensionalRewardUnfolding<ValueType, SingleObjectiveMode>::setCurrentEpochClass(Epoch const& epoch) {
     EpochClass epochClass = epochManager.getEpochClass(epoch);
-    // std::cout << "Setting epoch class for epoch " << epochManager.toString(epoch) << std::endl;
+    // std::cout << "Setting epoch class for epoch " << epochManager.toString(epoch) << '\n';
     auto productObjectiveRewards = productModel->computeObjectiveRewards(epochClass, objectives);
 
     storm::storage::BitVector stepChoices(productModel->getProduct().getTransitionMatrix().getRowCount(), false);

--- a/src/storm/modelchecker/prctl/helper/rewardbounded/ProductModel.cpp
+++ b/src/storm/modelchecker/prctl/helper/rewardbounded/ProductModel.cpp
@@ -653,7 +653,7 @@ typename ProductModel<ValueType>::MemoryState ProductModel<ValueType>::transform
     }
 
     //  std::cout << "Transformed memory state " << memoryStateManager.toString(memoryState) << " at epoch class " << epochClass << " with predecessor " <<
-    //  memoryStateManager.toString(predecessorMemoryState) << " to " << memoryStateManager.toString(memoryStatePrime) << std::endl;
+    //  memoryStateManager.toString(predecessorMemoryState) << " to " << memoryStateManager.toString(memoryStatePrime) << '\n';
 
     return memoryStatePrime;
 }

--- a/src/storm/modelchecker/prctl/helper/rewardbounded/QuantileHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/rewardbounded/QuantileHelper.cpp
@@ -245,10 +245,10 @@ std::vector<std::vector<typename ModelType::ValueType>> QuantileHelper<ModelType
         result.push_back(resultPoint);
     }
     if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-        std::cout << "Number of checked epochs: " << numCheckedEpochs << std::endl;
-        std::cout << "Number of required precision refinements: " << numPrecisionRefinements << std::endl;
-        std::cout << "Time for epoch exploration: " << swExploration << " seconds." << std::endl;
-        std::cout << "\tTime for epoch model analysis: " << swEpochAnalysis << " seconds." << std::endl;
+        std::cout << "Number of checked epochs: " << numCheckedEpochs << '\n';
+        std::cout << "Number of required precision refinements: " << numPrecisionRefinements << '\n';
+        std::cout << "Time for epoch exploration: " << swExploration << " seconds.\n";
+        std::cout << "\tTime for epoch model analysis: " << swEpochAnalysis << " seconds.\n";
     }
     return result;
 }

--- a/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.cpp
+++ b/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.cpp
@@ -328,13 +328,13 @@ SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeLongRunValues(sto
         std::chrono::high_resolution_clock::duration totalTime = totalTimeEnd - totalTimeStart;
         std::chrono::milliseconds totalTimeInMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(totalTime);
 
-        STORM_PRINT_AND_LOG(std::endl);
-        STORM_PRINT_AND_LOG("Time breakdown:" << std::endl);
-        STORM_PRINT_AND_LOG("    * time for SCC decomposition: " << sccDecompositionTimeInMilliseconds.count() << "ms" << std::endl);
-        STORM_PRINT_AND_LOG("    * time for conversion: " << conversionTimeInMilliseconds.count() << "ms" << std::endl);
-        STORM_PRINT_AND_LOG("    * time for checking: " << modelCheckingTimeInMilliseconds.count() << "ms" << std::endl);
-        STORM_PRINT_AND_LOG("------------------------------------------" << std::endl);
-        STORM_PRINT_AND_LOG("    * total time: " << totalTimeInMilliseconds.count() << "ms" << std::endl);
+        STORM_PRINT_AND_LOG('\n');
+        STORM_PRINT_AND_LOG("Time breakdown:\n");
+        STORM_PRINT_AND_LOG("    * time for SCC decomposition: " << sccDecompositionTimeInMilliseconds.count() << "ms\n");
+        STORM_PRINT_AND_LOG("    * time for conversion: " << conversionTimeInMilliseconds.count() << "ms\n");
+        STORM_PRINT_AND_LOG("    * time for checking: " << modelCheckingTimeInMilliseconds.count() << "ms\n");
+        STORM_PRINT_AND_LOG("------------------------------------------\n");
+        STORM_PRINT_AND_LOG("    * total time: " << totalTimeInMilliseconds.count() << "ms\n");
     }
 
     // Now, we return the value for the only initial state.
@@ -745,9 +745,9 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
     std::shared_ptr<StatePriorityQueue> statePriorities =
         createStatePriorityQueue(distanceBasedPriorities, flexibleMatrix, flexibleBackwardTransitions, oneStepProbabilities, statesToEliminate);
 
-    STORM_LOG_INFO("Computing conditional probilities." << std::endl);
+    STORM_LOG_INFO("Computing conditional probilities.\n");
     uint_fast64_t numberOfStatesToEliminate = statePriorities->size();
-    STORM_LOG_INFO("Eliminating " << numberOfStatesToEliminate << " states using the state elimination technique." << std::endl);
+    STORM_LOG_INFO("Eliminating " << numberOfStatesToEliminate << " states using the state elimination technique.\n");
     performPrioritizedStateElimination(statePriorities, flexibleMatrix, flexibleBackwardTransitions, oneStepProbabilities, this->getModel().getInitialStates(),
                                        true);
 
@@ -900,9 +900,9 @@ void SparseDtmcEliminationModelChecker<SparseDtmcModelType>::performOrdinaryStat
         createStatePriorityQueue(distanceBasedPriorities, transitionMatrix, backwardTransitions, values, subsystem);
 
     std::size_t numberOfStatesToEliminate = statePriorities->size();
-    STORM_LOG_DEBUG("Eliminating " << numberOfStatesToEliminate << " states using the state elimination technique." << std::endl);
+    STORM_LOG_DEBUG("Eliminating " << numberOfStatesToEliminate << " states using the state elimination technique.\n");
     performPrioritizedStateElimination(statePriorities, transitionMatrix, backwardTransitions, values, initialStates, computeResultsForInitialStatesOnly);
-    STORM_LOG_DEBUG("Eliminated " << numberOfStatesToEliminate << " states." << std::endl);
+    STORM_LOG_DEBUG("Eliminated " << numberOfStatesToEliminate << " states.\n");
 }
 
 template<typename SparseDtmcModelType>
@@ -913,7 +913,7 @@ uint_fast64_t SparseDtmcEliminationModelChecker<SparseDtmcModelType>::performHyb
     boost::optional<std::vector<uint_fast64_t>> const& distanceBasedPriorities) {
     // When using the hybrid technique, we recursively treat the SCCs up to some size.
     std::vector<storm::storage::sparse::state_type> entryStateQueue;
-    STORM_LOG_DEBUG("Eliminating " << subsystem.size() << " states using the hybrid elimination technique." << std::endl);
+    STORM_LOG_DEBUG("Eliminating " << subsystem.size() << " states using the hybrid elimination technique.\n");
     uint_fast64_t maximalDepth = treatScc(transitionMatrix, values, initialStates, subsystem, initialStates, forwardTransitions, backwardTransitions, false, 0,
                                           storm::settings::getModule<storm::settings::modules::EliminationSettings>().getMaximalSccSize(), entryStateQueue,
                                           computeResultsForInitialStatesOnly, distanceBasedPriorities);
@@ -925,7 +925,7 @@ uint_fast64_t SparseDtmcEliminationModelChecker<SparseDtmcModelType>::performHyb
         std::shared_ptr<StatePriorityQueue> queuePriorities = std::make_shared<StaticStatePriorityQueue>(sortedStates);
         performPrioritizedStateElimination(queuePriorities, transitionMatrix, backwardTransitions, values, initialStates, computeResultsForInitialStatesOnly);
     }
-    STORM_LOG_DEBUG("Eliminated " << subsystem.size() << " states." << std::endl);
+    STORM_LOG_DEBUG("Eliminated " << subsystem.size() << " states.\n");
     return maximalDepth;
 }
 

--- a/src/storm/modelchecker/results/ParetoCurveCheckResult.cpp
+++ b/src/storm/modelchecker/results/ParetoCurveCheckResult.cpp
@@ -59,14 +59,14 @@ typename ParetoCurveCheckResult<ValueType>::polytope_type const& ParetoCurveChec
 
 template<typename ValueType>
 std::ostream& ParetoCurveCheckResult<ValueType>::writeToStream(std::ostream& out) const {
-    out << std::endl;
+    out << '\n';
     if (hasUnderApproximation()) {
-        out << "Underapproximation of achievable values: " << underApproximation->toString() << std::endl;
+        out << "Underapproximation of achievable values: " << underApproximation->toString() << '\n';
     }
     if (hasOverApproximation()) {
-        out << "Overapproximation of achievable values: " << overApproximation->toString() << std::endl;
+        out << "Overapproximation of achievable values: " << overApproximation->toString() << '\n';
     }
-    out << points.size() << " Pareto optimal points found:" << std::endl;
+    out << points.size() << " Pareto optimal points found:\n";
     for (auto const& p : points) {
         out << "   (";
         for (auto it = p.begin(); it != p.end(); ++it) {
@@ -87,7 +87,7 @@ std::ostream& ParetoCurveCheckResult<ValueType>::writeToStream(std::ostream& out
             }
             out << " )";
         }
-        out << std::endl;
+        out << '\n';
     }
     return out;
 }

--- a/src/storm/modelchecker/results/SymbolicQualitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/SymbolicQualitativeCheckResult.cpp
@@ -100,12 +100,12 @@ std::ostream& SymbolicQualitativeCheckResult<Type>::writeToStream(std::ostream& 
             out << "true";
         }
     } else if (states == truthValues) {
-        out << "{true}" << std::endl;
+        out << "{true}\n";
     } else {
         if (truthValues.isZero()) {
-            out << "{false}" << std::endl;
+            out << "{false}\n";
         } else {
-            out << "{true, false}" << std::endl;
+            out << "{true, false}\n";
         }
     }
     return out;

--- a/src/storm/modelchecker/rpatl/SparseSmgRpatlModelChecker.cpp
+++ b/src/storm/modelchecker/rpatl/SparseSmgRpatlModelChecker.cpp
@@ -70,7 +70,7 @@ std::unique_ptr<CheckResult> SparseSmgRpatlModelChecker<SparseSmgModelType>::com
     auto rewardModel = storm::utility::createFilteredRewardModel(this->getModel(), checkTask);
     STORM_LOG_THROW(checkTask.isPlayerCoalitionSet(), storm::exceptions::InvalidPropertyException, "No player coalition was set.");
     auto coalitionStates = this->getModel().computeStatesOfCoalition(checkTask.getPlayerCoalition());
-    std::cout << "Found " << coalitionStates.getNumberOfSetBits() << " states in coalition." << std::endl;
+    std::cout << "Found " << coalitionStates.getNumberOfSetBits() << " states in coalition.\n";
     STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "Not implemented.");
 }
 

--- a/src/storm/models/sparse/DeterministicModel.cpp
+++ b/src/storm/models/sparse/DeterministicModel.cpp
@@ -39,24 +39,24 @@ void DeterministicModel<ValueType, RewardModelType>::writeDotToStream(std::ostre
         std::string arrowOrigin = std::to_string(i);
         if (this->hasChoiceLabeling()) {
             arrowOrigin = "\"" + arrowOrigin + "c\"";
-            outStream << "\t" << arrowOrigin << " [shape = \"point\"]" << std::endl;
+            outStream << "\t" << arrowOrigin << " [shape = \"point\"]\n";
             outStream << "\t" << i << " -> " << arrowOrigin << " [label= \"{";
             storm::utility::outputFixedWidth(outStream, this->getChoiceLabeling().getLabelsOfChoice(i), maxWidthLabel);
-            outStream << "}\"];" << std::endl;
+            outStream << "}\"];\n";
         }
 
         typename storm::storage::SparseMatrix<ValueType>::const_rows row = this->getTransitionMatrix().getRow(i);
         for (auto const& transition : row) {
             if (transition.getValue() != storm::utility::zero<ValueType>()) {
                 if (subsystem == nullptr || subsystem->get(transition.getColumn())) {
-                    outStream << "\t" << arrowOrigin << " -> " << transition.getColumn() << " [ label= \"" << transition.getValue() << "\" ];" << std::endl;
+                    outStream << "\t" << arrowOrigin << " -> " << transition.getColumn() << " [ label= \"" << transition.getValue() << "\" ];\n";
                 }
             }
         }
     }
 
     if (finalizeOutput) {
-        outStream << "}" << std::endl;
+        outStream << "}\n";
     }
 }
 

--- a/src/storm/models/sparse/ItemLabeling.cpp
+++ b/src/storm/models/sparse/ItemLabeling.cpp
@@ -202,20 +202,20 @@ void ItemLabeling::setItems(std::string const& label, storage::BitVector&& label
 }
 
 void ItemLabeling::printLabelingInformationToStream(std::ostream& out) const {
-    out << this->getNumberOfLabels() << " labels" << std::endl;
+    out << this->getNumberOfLabels() << " labels\n";
     for (auto const& labelIndexPair : this->nameToLabelingIndexMap) {
-        out << "   * " << labelIndexPair.first << " -> " << this->labelings[labelIndexPair.second].getNumberOfSetBits() << " item(s)" << std::endl;
+        out << "   * " << labelIndexPair.first << " -> " << this->labelings[labelIndexPair.second].getNumberOfSetBits() << " item(s)\n";
     }
 }
 
 void ItemLabeling::printCompleteLabelingInformationToStream(std::ostream& out) const {
-    out << "Labels: \t" << this->getNumberOfLabels() << std::endl;
+    out << "Labels: \t" << this->getNumberOfLabels() << '\n';
     for (auto label : nameToLabelingIndexMap) {
         out << "Label '" << label.first << "': ";
         for (auto index : this->labelings[label.second]) {
             out << index << " ";
         }
-        out << std::endl;
+        out << '\n';
     }
 }
 

--- a/src/storm/models/sparse/MarkovAutomaton.cpp
+++ b/src/storm/models/sparse/MarkovAutomaton.cpp
@@ -294,15 +294,15 @@ bool MarkovAutomaton<ValueType, RewardModelType>::checkContainsZenoCycle() const
 template<typename ValueType, typename RewardModelType>
 void MarkovAutomaton<ValueType, RewardModelType>::printModelInformationToStream(std::ostream& out) const {
     this->printModelInformationHeaderToStream(out);
-    out << "Choices: \t" << this->getNumberOfChoices() << std::endl;
-    out << "Markovian St.: \t" << this->getMarkovianStates().getNumberOfSetBits() << std::endl;
+    out << "Choices: \t" << this->getNumberOfChoices() << '\n';
+    out << "Markovian St.: \t" << this->getMarkovianStates().getNumberOfSetBits() << '\n';
     out << "Max. Rate: \t";
     if (this->getMarkovianStates().empty()) {
         out << "None";
     } else {
         out << this->getMaximalExitRate();
     }
-    out << std::endl;
+    out << '\n';
     this->printModelInformationFooterToStream(out);
 }
 

--- a/src/storm/models/sparse/Model.cpp
+++ b/src/storm/models/sparse/Model.cpp
@@ -403,10 +403,10 @@ std::size_t Model<ValueType, RewardModelType>::hash() const {
 
 template<typename ValueType, typename RewardModelType>
 void Model<ValueType, RewardModelType>::printModelInformationHeaderToStream(std::ostream& out) const {
-    out << "-------------------------------------------------------------- " << std::endl;
-    out << "Model type: \t" << this->getType() << " (sparse)" << std::endl;
-    out << "States: \t" << this->getNumberOfStates() << std::endl;
-    out << "Transitions: \t" << this->getNumberOfTransitions() << std::endl;
+    out << "-------------------------------------------------------------- \n";
+    out << "Model type: \t" << this->getType() << " (sparse)\n";
+    out << "States: \t" << this->getNumberOfStates() << '\n';
+    out << "Transitions: \t" << this->getNumberOfTransitions() << '\n';
 }
 
 template<typename ValueType, typename RewardModelType>
@@ -418,9 +418,9 @@ void Model<ValueType, RewardModelType>::printModelInformationFooterToStream(std:
     if (this->hasChoiceLabeling()) {
         this->getChoiceLabeling().printLabelingInformationToStream(out);
     } else {
-        out << "none" << std::endl;
+        out << "none\n";
     }
-    out << "-------------------------------------------------------------- " << std::endl;
+    out << "-------------------------------------------------------------- \n";
 }
 
 template<typename ValueType, typename RewardModelType>
@@ -435,9 +435,9 @@ void Model<ValueType, RewardModelType>::printRewardModelsInformationToStream(std
                               rewardModelNames.push_back(nameRewardModelPair.first);
                           }
                       });
-        out << "Reward Models:  " << boost::join(rewardModelNames, ", ") << std::endl;
+        out << "Reward Models:  " << boost::join(rewardModelNames, ", ") << '\n';
     } else {
-        out << "Reward Models:  none" << std::endl;
+        out << "Reward Models:  none\n";
     }
 }
 
@@ -446,7 +446,7 @@ void Model<ValueType, RewardModelType>::writeDotToStream(std::ostream& outStream
                                                          storm::storage::BitVector const* subsystem, std::vector<ValueType> const* firstValue,
                                                          std::vector<ValueType> const* secondValue, std::vector<uint_fast64_t> const* stateColoring,
                                                          std::vector<std::string> const* colors, std::vector<uint_fast64_t>*, bool finalizeOutput) const {
-    outStream << "digraph model {" << std::endl;
+    outStream << "digraph model {\n";
 
     // Write all states to the stream.
     for (uint_fast64_t state = 0, highestStateIndex = this->getNumberOfStates() - 1; state <= highestStateIndex; ++state) {
@@ -499,13 +499,13 @@ void Model<ValueType, RewardModelType>::writeDotToStream(std::ostream& outStream
                 }
                 outStream << " ]";
             }
-            outStream << ";" << std::endl;
+            outStream << ";\n";
         }
     }
 
     // If this methods has not been called from a derived class, we want to close the digraph here.
     if (finalizeOutput) {
-        outStream << "}" << std::endl;
+        outStream << "}\n";
     }
 }
 

--- a/src/storm/models/sparse/NondeterministicModel.cpp
+++ b/src/storm/models/sparse/NondeterministicModel.cpp
@@ -67,7 +67,7 @@ std::shared_ptr<storm::models::sparse::Model<ValueType, RewardModelType>> Nondet
 template<typename ValueType, typename RewardModelType>
 void NondeterministicModel<ValueType, RewardModelType>::printModelInformationToStream(std::ostream& out) const {
     this->printModelInformationHeaderToStream(out);
-    out << "Choices: \t" << this->getNumberOfChoices() << std::endl;
+    out << "Choices: \t" << this->getNumberOfChoices() << '\n';
     this->printModelInformationFooterToStream(out);
 }
 
@@ -111,7 +111,7 @@ void NondeterministicModel<ValueType, RewardModelType>::writeDotToStream(std::os
                     outStream << ", fillcolor=\"red\"";
                 }
             }
-            outStream << "];" << std::endl;
+            outStream << "];\n";
 
             // The arrow to the intermediate node:
             outStream << "\t" << state << " -> \"" << state << "c" << choice << "\"";
@@ -152,9 +152,9 @@ void NondeterministicModel<ValueType, RewardModelType>::writeDotToStream(std::os
             }
 
             if (arrowHasLabel || scheduler != nullptr) {
-                outStream << "]" << std::endl;
+                outStream << "]\n";
             }
-            outStream << ";" << std::endl;
+            outStream << ";\n";
 
             // Now draw all probabilistic arcs that belong to this non-deterministic choice.
             for (auto const& transition : row) {
@@ -169,14 +169,14 @@ void NondeterministicModel<ValueType, RewardModelType>::writeDotToStream(std::os
                             outStream << " [style = \"dotted\"]";
                         }
                     }
-                    outStream << ";" << std::endl;
+                    outStream << ";\n";
                 }
             }
         }
     }
 
     if (finalizeOutput) {
-        outStream << "}" << std::endl;
+        outStream << "}\n";
     }
 }
 

--- a/src/storm/models/sparse/Pomdp.cpp
+++ b/src/storm/models/sparse/Pomdp.cpp
@@ -40,8 +40,8 @@ Pomdp<ValueType, RewardModelType>::Pomdp(storm::storage::sparse::ModelComponents
 template<typename ValueType, typename RewardModelType>
 void Pomdp<ValueType, RewardModelType>::printModelInformationToStream(std::ostream &out) const {
     this->printModelInformationHeaderToStream(out);
-    out << "Choices: \t" << this->getNumberOfChoices() << std::endl;
-    out << "Observations: \t" << this->nrObservations << std::endl;
+    out << "Choices: \t" << this->getNumberOfChoices() << '\n';
+    out << "Observations: \t" << this->nrObservations << '\n';
     this->printModelInformationFooterToStream(out);
 }
 

--- a/src/storm/models/symbolic/Model.cpp
+++ b/src/storm/models/symbolic/Model.cpp
@@ -325,25 +325,24 @@ std::vector<std::string> Model<Type, ValueType>::getLabels() const {
 
 template<storm::dd::DdType Type, typename ValueType>
 void Model<Type, ValueType>::printModelInformationHeaderToStream(std::ostream& out) const {
-    out << "-------------------------------------------------------------- " << std::endl;
-    out << "Model type: \t" << this->getType() << " (symbolic)" << std::endl;
-    out << "States: \t" << this->getNumberOfStates() << " (" << reachableStates.getNodeCount() << " nodes)" << std::endl;
-    out << "Transitions: \t" << this->getNumberOfTransitions() << " (" << transitionMatrix.getNodeCount() << " nodes)" << std::endl;
+    out << "-------------------------------------------------------------- \n";
+    out << "Model type: \t" << this->getType() << " (symbolic)\n";
+    out << "States: \t" << this->getNumberOfStates() << " (" << reachableStates.getNodeCount() << " nodes)\n";
+    out << "Transitions: \t" << this->getNumberOfTransitions() << " (" << transitionMatrix.getNodeCount() << " nodes)\n";
 }
 
 template<storm::dd::DdType Type, typename ValueType>
 void Model<Type, ValueType>::printModelInformationFooterToStream(std::ostream& out) const {
     this->printRewardModelsInformationToStream(out);
     this->printDdVariableInformationToStream(out);
-    out << std::endl;
-    out << "Labels: \t" << (this->labelToExpressionMap.size() + this->labelToBddMap.size()) << std::endl;
+    out << "\nLabels: \t" << (this->labelToExpressionMap.size() + this->labelToBddMap.size()) << '\n';
     for (auto const& label : labelToBddMap) {
-        out << "   * " << label.first << " -> " << label.second.getNonZeroCount() << " state(s) (" << label.second.getNodeCount() << " nodes)" << std::endl;
+        out << "   * " << label.first << " -> " << label.second.getNonZeroCount() << " state(s) (" << label.second.getNodeCount() << " nodes)\n";
     }
     for (auto const& label : labelToExpressionMap) {
-        out << "   * " << label.first << std::endl;
+        out << "   * " << label.first << '\n';
     }
-    out << "-------------------------------------------------------------- " << std::endl;
+    out << "-------------------------------------------------------------- \n";
 }
 
 template<storm::dd::DdType Type, typename ValueType>
@@ -358,9 +357,9 @@ void Model<Type, ValueType>::printRewardModelsInformationToStream(std::ostream& 
                               rewardModelNames.push_back(nameRewardModelPair.first);
                           }
                       });
-        out << "Reward Models:  " << boost::join(rewardModelNames, ", ") << std::endl;
+        out << "Reward Models:  " << boost::join(rewardModelNames, ", ") << '\n';
     } else {
-        out << "Reward Models:  none" << std::endl;
+        out << "Reward Models:  none\n";
     }
 }
 

--- a/src/storm/models/symbolic/NondeterministicModel.cpp
+++ b/src/storm/models/symbolic/NondeterministicModel.cpp
@@ -75,7 +75,7 @@ storm::dd::Bdd<Type> NondeterministicModel<Type, ValueType>::getIllegalSuccessor
 template<storm::dd::DdType Type, typename ValueType>
 void NondeterministicModel<Type, ValueType>::printModelInformationToStream(std::ostream& out) const {
     this->printModelInformationHeaderToStream(out);
-    out << "Choices: \t" << this->getNumberOfChoices() << std::endl;
+    out << "Choices: \t" << this->getNumberOfChoices() << '\n';
     this->printModelInformationFooterToStream(out);
 }
 

--- a/src/storm/permissivesched/MILPPermissiveSchedulers.h
+++ b/src/storm/permissivesched/MILPPermissiveSchedulers.h
@@ -64,19 +64,19 @@ class MilpPermissiveSchedulerComputation : public PermissiveSchedulerComputation
         std::fstream filestream;
         filestream.open(filename, std::fstream::out);
         for (auto const& pVar : mProbVariables) {
-            filestream << pVar.second.getName() << "->" << solver.getContinuousValue(pVar.second) << std::endl;
+            filestream << pVar.second.getName() << "->" << solver.getContinuousValue(pVar.second) << '\n';
         }
         for (auto const& yVar : multistrategyVariables) {
-            filestream << yVar.second.getName() << "->" << solver.getBinaryValue(yVar.second) << std::endl;
+            filestream << yVar.second.getName() << "->" << solver.getBinaryValue(yVar.second) << '\n';
         }
         for (auto const& aVar : mAlphaVariables) {
-            filestream << aVar.second.getName() << "->" << solver.getBinaryValue(aVar.second) << std::endl;
+            filestream << aVar.second.getName() << "->" << solver.getBinaryValue(aVar.second) << '\n';
         }
         for (auto const& betaVar : mBetaVariables) {
-            filestream << betaVar.second.getName() << "->" << solver.getBinaryValue(betaVar.second) << std::endl;
+            filestream << betaVar.second.getName() << "->" << solver.getBinaryValue(betaVar.second) << '\n';
         }
         for (auto const& gammaVar : mGammaVariables) {
-            filestream << gammaVar.second.getName() << "->" << solver.getContinuousValue(gammaVar.second) << std::endl;
+            filestream << gammaVar.second.getName() << "->" << solver.getContinuousValue(gammaVar.second) << '\n';
         }
         filestream.close();
     }

--- a/src/storm/permissivesched/PermissiveSchedulers.cpp
+++ b/src/storm/permissivesched/PermissiveSchedulers.cpp
@@ -31,7 +31,7 @@ boost::optional<SubMDPPermissiveScheduler<RM>> computePermissiveSchedulerViaMILP
     STORM_LOG_THROW(!storm::logic::isStrict(safeProp.getComparisonType()), storm::exceptions::NotImplementedException, "Strict bounds are not supported");
     comp.calculatePermissiveScheduler(storm::logic::isLowerBound(safeProp.getComparisonType()), safeProp.getThresholdAs<double>());
     // comp.dumpLpToFile("milpdump.lp");
-    std::cout << "Found Solution: " << (comp.foundSolution() ? "yes" : "no") << std::endl;
+    std::cout << "Found Solution: " << (comp.foundSolution() ? "yes" : "no") << '\n';
     if (comp.foundSolution()) {
         return boost::optional<SubMDPPermissiveScheduler<RM>>(comp.getScheduler());
     } else {

--- a/src/storm/settings/SettingsManager.cpp
+++ b/src/storm/settings/SettingsManager.cpp
@@ -201,8 +201,8 @@ void SettingsManager::setFromConfigurationFile(std::string const& configFilename
                 // If the option was already set from the command line, we issue a warning and ignore the
                 // settings from the configuration file.
                 STORM_LOG_WARN("The option '" << option->getLongName() << "' of module '" << option->getModuleName()
-                                              << "' has been set in the configuration file '" << configFilename << "', but was overwritten on the command line."
-                                              << std::endl);
+                                              << "' has been set in the configuration file '" << configFilename
+                                              << "', but was overwritten on the command line.\n");
             } else {
                 // If, however, the option has not been set yet, we try to assign values ot its arguments
                 // based on the argument strings.
@@ -215,7 +215,7 @@ void SettingsManager::setFromConfigurationFile(std::string const& configFilename
 }
 
 void SettingsManager::printHelp(std::string const& filter) const {
-    STORM_PRINT("usage: " << executableName << " [options]" << std::endl << std::endl);
+    STORM_PRINT("usage: " << executableName << " [options]\n\n");
 
     if (filter == "frequent" || filter == "all") {
         bool includeAdvanced = (filter == "all");
@@ -249,19 +249,19 @@ void SettingsManager::printHelp(std::string const& filter) const {
         }
         if (!includeAdvanced) {
             if (numHidden == 1) {
-                STORM_PRINT(numHidden << " hidden option." << std::endl);
+                STORM_PRINT(numHidden << " hidden option.\n");
             } else {
-                STORM_PRINT(numHidden << " hidden options." << std::endl);
+                STORM_PRINT(numHidden << " hidden options.\n");
             }
             if (!invisibleModules.empty()) {
                 if (invisibleModules.size() == 1) {
-                    STORM_PRINT(invisibleModules.size() << " hidden module (" << boost::join(invisibleModules, ", ") << ")." << std::endl);
+                    STORM_PRINT(invisibleModules.size() << " hidden module (" << boost::join(invisibleModules, ", ") << ").\n");
                 } else {
-                    STORM_PRINT(invisibleModules.size() << " hidden modules (" << boost::join(invisibleModules, ", ") << ")." << std::endl);
+                    STORM_PRINT(invisibleModules.size() << " hidden modules (" << boost::join(invisibleModules, ", ") << ").\n");
                 }
             }
-            STORM_PRINT(std::endl << "Type '" + executableName + " --help modulename' to display all options of a specific module." << std::endl);
-            STORM_PRINT("Type '" + executableName + " --help all' to display a complete list of options." << std::endl);
+            STORM_PRINT("\nType '" + executableName + " --help modulename' to display all options of a specific module.\n");
+            STORM_PRINT("Type '" + executableName + " --help all' to display a complete list of options.\n");
         }
     } else {
         // Create a regular expression from the input hint.
@@ -288,7 +288,7 @@ void SettingsManager::printHelp(std::string const& filter) const {
         std::string optionList = getHelpForSelection(matchingModuleNames, matchingOptionNames,
                                                      "Matching modules for filter '" + filter + "':", "Matching options for filter '" + filter + "':");
         if (optionList.empty()) {
-            STORM_PRINT("Filter '" << filter << "' did not match any modules or options." << std::endl);
+            STORM_PRINT("Filter '" << filter << "' did not match any modules or options.\n");
         } else {
             STORM_PRINT(optionList);
         }
@@ -333,7 +333,7 @@ std::string SettingsManager::getHelpForSelection(std::vector<std::string> const&
     uint_fast64_t maxLength = std::max(maxLengthModules, maxLengthOptions);
     if (selectedModuleNames.size() > 0) {
         if (modulesHeader != "") {
-            stream << modulesHeader << std::endl;
+            stream << modulesHeader << '\n';
         }
         for (auto const& matchingModuleName : selectedModuleNames) {
             stream << getHelpForModule(matchingModuleName, maxLength, true);
@@ -343,10 +343,10 @@ std::string SettingsManager::getHelpForSelection(std::vector<std::string> const&
     // Print the matching options.
     if (matchingOptions.size() > 0) {
         if (optionsHeader != "") {
-            stream << optionsHeader << std::endl;
+            stream << optionsHeader << '\n';
         }
         for (auto const& option : matchingOptions) {
-            stream << std::setw(maxLength) << std::left << *option << std::endl;
+            stream << std::setw(maxLength) << std::left << *option << '\n';
         }
     }
     return stream.str();
@@ -374,8 +374,7 @@ std::string SettingsManager::getHelpForModule(std::string const& moduleName, uin
         if (!includeAdvanced) {
             displayedModuleName += " (" + std::to_string(numOfOptions) + "/" + std::to_string(moduleIterator->second.size()) + " shown)";
         }
-        stream << "##### Module " << displayedModuleName << " " << std::string(std::min(maxLength, maxLength - displayedModuleName.length() - 14), '#')
-               << std::endl;
+        stream << "##### Module " << displayedModuleName << " " << std::string(std::min(maxLength, maxLength - displayedModuleName.length() - 14), '#') << '\n';
 
         // Save the flags for std::cout so we can manipulate them and be sure they will be restored as soon as this
         // stream goes out of scope.
@@ -383,10 +382,10 @@ std::string SettingsManager::getHelpForModule(std::string const& moduleName, uin
 
         for (auto const& option : moduleIterator->second) {
             if (includeAdvanced || !option->getIsAdvanced()) {
-                stream << std::setw(maxLength) << std::left << *option << std::endl;
+                stream << std::setw(maxLength) << std::left << *option << '\n';
             }
         }
-        stream << std::endl;
+        stream << '\n';
     }
     return stream.str();
 }

--- a/src/storm/solver/GurobiLpSolver.cpp
+++ b/src/storm/solver/GurobiLpSolver.cpp
@@ -205,7 +205,7 @@ void GurobiLpSolver<ValueType>::addVariable(storm::expressions::Variable const& 
 
 template<typename ValueType>
 void GurobiLpSolver<ValueType>::addConstraint(std::string const& name, storm::expressions::Expression const& constraint) {
-    STORM_LOG_TRACE("Adding constraint " << (name == "" ? std::to_string(nextConstraintIndex) : name) << " to GurobiLpSolver:" << std::endl
+    STORM_LOG_TRACE("Adding constraint " << (name == "" ? std::to_string(nextConstraintIndex) : name) << " to GurobiLpSolver:\n"
                                          << "\t" << constraint);
     STORM_LOG_THROW(constraint.isRelationalExpression(), storm::exceptions::InvalidArgumentException, "Illegal constraint is not a relational expression.");
     STORM_LOG_THROW(constraint.getOperator() != storm::expressions::OperatorType::NotEqual, storm::exceptions::InvalidArgumentException,

--- a/src/storm/solver/SmtlibSmtSolver.cpp
+++ b/src/storm/solver/SmtlibSmtSolver.cpp
@@ -245,7 +245,7 @@ bool SmtlibSmtSolver::isNeedsRestart() const {
 
 void SmtlibSmtSolver::writeCommand(std::string smt2Command, bool expectSuccess) {
     if (isCommandFileOpen) {
-        commandFile << smt2Command << std::endl;
+        commandFile << smt2Command << '\n';
     }
 
 #ifndef WINDOWS

--- a/src/storm/solver/TopologicalCudaMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/TopologicalCudaMinMaxLinearEquationSolver.cpp
@@ -88,10 +88,10 @@ bool TopologicalCudaMinMaxLinearEquationSolver<ValueType>::internalSolveEquation
 
     // For testing only
     if (sizeof(ValueType) == sizeof(double)) {
-        // std::cout << "<<< Using CUDA-DOUBLE Kernels >>>" << std::endl;
+        // std::cout << "<<< Using CUDA-DOUBLE Kernels >>>\n";
         STORM_LOG_INFO("<<< Using CUDA-DOUBLE Kernels >>>");
     } else {
-        // std::cout << "<<< Using CUDA-FLOAT Kernels >>>" << std::endl;
+        // std::cout << "<<< Using CUDA-FLOAT Kernels >>>\n";
         STORM_LOG_INFO("<<< Using CUDA-FLOAT Kernels >>>");
     }
 
@@ -112,7 +112,7 @@ bool TopologicalCudaMinMaxLinearEquationSolver<ValueType>::internalSolveEquation
     std::vector<std::pair<bool, storm::storage::StateBlock>> sccDecomposition;
     if (__USE_CUDAFORSTORM_OPT && (gpuSizeOfCompleteSystem < cudaFreeMemory)) {
         // Dummy output for SCC Times
-        // std::cout << "Computing the SCC Decomposition took 0ms" << std::endl;
+        // std::cout << "Computing the SCC Decomposition took 0ms\n";
 
 #ifdef STORM_HAVE_CUDA
         STORM_LOG_THROW(resetCudaDevice(), storm::exceptions::InvalidStateException, "Could not reset CUDA Device, can not use CUDA Equation Solver.");
@@ -262,7 +262,7 @@ bool TopologicalCudaMinMaxLinearEquationSolver<ValueType>::internalSolveEquation
                     << "The useGpu Flag of a SCC was set, but this version of storm does not support CUDA acceleration. Internal Error!";
 #endif
             } else {
-                // std::cout << "WARNING: Using CPU based TopoSolver! (double)" << std::endl;
+                // std::cout << "WARNING: Using CPU based TopoSolver! (double)\n";
                 STORM_LOG_INFO("Performance Warning: Using CPU based TopoSolver! (double)");
                 localIterations = 0;
                 converged = false;
@@ -316,8 +316,7 @@ bool TopologicalCudaMinMaxLinearEquationSolver<ValueType>::internalSolveEquation
             }
         }
 
-        // std::cout << "Used a total of " << globalIterations << " iterations with a maximum of " << localIterations << " iterations in a single block." <<
-        // std::endl;
+        // std::cout << "Used a total of " << globalIterations << " iterations with a maximum of " << localIterations << " iterations in a single block.\n"
 
         // Check if the solver converged and issue a warning otherwise.
         if (converged) {

--- a/src/storm/solver/TopologicalLinearEquationSolver.cpp
+++ b/src/storm/solver/TopologicalLinearEquationSolver.cpp
@@ -226,8 +226,8 @@ bool TopologicalLinearEquationSolver<ValueType>::solveScc(storm::Environment con
         this->sccSolver->setUpperBounds(storm::utility::vector::filterVector(this->getUpperBounds(), scc));
     }
 
-    // std::cout << "rhs is " << storm::utility::vector::toString(sccB) << std::endl;
-    // std::cout << "x is " << storm::utility::vector::toString(sccX) << std::endl;
+    // std::cout << "rhs is " << storm::utility::vector::toString(sccB) << '\n';
+    // std::cout << "x is " << storm::utility::vector::toString(sccX) << '\n';
 
     bool returnvalue = this->sccSolver->solveEquations(sccSolverEnvironment, sccX, sccB);
     storm::utility::vector::setVectorValues(globalX, scc, sccX);

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -856,7 +856,7 @@ storm::storage::BitVector BitVector::getAsBitVector(uint_fast64_t start, uint_fa
             STORM_LOG_ERROR("Getting from " << start << " with length " << length);
             std::stringstream stream;
             printBits(stream);
-            stream << std::endl;
+            stream << '\n';
             result.printBits(stream);
             STORM_LOG_ERROR(stream.str());
             STORM_LOG_ASSERT(false, "Getting of bits not correct.");
@@ -869,7 +869,7 @@ storm::storage::BitVector BitVector::getAsBitVector(uint_fast64_t start, uint_fa
                 STORM_LOG_ERROR("Getting from " << start << " with length " << length);
                 std::stringstream stream;
                 printBits(stream);
-                stream << std::endl;
+                stream << '\n';
                 original.printBits(stream);
                 STORM_LOG_ERROR(stream.str());
                 STORM_LOG_ASSERT(false, "Getting of bits not correct.");
@@ -949,7 +949,7 @@ void BitVector::setFromBitVector(uint_fast64_t start, BitVector const& other) {
             STORM_LOG_ERROR("Setting from " << start << " with length " << other.bitCount);
             std::stringstream stream;
             printBits(stream);
-            stream << std::endl;
+            stream << '\n';
             other.printBits(stream);
             STORM_LOG_ERROR(stream.str());
             STORM_LOG_ASSERT(false, "Setting of bits not correct.");
@@ -962,7 +962,7 @@ void BitVector::setFromBitVector(uint_fast64_t start, BitVector const& other) {
                 STORM_LOG_ERROR("Setting from " << start << " with length " << other.bitCount);
                 std::stringstream stream;
                 printBits(stream);
-                stream << std::endl;
+                stream << '\n';
                 original.printBits(stream);
                 STORM_LOG_ERROR(stream.str());
                 STORM_LOG_ASSERT(false, "Setting of bits not correct.");
@@ -1075,7 +1075,7 @@ void BitVector::printBits(std::ostream& out) const {
             out << tmp[63 - i];
         }
     }
-    out << std::endl;
+    out << '\n';
 }
 
 std::size_t FNV1aBitVectorHash::operator()(storm::storage::BitVector const& bv) const {

--- a/src/storm/storage/FlexibleSparseMatrix.cpp
+++ b/src/storm/storage/FlexibleSparseMatrix.cpp
@@ -303,20 +303,20 @@ std::ostream& operator<<(std::ostream& out, FlexibleSparseMatrix<ValueType> cons
     for (FlexibleIndex i = 0; i < matrix.getColumnCount(); ++i) {
         out << i << "\t";
     }
-    out << std::endl;
+    out << '\n';
 
     if (!matrix.hasTrivialRowGrouping()) {
         // Iterate over all row groups
         FlexibleIndex rowGroupCount = matrix.getRowGroupCount();
         for (FlexibleIndex rowGroup = 0; rowGroup < rowGroupCount; ++rowGroup) {
-            out << "\t---- group " << rowGroup << "/" << (rowGroupCount - 1) << " ---- " << std::endl;
+            out << "\t---- group " << rowGroup << "/" << (rowGroupCount - 1) << " ---- \n";
             FlexibleIndex endRow = matrix.rowGroupIndices[rowGroup + 1];
             // Iterate over all rows.
             for (FlexibleIndex row = matrix.rowGroupIndices[rowGroup]; row < endRow; ++row) {
                 // Print the actual row.
                 out << rowGroup << "\t(\t";
                 matrix.printRow(out, row);
-                out << "\t)\t" << rowGroup << std::endl;
+                out << "\t)\t" << rowGroup << '\n';
             }
         }
 
@@ -326,7 +326,7 @@ std::ostream& operator<<(std::ostream& out, FlexibleSparseMatrix<ValueType> cons
             // Print the actual row.
             out << row << "\t(\t";
             matrix.printRow(out, row);
-            out << "\t)\t" << row << std::endl;
+            out << "\t)\t" << row << '\n';
         }
     }
 
@@ -335,7 +335,7 @@ std::ostream& operator<<(std::ostream& out, FlexibleSparseMatrix<ValueType> cons
     for (FlexibleIndex i = 0; i < matrix.getColumnCount(); ++i) {
         out << i << "\t";
     }
-    out << std::endl;
+    out << '\n';
     return out;
 }
 

--- a/src/storm/storage/Qvbs.cpp
+++ b/src/storm/storage/Qvbs.cpp
@@ -118,22 +118,22 @@ std::string const& QvbsBenchmark::getConstantDefinition(uint64_t instanceIndex) 
 
 std::string QvbsBenchmark::getInfo(uint64_t instanceIndex, boost::optional<std::vector<std::string>> propertyFilter) const {
     std::stringstream s;
-    s << "--------------------------------------------------------------" << std::endl;
+    s << "--------------------------------------------------------------\n";
     s << "QVBS " << getString(modelData["type"]) << "-Benchmark: " << getString(modelData["name"]) << " (" << getString(modelData["short"]) << ") v"
-      << getString(modelData["version"]) << std::endl;
+      << getString(modelData["version"]) << '\n';
     if (instanceInfos.size() == 1) {
-        s << "1 instance:" << std::endl;
+        s << "1 instance:\n";
     } else if (instanceInfos.size() > 1) {
-        s << instanceInfos.size() << " instances:" << std::endl;
+        s << instanceInfos.size() << " instances:\n";
     }
     for (uint64_t i = 0; i < instanceInfos.size(); ++i) {
-        s << "\t" << (i == instanceIndex ? "*" : " ") << i << "\t" << instanceInfos[i] << std::endl;
+        s << "\t" << (i == instanceIndex ? "*" : " ") << i << "\t" << instanceInfos[i] << '\n';
     }
     if (modelData.count("properties") == 1) {
         if (modelData["properties"].size() == 1) {
-            s << "1 property:" << std::endl;
+            s << "1 property:\n";
         } else if (modelData["properties"].size() > 1) {
-            s << modelData["properties"].size() << " properties:" << std::endl;
+            s << modelData["properties"].size() << " properties:\n";
         }
         for (auto const& property : modelData["properties"]) {
             std::string propertyName = getString(property["name"]);
@@ -143,10 +143,10 @@ std::string QvbsBenchmark::getInfo(uint64_t instanceIndex, boost::optional<std::
             } else {
                 s << " ";
             }
-            s << propertyName << " \t(" << getString(property["type"]) << ")" << std::endl;
+            s << propertyName << " \t(" << getString(property["type"]) << ")\n";
         }
     }
-    s << "--------------------------------------------------------------" << std::endl;
+    s << "--------------------------------------------------------------\n";
     return s.str();
 }
 

--- a/src/storm/storage/Scheduler.cpp
+++ b/src/storm/storage/Scheduler.cpp
@@ -180,18 +180,17 @@ void Scheduler<ValueType>::printToStream(std::ostream& out, std::shared_ptr<stor
     widthOfStates = std::max(widthOfStates, (uint_fast64_t)12);
     uint_fast64_t numOfSkippedStatesWithUniqueChoice = 0;
 
-    out << "___________________________________________________________________" << std::endl;
+    out << "___________________________________________________________________\n";
     out << (isPartialScheduler() ? "Partially" : "Fully") << " defined ";
     out << (isMemorylessScheduler() ? "memoryless " : "");
     out << (isDeterministicScheduler() ? "deterministic" : "randomized") << " scheduler";
     if (!isMemorylessScheduler()) {
         out << " with " << getNumberOfMemoryStates() << " memory states";
     }
-    out << ":" << std::endl;
+    out << ":\n";
     STORM_LOG_WARN_COND(!(skipUniqueChoices && model == nullptr), "Can not skip unique choices if the model is not given.");
     out << std::setw(widthOfStates) << "model state:"
-        << "    " << (isMemorylessScheduler() ? "" : " memory:     ") << "choice(s)" << (isMemorylessScheduler() ? "" : "     memory updates:     ")
-        << std::endl;
+        << "    " << (isMemorylessScheduler() ? "" : " memory:     ") << "choice(s)" << (isMemorylessScheduler() ? "" : "     memory updates:     ") << '\n';
     for (uint_fast64_t state = 0; state < schedulerChoices.front().size(); ++state) {
         // Check whether the state is skipped
         if (skipUniqueChoices && model != nullptr && model->getTransitionMatrix().getRowGroupSize(state) == 1) {
@@ -289,13 +288,13 @@ void Scheduler<ValueType>::printToStream(std::ostream& out, std::shared_ptr<stor
                 }
             }
 
-            out << std::endl;
+            out << '\n';
         }
     }
     if (numOfSkippedStatesWithUniqueChoice > 0) {
-        out << "Skipped " << numOfSkippedStatesWithUniqueChoice << " deterministic states with unique choice." << std::endl;
+        out << "Skipped " << numOfSkippedStatesWithUniqueChoice << " deterministic states with unique choice.\n";
     }
-    out << "___________________________________________________________________" << std::endl;
+    out << "___________________________________________________________________\n";
 }
 
 template<>

--- a/src/storm/storage/SparseMatrix.cpp
+++ b/src/storm/storage/SparseMatrix.cpp
@@ -365,7 +365,7 @@ void print(std::vector<typename SparseMatrix<ValueType>::index_type> const& rowG
     typename SparseMatrix<ValueType>::index_type endRows;
     // Iterate over all row groups.
     for (typename SparseMatrix<ValueType>::index_type group = 0; group < rowGroupIndices.size(); ++group) {
-        std::cout << "\t---- group " << group << "/" << (rowGroupIndices.size() - 1) << " ---- " << std::endl;
+        std::cout << "\t---- group " << group << "/" << (rowGroupIndices.size() - 1) << " ---- \n";
         endGroups = group < rowGroupIndices.size() - 1 ? rowGroupIndices[group + 1] : rowIndications.size();
         // Iterate over all rows in a row group
         for (typename SparseMatrix<ValueType>::index_type i = rowGroupIndices[group]; i < endGroups; ++i) {
@@ -376,7 +376,7 @@ void print(std::vector<typename SparseMatrix<ValueType>::index_type> const& rowG
             for (typename SparseMatrix<ValueType>::index_type pos = rowIndications[i]; pos < endRows; ++pos) {
                 std::cout << "(" << columnsAndValues[pos].getColumn() << ": " << columnsAndValues[pos].getValue() << ") ";
             }
-            std::cout << std::endl;
+            std::cout << '\n';
         }
     }
 }
@@ -2478,11 +2478,11 @@ std::ostream& operator<<(std::ostream& out, SparseMatrix<ValueType> const& matri
     for (typename SparseMatrix<ValueType>::index_type i = 0; i < matrix.getColumnCount(); ++i) {
         out << i << "\t";
     }
-    out << std::endl;
+    out << '\n';
 
     // Iterate over all row groups.
     for (typename SparseMatrix<ValueType>::index_type group = 0; group < matrix.getRowGroupCount(); ++group) {
-        out << "\t---- group " << group << "/" << (matrix.getRowGroupCount() - 1) << " ---- " << std::endl;
+        out << "\t---- group " << group << "/" << (matrix.getRowGroupCount() - 1) << " ---- \n";
         typename SparseMatrix<ValueType>::index_type start = matrix.hasTrivialRowGrouping() ? group : matrix.getRowGroupIndices()[group];
         typename SparseMatrix<ValueType>::index_type end = matrix.hasTrivialRowGrouping() ? group + 1 : matrix.getRowGroupIndices()[group + 1];
 
@@ -2501,7 +2501,7 @@ std::ostream& operator<<(std::ostream& out, SparseMatrix<ValueType> const& matri
                 }
                 ++currentRealIndex;
             }
-            out << "\t)\t" << i << std::endl;
+            out << "\t)\t" << i << '\n';
         }
     }
 
@@ -2510,7 +2510,7 @@ std::ostream& operator<<(std::ostream& out, SparseMatrix<ValueType> const& matri
     for (typename SparseMatrix<ValueType>::index_type i = 0; i < matrix.getColumnCount(); ++i) {
         out << i << "\t";
     }
-    out << std::endl;
+    out << '\n';
 
     return out;
 }
@@ -2535,7 +2535,7 @@ void SparseMatrix<ValueType>::printAsMatlabMatrix(std::ostream& out) const {
                 }
                 ++currentRealIndex;
             }
-            out << ";" << std::endl;
+            out << ";\n";
         }
     }
 }

--- a/src/storm/storage/bisimulation/BisimulationDecomposition.cpp
+++ b/src/storm/storage/bisimulation/BisimulationDecomposition.cpp
@@ -243,15 +243,13 @@ void BisimulationDecomposition<ModelType, BlockDataType>::computeBisimulationDec
         std::chrono::milliseconds extractionTimeInMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(extractionTime);
         std::chrono::milliseconds quotientBuildTimeInMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(quotientBuildTime);
         std::chrono::milliseconds totalTimeInMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(totalTime);
-        std::cout << std::endl;
-        std::cout << "Time breakdown:" << std::endl;
-        std::cout << "    * time for initial partition: " << initialPartitionTimeInMilliseconds.count() << "ms" << std::endl;
-        std::cout << "    * time for partitioning: " << refinementTimeInMilliseconds.count() << "ms" << std::endl;
-        std::cout << "    * time for extraction: " << extractionTimeInMilliseconds.count() << "ms" << std::endl;
-        std::cout << "    * time for building quotient: " << quotientBuildTimeInMilliseconds.count() << "ms" << std::endl;
-        std::cout << "------------------------------------------" << std::endl;
-        std::cout << "    * total time: " << totalTimeInMilliseconds.count() << "ms" << std::endl;
-        std::cout << std::endl;
+        std::cout << "\nTime breakdown:\n";
+        std::cout << "    * time for initial partition: " << initialPartitionTimeInMilliseconds.count() << "ms\n";
+        std::cout << "    * time for partitioning: " << refinementTimeInMilliseconds.count() << "ms\n";
+        std::cout << "    * time for extraction: " << extractionTimeInMilliseconds.count() << "ms\n";
+        std::cout << "    * time for building quotient: " << quotientBuildTimeInMilliseconds.count() << "ms\n";
+        std::cout << "------------------------------------------\n";
+        std::cout << "    * total time: " << totalTimeInMilliseconds.count() << "ms\n\n";
     }
 }
 
@@ -282,7 +280,7 @@ void BisimulationDecomposition<ModelType, BlockDataType>::performPartitionRefine
         refinePartitionBasedOnSplitter(*splitter, splitterQueue);
 
         if (storm::utility::resources::isTerminate()) {
-            std::cout << "Performed " << iterations << " iterations of partition refinement before abort." << std::endl;
+            std::cout << "Performed " << iterations << " iterations of partition refinement before abort.\n";
             STORM_LOG_THROW(false, storm::exceptions::AbortException, "Aborted in bisimulation computation.");
             break;
         }

--- a/src/storm/storage/bisimulation/Block.cpp
+++ b/src/storm/storage/bisimulation/Block.cpp
@@ -38,13 +38,12 @@ bool Block<DataType>::operator!=(Block const& other) const {
 
 template<typename DataType>
 void Block<DataType>::print(Partition<DataType> const& partition) const {
-    std::cout << "block [" << this << "] " << this->id << " from " << this->beginIndex << " to " << this->endIndex << " with data [" << this->data() << "]"
-              << std::endl;
+    std::cout << "block [" << this << "] " << this->id << " from " << this->beginIndex << " to " << this->endIndex << " with data [" << this->data() << "]\n";
     std::cout << "states ";
     for (auto stateIt = partition.begin(*this), stateIte = partition.end(*this); stateIt != stateIte; ++stateIt) {
         std::cout << *stateIt << ", ";
     }
-    std::cout << std::endl;
+    std::cout << '\n';
 }
 
 template<typename DataType>

--- a/src/storm/storage/bisimulation/NondeterministicModelBisimulationDecomposition.cpp
+++ b/src/storm/storage/bisimulation/NondeterministicModelBisimulationDecomposition.cpp
@@ -301,8 +301,8 @@ bool NondeterministicModelBisimulationDecomposition<ModelType>::checkQuotientDis
             }
 
             if (!distribution.equals(quotientDistributions[choice])) {
-                std::cout << "the distributions for choice " << choice << " of state " << state << " do not match." << std::endl;
-                std::cout << "is: " << quotientDistributions[choice] << " but should be " << distribution << std::endl;
+                std::cout << "the distributions for choice " << choice << " of state " << state << " do not match.\n";
+                std::cout << "is: " << quotientDistributions[choice] << " but should be " << distribution << '\n';
                 exit(-1);
             }
 
@@ -310,16 +310,16 @@ bool NondeterministicModelBisimulationDecomposition<ModelType>::checkQuotientDis
             bool less2 = quotientDistributions[choice].less(distribution, this->comparator);
 
             if (distribution.equals(quotientDistributions[choice]) && (less1 || less2)) {
-                std::cout << "mismatch of equality and less for " << std::endl;
-                std::cout << quotientDistributions[choice] << " vs " << distribution << std::endl;
+                std::cout << "mismatch of equality and less for \n";
+                std::cout << quotientDistributions[choice] << " vs " << distribution << '\n';
                 exit(-1);
             }
         }
 
         for (auto choice = nondeterministicChoiceIndices[state]; choice < nondeterministicChoiceIndices[state + 1] - 1; ++choice) {
             if (orderedQuotientDistributions[choice + 1]->less(*orderedQuotientDistributions[choice], this->comparator)) {
-                std::cout << "choice " << (choice + 1) << " is less than predecessor" << std::endl;
-                std::cout << *orderedQuotientDistributions[choice] << " should be less than " << *orderedQuotientDistributions[choice + 1] << std::endl;
+                std::cout << "choice " << (choice + 1) << " is less than predecessor\n";
+                std::cout << *orderedQuotientDistributions[choice] << " should be less than " << *orderedQuotientDistributions[choice + 1] << '\n';
                 exit(-1);
             }
         }
@@ -331,25 +331,25 @@ template<typename ModelType>
 bool NondeterministicModelBisimulationDecomposition<ModelType>::printDistributions(uint_fast64_t state) const {
     std::vector<uint_fast64_t> nondeterministicChoiceIndices = this->model.getTransitionMatrix().getRowGroupIndices();
     for (auto choice = nondeterministicChoiceIndices[state]; choice < nondeterministicChoiceIndices[state + 1]; ++choice) {
-        std::cout << quotientDistributions[choice] << std::endl;
+        std::cout << quotientDistributions[choice] << '\n';
     }
     return true;
 }
 
 template<typename ModelType>
 bool NondeterministicModelBisimulationDecomposition<ModelType>::checkBlockStable(bisimulation::Block<BlockDataType> const& newBlock) const {
-    std::cout << "checking stability of new block " << newBlock.getId() << " of size " << newBlock.getNumberOfStates() << std::endl;
+    std::cout << "checking stability of new block " << newBlock.getId() << " of size " << newBlock.getNumberOfStates() << '\n';
     for (auto stateIt1 = this->partition.begin(newBlock), stateIte1 = this->partition.end(newBlock); stateIt1 != stateIte1; ++stateIt1) {
         for (auto stateIt2 = this->partition.begin(newBlock), stateIte2 = this->partition.end(newBlock); stateIt2 != stateIte2; ++stateIt2) {
             bool less1 = quotientDistributionsLess(*stateIt1, *stateIt2);
             bool less2 = quotientDistributionsLess(*stateIt2, *stateIt1);
             if (less1 || less2) {
-                std::cout << "the partition is not stable for the states " << *stateIt1 << " and " << *stateIt2 << std::endl;
-                std::cout << "less1 " << less1 << " and less2 " << less2 << std::endl;
+                std::cout << "the partition is not stable for the states " << *stateIt1 << " and " << *stateIt2 << '\n';
+                std::cout << "less1 " << less1 << " and less2 " << less2 << '\n';
 
-                std::cout << "distributions of state " << *stateIt1 << std::endl;
+                std::cout << "distributions of state " << *stateIt1 << '\n';
                 this->printDistributions(*stateIt1);
-                std::cout << "distributions of state " << *stateIt2 << std::endl;
+                std::cout << "distributions of state " << *stateIt2 << '\n';
                 this->printDistributions(*stateIt2);
                 exit(-1);
             }
@@ -364,12 +364,12 @@ bool NondeterministicModelBisimulationDecomposition<ModelType>::checkDistributio
     for (auto stateIt1 = this->partition.begin(block), stateIte1 = this->partition.end(block); stateIt1 != stateIte1; ++stateIt1) {
         for (auto stateIt2 = this->partition.begin() + block.getEndIndex(), stateIte2 = this->partition.begin() + end; stateIt2 != stateIte2; ++stateIt2) {
             if (!quotientDistributionsLess(*stateIt1, *stateIt2)) {
-                std::cout << "distributions are not less, even though they should be!" << std::endl;
+                std::cout << "distributions are not less, even though they should be!\n";
                 exit(-3);
             } else {
-                std::cout << "less:" << std::endl;
+                std::cout << "less:\n";
                 this->printDistributions(*stateIt1);
-                std::cout << "and" << std::endl;
+                std::cout << "and\n";
                 this->printDistributions(*stateIt2);
             }
         }

--- a/src/storm/storage/bisimulation/Partition.cpp
+++ b/src/storm/storage/bisimulation/Partition.cpp
@@ -348,20 +348,19 @@ void Partition<DataType>::print() const {
     for (auto const& block : this->blocks) {
         block->print(*this);
     }
-    std::cout << "states in partition" << std::endl;
+    std::cout << "states in partition\n";
     for (auto const& state : states) {
         std::cout << state << " ";
     }
-    std::cout << std::endl << "positions: " << std::endl;
+    std::cout << "\npositions: \n";
     for (auto const& index : positions) {
         std::cout << index << " ";
     }
-    std::cout << std::endl << "state to block mapping: " << std::endl;
+    std::cout << "\nstate to block mapping: \n";
     for (auto const& block : stateToBlockMapping) {
         std::cout << block << "[" << block->getId() << "] ";
     }
-    std::cout << std::endl;
-    std::cout << "size: " << blocks.size() << std::endl;
+    std::cout << "\nsize: " << blocks.size() << '\n';
     STORM_LOG_ASSERT(this->check(), "Partition corrupted.");
 }
 

--- a/src/storm/storage/dd/Add.cpp
+++ b/src/storm/storage/dd/Add.cpp
@@ -1165,12 +1165,12 @@ AddIterator<LibraryType, ValueType> Add<LibraryType, ValueType>::end() const {
 template<DdType LibraryType, typename ValueType>
 std::ostream& operator<<(std::ostream& out, Add<LibraryType, ValueType> const& add) {
     out << "ADD [" << add.getInternalAdd().getStringId() << "] with " << add.getNonZeroCount() << " nnz, " << add.getNodeCount() << " nodes, "
-        << add.getLeafCount() << " leaves" << std::endl;
+        << add.getLeafCount() << " leaves\n";
     std::vector<std::string> variableNames;
     for (auto const& variable : add.getContainedMetaVariables()) {
         variableNames.push_back(variable.getName());
     }
-    out << "contained variables: " << boost::algorithm::join(variableNames, ", ") << std::endl;
+    out << "contained variables: " << boost::algorithm::join(variableNames, ", ") << '\n';
     return out;
 }
 

--- a/src/storm/storage/dd/Odd.cpp
+++ b/src/storm/storage/dd/Odd.cpp
@@ -129,41 +129,43 @@ void Odd::exportToDot(std::string const& filename) const {
     storm::utility::openFile(filename, dotFile);
 
     // Print header.
-    dotFile << "digraph \"ODD\" {" << std::endl << "center=true;" << std::endl << "edge [dir = none];" << std::endl;
+    dotFile << "digraph \"ODD\" {\n"
+            << "center=true;\n"
+            << "edge [dir = none];\n";
 
     // Print levels as ranks.
-    dotFile << "{ node [shape = plaintext];" << std::endl << "edge [style = invis];" << std::endl;
+    dotFile << "{ node [shape = plaintext];\n"
+            << "edge [style = invis];\n";
     std::vector<std::string> levelNames;
     for (uint_fast64_t level = 0; level < this->getHeight(); ++level) {
         levelNames.push_back("\"" + std::to_string(level) + "\"");
     }
     dotFile << boost::join(levelNames, " -> ") << ";";
-    dotFile << "}" << std::endl;
+    dotFile << "}\n";
 
     std::map<uint_fast64_t, std::unordered_set<storm::dd::Odd const*>> levelToOddNodesMap;
     this->addToLevelToOddNodesMap(levelToOddNodesMap);
 
     for (auto const& levelNodes : levelToOddNodesMap) {
-        dotFile << "{ rank = same; \"" << levelNodes.first << "\"" << std::endl;
+        dotFile << "{ rank = same; \"" << levelNodes.first << "\"\n";
         ;
         for (auto const& node : levelNodes.second) {
-            dotFile << "\"" << node << "\";" << std::endl;
+            dotFile << "\"" << node << "\";\n";
         }
-        dotFile << "}" << std::endl;
+        dotFile << "}\n";
     }
 
     for (auto const& levelNodes : levelToOddNodesMap) {
         for (auto const& node : levelNodes.second) {
-            dotFile << "\"" << node << "\" [label=\"" << node->getTotalOffset() << "\"];" << std::endl;
+            dotFile << "\"" << node << "\" [label=\"" << node->getTotalOffset() << "\"];\n";
             if (!node->isTerminalNode()) {
-                dotFile << "\"" << node << "\" -> \"" << &node->getElseSuccessor() << "\" [style=dashed, label=\"0\"];" << std::endl;
-                dotFile << "\"" << node << "\" -> \"" << &node->getThenSuccessor() << "\" [style=solid, label=\"" << node->getElseOffset() << "\"];"
-                        << std::endl;
+                dotFile << "\"" << node << "\" -> \"" << &node->getElseSuccessor() << "\" [style=dashed, label=\"0\"];\n";
+                dotFile << "\"" << node << "\" -> \"" << &node->getThenSuccessor() << "\" [style=solid, label=\"" << node->getElseOffset() << "\"];\n";
             }
         }
     }
 
-    dotFile << "}" << std::endl;
+    dotFile << "}\n";
     storm::utility::closeFile(dotFile);
 }
 

--- a/src/storm/storage/expressions/ExpressionManager.cpp
+++ b/src/storm/storage/expressions/ExpressionManager.cpp
@@ -345,14 +345,14 @@ std::shared_ptr<ExpressionManager const> ExpressionManager::getSharedPointer() c
 }
 
 std::ostream& operator<<(std::ostream& out, ExpressionManager const& manager) {
-    out << "manager {" << std::endl;
+    out << "manager {\n";
 
     for (auto const& variableTypePair : manager) {
         out << "\t" << variableTypePair.second << " " << variableTypePair.first.getName() << " [offset " << variableTypePair.first.getOffset() << ", "
-            << variableTypePair.first.getIndex() << " ]" << std::endl;
+            << variableTypePair.first.getIndex() << " ]\n";
     }
 
-    out << "}" << std::endl;
+    out << "}\n";
 
     return out;
 }

--- a/src/storm/storage/expressions/SimpleValuation.cpp
+++ b/src/storm/storage/expressions/SimpleValuation.cpp
@@ -124,25 +124,25 @@ std::string SimpleValuation::toString(bool pretty) const {
         return toPrettyString(allVariables);
     } else {
         std::stringstream sstr;
-        sstr << "[" << std::endl;
-        sstr << getManager() << std::endl;
+        sstr << "[\n";
+        sstr << getManager() << '\n';
         if (!booleanValues.empty()) {
             for (auto element : booleanValues) {
                 sstr << element << " ";
             }
-            sstr << std::endl;
+            sstr << '\n';
         }
         if (!integerValues.empty()) {
             for (auto const& element : integerValues) {
                 sstr << element << " ";
             }
-            sstr << std::endl;
+            sstr << '\n';
         }
         if (!rationalValues.empty()) {
             for (auto const& element : rationalValues) {
                 sstr << element << " ";
             }
-            sstr << std::endl;
+            sstr << '\n';
         }
         sstr << "]";
         return sstr.str();
@@ -166,7 +166,7 @@ typename SimpleValuation::Json SimpleValuation::toJson() const {
 }
 
 std::ostream& operator<<(std::ostream& out, SimpleValuation const& valuation) {
-    out << valuation.toString(false) << std::endl;
+    out << valuation.toString(false) << '\n';
     return out;
 }
 

--- a/src/storm/storage/geometry/Polytope.cpp
+++ b/src/storm/storage/geometry/Polytope.cpp
@@ -241,9 +241,9 @@ template<typename ValueType>
 std::string Polytope<ValueType>::toString(bool numbersAsDouble) const {
     auto halfspaces = this->getHalfspaces();
     std::stringstream stream;
-    stream << "Polytope with " << halfspaces.size() << " Halfspaces" << (halfspaces.empty() ? "" : ":") << std::endl;
+    stream << "Polytope with " << halfspaces.size() << " Halfspaces" << (halfspaces.empty() ? "" : ":") << '\n';
     for (auto const& h : halfspaces) {
-        stream << "   " << h.toString(numbersAsDouble) << std::endl;
+        stream << "   " << h.toString(numbersAsDouble) << '\n';
     }
     return stream.str();
 }

--- a/src/storm/storage/geometry/PolytopeTree.h
+++ b/src/storm/storage/geometry/PolytopeTree.h
@@ -142,7 +142,7 @@ class PolytopeTree {
             return "Empty PolytopeTree";
         }
         std::stringstream s;
-        s << "PolytopeTree node with " << getChildren().size() << " children: " << getPolytope()->toString(true) << std::endl << "Vertices: ";
+        s << "PolytopeTree node with " << getChildren().size() << " children: " << getPolytope()->toString(true) << "\nVertices: ";
         auto vertices = getPolytope()->getVertices();
         for (auto const& v : vertices) {
             s << "[";
@@ -151,7 +151,7 @@ class PolytopeTree {
             }
             s << "]\t";
         }
-        s << std::endl;
+        s << '\n';
         return s.str();
     }
 

--- a/src/storm/storage/geometry/ReduceVertexCloud.cpp
+++ b/src/storm/storage/geometry/ReduceVertexCloud.cpp
@@ -59,7 +59,7 @@ std::pair<storm::storage::BitVector, bool> ReduceVertexCloud<ValueType>::elimina
     storm::storage::BitVector vertices(input.size());
     for (uint64_t pointIndex = 0; pointIndex < input.size(); ++pointIndex) {
 #ifdef _DEBUG_REUCE_VERTEX_CLOUD
-        std::cout << pointIndex << " out of " << input.size() << std::endl;
+        std::cout << pointIndex << " out of " << input.size() << '\n';
 #endif
         smtSolver->push();
         std::map<uint64_t, std::vector<storm::expressions::Expression>> dimensionTerms;
@@ -90,7 +90,7 @@ std::pair<storm::storage::BitVector, bool> ReduceVertexCloud<ValueType>::elimina
 #ifdef _DEBUG_REDUCE_VERTEX_CLOUD
             if (input[pointIndex].size() == 2) {
                 std::cout << "point " << toString(input[pointIndex]) << " is a vertex:";
-                std::cout << smtSolver->getSmtLibString() << std::endl;
+                std::cout << smtSolver->getSmtLibString() << '\n';
             }
 #endif
             vertices.set(pointIndex, true);
@@ -106,7 +106,7 @@ std::pair<storm::storage::BitVector, bool> ReduceVertexCloud<ValueType>::elimina
                 }
                 varIndex++;
             }
-            std::cout << std::endl;
+            std::cout << '\n';
         }
         if (timeOut >)
 #endif
@@ -118,8 +118,8 @@ std::pair<storm::storage::BitVector, bool> ReduceVertexCloud<ValueType>::elimina
             }
         smtSolver->pop();
 #ifdef _DEBUG_REDUCE_VERTEX_CLOUD
-        std::cout << "Solver time " << solverTime.getTimeInMilliseconds() << std::endl;
-        std::cout << "Total time " << totalTime.getTimeInMilliseconds() << std::endl;
+        std::cout << "Solver time " << solverTime.getTimeInMilliseconds() << '\n';
+        std::cout << "Total time " << totalTime.getTimeInMilliseconds() << '\n';
 #endif
     }
     return {vertices, false};

--- a/src/storm/storage/jani/Automaton.cpp
+++ b/src/storm/storage/jani/Automaton.cpp
@@ -575,18 +575,18 @@ void Automaton::restrictToEdges(storm::storage::FlatSet<uint_fast64_t> const& ed
 }
 
 void Automaton::writeDotToStream(std::ostream& outStream, std::vector<std::string> const& actionNames) const {
-    outStream << "\tsubgraph " << name << " {" << std::endl;
+    outStream << "\tsubgraph " << name << " {\n";
 
     // Write all locations to the stream.
     uint64_t locIndex = 0;
     for (auto const& loc : locations) {
-        outStream << "\t" << name << "_s" << locIndex << "[ label=\"" << loc.getName() << "\"];" << std::endl;
+        outStream << "\t" << name << "_s" << locIndex << "[ label=\"" << loc.getName() << "\"];\n";
         ++locIndex;
     }
     // Write for each edge an node to the stream;
     uint64_t edgeIndex = 0;
     for (auto const& edge : edges) {
-        outStream << "\t" << name << "_e" << edgeIndex << "[ label=\"\" , shape=circle, width=.2, style=filled, fillcolor=\"black\"];" << std::endl;
+        outStream << "\t" << name << "_e" << edgeIndex << "[ label=\"\" , shape=circle, width=.2, style=filled, fillcolor=\"black\"];\n";
         ++edgeIndex;
 
         // Silencing unused variable warning.
@@ -597,14 +597,14 @@ void Automaton::writeDotToStream(std::ostream& outStream, std::vector<std::strin
     edgeIndex = 0;
     for (auto const& edge : edges) {
         outStream << "\t" << name << "_s" << edge.getSourceLocationIndex() << " -> " << name << "_e" << edgeIndex << " [label=\""
-                  << actionNames.at(edge.getActionIndex()) << "\"];" << std::endl;
+                  << actionNames.at(edge.getActionIndex()) << "\"];\n";
         for (auto const& edgeDest : edge.getDestinations()) {
-            outStream << "\t" << name << "_e" << edgeIndex << " -> " << name << "_s" << edgeDest.getLocationIndex() << ";" << std::endl;
+            outStream << "\t" << name << "_e" << edgeIndex << " -> " << name << "_s" << edgeDest.getLocationIndex() << ";\n";
         }
         ++edgeIndex;
     }
 
-    outStream << "\t}" << std::endl;
+    outStream << "\t}\n";
 }
 }  // namespace jani
 }  // namespace storm

--- a/src/storm/storage/jani/Edge.cpp
+++ b/src/storm/storage/jani/Edge.cpp
@@ -181,11 +181,11 @@ std::ostream& operator<<(std::ostream& stream, Edge const& edge) {
     if (edge.getDestinations().empty()) {
         stream << "without any destination";
     } else {
-        stream << " to ... [" << std::endl;
+        stream << " to ... [\n";
         for (auto const& dest : edge.getDestinations()) {
             stream << "\tlocation_id: " << dest.getLocationIndex() << " with probability '" << dest.getProbability() << "' and updates: ";
             if (dest.getOrderedAssignments().empty()) {
-                stream << "none" << std::endl;
+                stream << "none\n";
             }
             bool first = true;
             for (auto const& a : dest.getOrderedAssignments()) {

--- a/src/storm/storage/jani/Model.cpp
+++ b/src/storm/storage/jani/Model.cpp
@@ -1627,7 +1627,7 @@ std::string filterName(std::string const& text) {
 }
 
 void Model::writeDotToStream(std::ostream& outStream) const {
-    outStream << "digraph " << filterName(name) << " {" << std::endl;
+    outStream << "digraph " << filterName(name) << " {\n";
 
     std::vector<std::string> actionNames;
     for (auto const& act : actions) {
@@ -1636,7 +1636,7 @@ void Model::writeDotToStream(std::ostream& outStream) const {
 
     for (auto const& automaton : automata) {
         automaton.writeDotToStream(outStream, actionNames);
-        outStream << std::endl;
+        outStream << '\n';
     }
 
     outStream << "}";

--- a/src/storm/storage/jani/OrderedAssignments.cpp
+++ b/src/storm/storage/jani/OrderedAssignments.cpp
@@ -307,9 +307,9 @@ bool OrderedAssignments::checkOrder() const {
 }
 
 std::ostream& operator<<(std::ostream& stream, OrderedAssignments const& assignments) {
-    stream << "[" << std::endl;
+    stream << "[\n";
     for (auto const& e : assignments.allAssignments) {
-        stream << "\t" << *e << std::endl;
+        stream << "\t" << *e << '\n';
     }
     stream << "]";
     return stream;

--- a/src/storm/storage/jani/eliminator/ArrayEliminator.cpp
+++ b/src/storm/storage/jani/eliminator/ArrayEliminator.cpp
@@ -507,11 +507,9 @@ class ArrayExpressionEliminationVisitor : public storm::expressions::ExpressionV
         ArrayAccessIndices arrayAccessIndices;
         auto res = boost::any_cast<ResultType>(expression.accept(*this, &arrayAccessIndices));
         if (!res.isArrayOutOfBounds()) {
-            STORM_LOG_ASSERT(!containsArrayExpression(res.expr()->toExpression()),
-                             "Expression still contains array expressions. Before: " << std::endl
-                                                                                     << expression << std::endl
-                                                                                     << "After:" << std::endl
-                                                                                     << res.expr()->toExpression());
+            STORM_LOG_ASSERT(!containsArrayExpression(res.expr()->toExpression()), "Expression still contains array expressions. Before: \n"
+                                                                                       << expression << "\nAfter:\n"
+                                                                                       << res.expr()->toExpression());
             res.expr() = res.expr()->simplify();
         }
 

--- a/src/storm/storage/jani/localeliminator/UnfoldDependencyGraph.cpp
+++ b/src/storm/storage/jani/localeliminator/UnfoldDependencyGraph.cpp
@@ -215,28 +215,27 @@ UnfoldDependencyGraph::VariableInfo::VariableInfo(std::string expressionVariable
 void UnfoldDependencyGraph::printGroups() {
     int groupCounter = 0;
     for (const auto &group : variableGroups) {
-        std::cout << std::endl << "Variable Group " << groupCounter << std::endl;
+        std::cout << "\nVariable Group " << groupCounter << '\n';
         if (group.allVariablesUnfoldable) {
-            std::cout << "\tDomain size: " << group.domainSize << std::endl;
-            std::cout << "\tCan be unfolded" << std::endl;
+            std::cout << "\tDomain size: " << group.domainSize << '\n';
+            std::cout << "\tCan be unfolded\n";
         } else {
-            std::cout << "\tCan not be unfolded" << std::endl;
+            std::cout << "\tCan not be unfolded\n";
         }
-        std::cout << "\tVariables:" << std::endl;
+        std::cout << "\tVariables:\n";
         for (const auto &var : group.variables) {
             std::cout << "\t\t" << var.expressionVariableName;
             if (var.isConstBoundedInteger)
-                std::cout << " (const-bounded integer with domain size " << var.domainSize << ")";
+                std::cout << " (const-bounded integer with domain size " << var.domainSize << ")\n";
             else
-                std::cout << " (not a const-bounded integer)";
-            std::cout << std::endl;
+                std::cout << " (not a const-bounded integer)\n";
         }
         if (group.dependencies.empty())
-            std::cout << "\tNo Dependencies" << std::endl;
+            std::cout << "\tNo Dependencies\n";
         else
-            std::cout << "\tDependencies:" << std::endl;
+            std::cout << "\tDependencies:\n";
         for (auto dep : group.dependencies) {
-            std::cout << "\t\t" << dep << std::endl;
+            std::cout << "\t\t" << dep << '\n';
         }
 
         groupCounter++;

--- a/src/storm/storage/jani/visitor/JSONExporter.cpp
+++ b/src/storm/storage/jani/visitor/JSONExporter.cpp
@@ -793,11 +793,11 @@ void JsonExporter::toStream(storm::jani::Model const& janiModel, std::vector<sto
     if (compact) {
         // Dump without line breaks/indents
         STORM_LOG_INFO("Producing compact json output... " << janiModel.getName() << ".");
-        os << exporter.finalize().dump() << std::endl;
+        os << exporter.finalize().dump() << '\n';
     } else {
         // Dump with line breaks and indention with 4 spaces
         STORM_LOG_INFO("Producing json output... " << janiModel.getName() << ".");
-        os << exporter.finalize().dump(4) << std::endl;
+        os << exporter.finalize().dump(4) << '\n';
     }
     STORM_LOG_INFO("Conversion completed " << janiModel.getName() << ".");
 }

--- a/src/storm/storage/memorystructure/MemoryStructure.cpp
+++ b/src/storm/storage/memorystructure/MemoryStructure.cpp
@@ -143,7 +143,7 @@ SparseModelMemoryProduct<ValueType, RewardModelType> MemoryStructure::product(
 std::string MemoryStructure::toString() const {
     std::stringstream stream;
 
-    stream << "Memory Structure with " << getNumberOfStates() << " states: " << std::endl;
+    stream << "Memory Structure with " << getNumberOfStates() << " states: \n";
 
     for (uint_fast64_t state = 0; state < getNumberOfStates(); ++state) {
         stream << "State " << state << ": Labels = {";
@@ -155,7 +155,7 @@ std::string MemoryStructure::toString() const {
             firstLabel = false;
             stream << label;
         }
-        stream << "}, Transitions: " << std::endl;
+        stream << "}, Transitions: \n";
         for (uint_fast64_t transitionTarget = 0; transitionTarget < getNumberOfStates(); ++transitionTarget) {
             stream << "\t From " << state << " to " << transitionTarget << ": \t";
             auto const& transition = getTransitionMatrix()[state][transitionTarget];
@@ -164,7 +164,7 @@ std::string MemoryStructure::toString() const {
             } else {
                 stream << "false";
             }
-            stream << std::endl;
+            stream << '\n';
         }
     }
 

--- a/src/storm/storage/prism/InitialConstruct.cpp
+++ b/src/storm/storage/prism/InitialConstruct.cpp
@@ -17,9 +17,9 @@ InitialConstruct InitialConstruct::substitute(std::map<storm::expressions::Varia
 }
 
 std::ostream& operator<<(std::ostream& stream, InitialConstruct const& initialConstruct) {
-    stream << "init " << std::endl;
-    stream << "\t" << initialConstruct.getInitialStatesExpression() << std::endl;
-    stream << "endinit" << std::endl;
+    stream << "init \n";
+    stream << "\t" << initialConstruct.getInitialStatesExpression() << '\n';
+    stream << "endinit\n";
     return stream;
 }
 }  // namespace prism

--- a/src/storm/storage/prism/Module.cpp
+++ b/src/storm/storage/prism/Module.cpp
@@ -378,20 +378,20 @@ storm::expressions::Expression const& Module::getInvariant() const {
 }
 
 std::ostream& operator<<(std::ostream& stream, Module const& module) {
-    stream << "module " << module.getName() << std::endl;
+    stream << "module " << module.getName() << '\n';
     for (auto const& booleanVariable : module.getBooleanVariables()) {
-        stream << "\t" << booleanVariable << std::endl;
+        stream << "\t" << booleanVariable << '\n';
     }
     for (auto const& integerVariable : module.getIntegerVariables()) {
-        stream << "\t" << integerVariable << std::endl;
+        stream << "\t" << integerVariable << '\n';
     }
     for (auto const& clockVariable : module.getClockVariables()) {
-        stream << "\t" << clockVariable << std::endl;
+        stream << "\t" << clockVariable << '\n';
     }
     for (auto const& command : module.getCommands()) {
-        stream << "\t" << command << std::endl;
+        stream << "\t" << command << '\n';
     }
-    stream << "endmodule" << std::endl;
+    stream << "endmodule\n";
     return stream;
 }
 

--- a/src/storm/storage/prism/Player.cpp
+++ b/src/storm/storage/prism/Player.cpp
@@ -33,7 +33,7 @@ std::ostream& operator<<(std::ostream& stream, Player const& player) {
         } else {
             stream << ",";
         }
-        stream << std::endl << "\t" << module;
+        stream << "\n\t" << module;
     }
     for (auto const& action : player.getActions()) {
         if (firstElement) {
@@ -41,9 +41,9 @@ std::ostream& operator<<(std::ostream& stream, Player const& player) {
         } else {
             stream << ",";
         }
-        stream << std::endl << "\t[" << action << "]";
+        stream << "\n\t[" << action << "]";
     }
-    stream << std::endl << "endplayer" << std::endl;
+    stream << "\nendplayer\n";
     return stream;
 }
 }  // namespace prism

--- a/src/storm/storage/prism/Program.cpp
+++ b/src/storm/storage/prism/Program.cpp
@@ -2354,43 +2354,43 @@ std::ostream& operator<<(std::ostream& out, Program::ModelType const& type) {
 }
 
 std::ostream& operator<<(std::ostream& stream, Program const& program) {
-    stream << program.getModelType() << std::endl;
+    stream << program.getModelType() << '\n';
     for (auto const& constant : program.getConstants()) {
-        stream << constant << std::endl;
+        stream << constant << '\n';
     }
-    stream << std::endl;
+    stream << '\n';
 
     for (auto const& player : program.getPlayers()) {
-        stream << player << std::endl;
+        stream << player << '\n';
     }
 
     for (auto const& variable : program.getGlobalBooleanVariables()) {
-        stream << "global " << variable << std::endl;
+        stream << "global " << variable << '\n';
     }
     for (auto const& variable : program.getGlobalIntegerVariables()) {
-        stream << "global " << variable << std::endl;
+        stream << "global " << variable << '\n';
     }
-    stream << std::endl;
+    stream << '\n';
 
     for (auto const& formula : program.getFormulas()) {
-        stream << formula << std::endl;
+        stream << formula << '\n';
     }
-    stream << std::endl;
+    stream << '\n';
 
     for (auto const& module : program.getModules()) {
-        stream << module << std::endl;
+        stream << module << '\n';
     }
 
     for (auto const& rewardModel : program.getRewardModels()) {
-        stream << rewardModel << std::endl;
+        stream << rewardModel << '\n';
     }
 
     for (auto const& label : program.getLabels()) {
-        stream << label << std::endl;
+        stream << label << '\n';
     }
 
     if (program.hasInitialConstruct()) {
-        stream << program.getInitialConstruct() << std::endl;
+        stream << program.getInitialConstruct() << '\n';
     }
 
     if (program.specifiesSystemComposition()) {

--- a/src/storm/storage/prism/RewardModel.cpp
+++ b/src/storm/storage/prism/RewardModel.cpp
@@ -131,17 +131,17 @@ std::ostream& operator<<(std::ostream& stream, RewardModel const& rewardModel) {
     if (rewardModel.getName() != "") {
         stream << " \"" << rewardModel.getName() << "\"";
     }
-    stream << std::endl;
+    stream << '\n';
     for (auto const& reward : rewardModel.getStateRewards()) {
-        stream << reward << std::endl;
+        stream << reward << '\n';
     }
     for (auto const& reward : rewardModel.getStateActionRewards()) {
-        stream << reward << std::endl;
+        stream << reward << '\n';
     }
     for (auto const& reward : rewardModel.getTransitionRewards()) {
-        stream << reward << std::endl;
+        stream << reward << '\n';
     }
-    stream << "endrewards" << std::endl;
+    stream << "endrewards\n";
     return stream;
 }
 

--- a/src/storm/storage/prism/SystemCompositionConstruct.cpp
+++ b/src/storm/storage/prism/SystemCompositionConstruct.cpp
@@ -13,9 +13,9 @@ Composition const& SystemCompositionConstruct::getSystemComposition() const {
 }
 
 std::ostream& operator<<(std::ostream& stream, SystemCompositionConstruct const& systemCompositionConstruct) {
-    stream << "system" << std::endl;
-    stream << "\t" << systemCompositionConstruct.getSystemComposition() << std::endl;
-    stream << "endsystem" << std::endl;
+    stream << "system\n";
+    stream << "\t" << systemCompositionConstruct.getSystemComposition() << '\n';
+    stream << "endsystem\n";
     return stream;
 }
 

--- a/src/storm/storage/sparse/JaniChoiceOrigins.cpp
+++ b/src/storm/storage/sparse/JaniChoiceOrigins.cpp
@@ -49,7 +49,7 @@ void JaniChoiceOrigins::computeIdentifierInfos() const {
         for (auto const& edgeIndex : edgeSet) {
             auto autAndEdgeOffset = model->decodeAutomatonAndEdgeIndices(edgeIndex);
             ss << model->getAutomaton(autAndEdgeOffset.first).getEdge(autAndEdgeOffset.second).toString();
-            ss << "," << std::endl;
+            ss << ",\n";
         }
         this->identifierToInfo.emplace_back(ss.str());
         ss.clear();

--- a/src/storm/utility/ProgressMeasurement.cpp
+++ b/src/storm/utility/ProgressMeasurement.cpp
@@ -43,7 +43,7 @@ bool ProgressMeasurement::updateProgress(uint64_t count, std::ostream& outstream
         double itemsPerSecond = (static_cast<double>(count - this->lastDisplayedCount) * 1000.0 / static_cast<double>(durationSinceLastMessage));
         outstream << "Completed " << count << " " << itemName << " " << (this->isMaxCountSet() ? "(out of " + std::to_string(this->getMaxCount()) + ") " : "")
                   << "in " << std::chrono::duration_cast<std::chrono::seconds>(now - timeOfStart).count() << "s (currently " << itemsPerSecond << " "
-                  << itemName << " per second)." << std::endl;
+                  << itemName << " per second).\n";
         timeOfLastMessage = std::chrono::high_resolution_clock::now();
         lastDisplayedCount = count;
         return true;

--- a/src/storm/utility/SignalHandler.cpp
+++ b/src/storm/utility/SignalHandler.cpp
@@ -36,7 +36,7 @@ void signalHandler(int signal) {
     if (!isTerminate()) {
         // First time we get an abort signal
         // We give the program a number of seconds to print results obtained so far before termination
-        std::cerr << "ERROR: The program received signal " << signal << " and will be aborted in " << maxWaitTime << "s." << std::endl;
+        std::cerr << "ERROR: The program received signal " << signal << " and will be aborted in " << maxWaitTime << "s.\n";
         SignalInformation::infos().setTerminate(true);
         // Remember original signal such that the program returns the correct original signal
         SignalInformation::infos().setErrorCode(signal);
@@ -46,13 +46,13 @@ void signalHandler(int signal) {
         // Second time we get a signal
         // We now definitely have to terminate as fast as possible
         if (SignalInformation::infos().getErrorCode() == SIGXCPU) {
-            std::cerr << "TIMEOUT." << std::endl;
+            std::cerr << "TIMEOUT.\n";
         } else if (SignalInformation::infos().getErrorCode() == ENOMEM) {
-            std::cerr << "OUT OF MEMORY." << std::endl;
+            std::cerr << "OUT OF MEMORY.\n";
         } else if (SignalInformation::infos().getErrorCode() == SIGABRT || SignalInformation::infos().getErrorCode() == SIGINT) {
-            std::cerr << "ABORT." << std::endl;
+            std::cerr << "ABORT.\n";
         } else {
-            std::cerr << "Received signal " << signal << std::endl;
+            std::cerr << "Received signal " << signal << '\n';
         }
         quickest_exit(SignalInformation::infos().getErrorCode());
     }
@@ -70,26 +70,26 @@ void installSignalHandler() {
 
     // CPU Limit
     if (sigaction(SIGXCPU, &sa, nullptr) == -1) {
-        std::cerr << "FATAL: Installing a signal handler failed." << std::endl;
+        std::cerr << "FATAL: Installing a signal handler failed.\n";
     }
     // Memory out
     if (sigaction(ENOMEM, &sa, nullptr) == -1) {
-        std::cerr << "FATAL: Installing a signal handler failed." << std::endl;
+        std::cerr << "FATAL: Installing a signal handler failed.\n";
     }
     if (sigaction(SIGSEGV, &sa, nullptr) == -1) {
-        std::cerr << "FATAL: Installing a signal handler failed." << std::endl;
+        std::cerr << "FATAL: Installing a signal handler failed.\n";
     }
     if (sigaction(SIGABRT, &sa, nullptr) == -1) {
-        std::cerr << "FATAL: Installing a signal handler failed." << std::endl;
+        std::cerr << "FATAL: Installing a signal handler failed.\n";
     }
     if (sigaction(SIGINT, &sa, nullptr) == -1) {
-        std::cerr << "FATAL: Installing a signal handler failed." << std::endl;
+        std::cerr << "FATAL: Installing a signal handler failed.\n";
     }
     if (sigaction(SIGTERM, &sa, nullptr) == -1) {
-        std::cerr << "FATAL: Installing a signal handler failed." << std::endl;
+        std::cerr << "FATAL: Installing a signal handler failed.\n";
     }
     if (sigaction(SIGALRM, &sa, nullptr) == -1) {
-        std::cerr << "FATAL: Installing a signal handler failed." << std::endl;
+        std::cerr << "FATAL: Installing a signal handler failed.\n";
     }
 }
 

--- a/src/storm/utility/shortestPaths.cpp
+++ b/src/storm/utility/shortestPaths.cpp
@@ -357,7 +357,7 @@ void ShortestPathsGenerator<T>::printKShortestPath(state_t targetNode, unsigned 
     if (p.predecessorNode) {
         printKShortestPath(p.predecessorNode.get(), p.predecessorK, false);
     } else {
-        std::cout << " ]" << std::endl;
+        std::cout << " ]\n";
     }
 }
 

--- a/src/test/storm-pomdp/modelchecker/BeliefExplorationPomdpModelCheckerTest.cpp
+++ b/src/test/storm-pomdp/modelchecker/BeliefExplorationPomdpModelCheckerTest.cpp
@@ -258,7 +258,7 @@ namespace {
         ValueType expected = this->parseNumber("7/10");
         EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
         EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise." << std::endl;
+        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
     }
     
     TYPED_TEST(BeliefExplorationTest, simple_Pmin) {
@@ -271,7 +271,7 @@ namespace {
         ValueType expected = this->parseNumber("3/10");
         EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
         EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise." << std::endl;
+        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
     }
     
     TYPED_TEST(BeliefExplorationTest, simple_slippery_Pmax) {
@@ -284,7 +284,7 @@ namespace {
         ValueType expected = this->parseNumber("7/10");
         EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
         EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise." << std::endl;
+        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
     }
     
     TYPED_TEST(BeliefExplorationTest, simple_slippery_Pmin) {
@@ -297,7 +297,7 @@ namespace {
         ValueType expected = this->parseNumber("3/10");
         EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
         EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise." << std::endl;
+        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
     }
     
     TYPED_TEST(BeliefExplorationTest, simple_Rmax) {
@@ -310,7 +310,7 @@ namespace {
         ValueType expected = this->parseNumber("29/50");
         EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
         EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise." << std::endl;
+        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
     }
     
     TYPED_TEST(BeliefExplorationTest, simple_Rmin) {
@@ -323,7 +323,7 @@ namespace {
         ValueType expected = this->parseNumber("19/50");
         EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
         EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise." << std::endl;
+        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
     }
     
     TYPED_TEST(BeliefExplorationTest, simple_slippery_Rmax) {
@@ -336,7 +336,7 @@ namespace {
         ValueType expected = this->parseNumber("29/30");
         EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
         EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise." << std::endl;
+        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
     }
     
     TYPED_TEST(BeliefExplorationTest, simple_slippery_Rmin) {
@@ -349,7 +349,7 @@ namespace {
         ValueType expected = this->parseNumber("19/30");
         EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
         EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise." << std::endl;
+        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
     }
     
     TYPED_TEST(BeliefExplorationTest, maze2_Rmin) {
@@ -363,7 +363,7 @@ namespace {
         EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
         EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
         // Use relative difference of bounds for this one
-        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise." << std::endl;
+        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
     }
     
     TYPED_TEST(BeliefExplorationTest, maze2_Rmax) {
@@ -388,7 +388,7 @@ namespace {
         EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
         EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
         // Use relative difference of bounds for this one
-        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise." << std::endl;
+        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
     }
     
     TYPED_TEST(BeliefExplorationTest, maze2_slippery_Rmax) {
@@ -413,7 +413,7 @@ namespace {
         EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
         EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
         // Use relative difference of bounds for this one
-        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise." << std::endl;
+        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
     }
     
     TYPED_TEST(BeliefExplorationTest, refuel_Pmin) {
@@ -427,7 +427,7 @@ namespace {
         EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
         EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
         // Use relative difference of bounds for this one
-        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise." << std::endl;
+        EXPECT_LE(result.diff(), this->precision()) << "Result [" << result.lowerBound << ", " << result.upperBound << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
     }
     
     

--- a/src/test/storm/modelchecker/csl/ExpectedVisitingTimesCtmcCslModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/csl/ExpectedVisitingTimesCtmcCslModelCheckerTest.cpp
@@ -111,24 +111,24 @@ TYPED_TEST(ExpectedVisitingTimesCtmcCslModelCheckerTest, expvisittimestest) {
     std::sort(sortedVector.begin(), sortedVector.end());
 
     EXPECT_NEAR(sortedVector[0], this->parseNumber("8/2025"), this->precision())
-        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_NEAR(sortedVector[1], this->parseNumber("4/135"), this->precision())
-        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_NEAR(sortedVector[2], this->parseNumber("2/27"), this->precision())
-        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_NEAR(sortedVector[3], this->parseNumber("17/81"), this->precision())
-        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_NEAR(sortedVector[4], this->parseNumber("401/1620"), this->precision())
-        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_NEAR(sortedVector[5], this->parseNumber("341/1215"), this->precision())
-        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_EQ(sortedVector[6], storm::utility::infinity<ValueType>())
-        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_EQ(sortedVector[7], storm::utility::infinity<ValueType>())
-        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_EQ(sortedVector[8], storm::utility::infinity<ValueType>())
-        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_EQ(sortedVector[9], storm::utility::infinity<ValueType>())
-        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of expected visiting times computation is " << storm::utility::vector::toString(resultVector) << '\n';
 }
 }  // namespace

--- a/src/test/storm/modelchecker/csl/SteadyStateCtmcCslModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/csl/SteadyStateCtmcCslModelCheckerTest.cpp
@@ -110,20 +110,20 @@ TYPED_TEST(SteadyStateCtmcCslModelCheckerTest, steadystatetest) {
     auto sortedVector = resultVector;
     std::sort(sortedVector.begin(), sortedVector.end());
     EXPECT_EQ(sortedVector[0], storm::utility::zero<ValueType>())
-        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_EQ(sortedVector[1], storm::utility::zero<ValueType>())
-        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_EQ(sortedVector[2], storm::utility::zero<ValueType>())
-        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_NEAR(sortedVector[3], this->parseNumber("1/35"), this->precision())
-        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_NEAR(sortedVector[4], this->parseNumber("2/35"), this->precision())
-        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_NEAR(sortedVector[5], this->parseNumber("4/35"), this->precision())
-        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_NEAR(sortedVector[6], this->parseNumber("1/5"), this->precision())
-        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << '\n';
     EXPECT_NEAR(sortedVector[7], this->parseNumber("3/5"), this->precision())
-        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << std::endl;
+        << "Result of steady state computation is " << storm::utility::vector::toString(resultVector) << '\n';
 }
 }  // namespace

--- a/src/test/storm/modelchecker/multiobjective/MultiObjectiveSchedRestModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/multiobjective/MultiObjectiveSchedRestModelCheckerTest.cpp
@@ -82,7 +82,7 @@ std::string toString(std::vector<Point> pointset, bool asDouble) {
                 s << pi;
             }
         }
-        s << "]" << std::endl;
+        s << "]\n";
     }
     return s.str();
 }
@@ -112,14 +112,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, steps) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
@@ -127,14 +127,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, steps) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 }
 
@@ -171,14 +171,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, mecs) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     ++formulaIndex;
@@ -190,14 +190,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, mecs) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
@@ -205,14 +205,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, mecs) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     ++formulaIndex;
@@ -228,14 +228,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, mecs) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     ++formulaIndex;
@@ -251,14 +251,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, mecs) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 }
 
@@ -295,14 +295,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     ++formulaIndex;
@@ -313,14 +313,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
@@ -328,14 +328,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     ++formulaIndex;
@@ -351,14 +351,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     ++formulaIndex;
@@ -369,14 +369,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
@@ -384,14 +384,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     env = getGoalDeterministicEnvironment();
@@ -404,14 +404,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
@@ -419,14 +419,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     ++formulaIndex;
@@ -437,14 +437,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
@@ -452,14 +452,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     ++formulaIndex;
@@ -470,14 +470,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
@@ -485,14 +485,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     ++formulaIndex;
@@ -503,14 +503,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 
     env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
@@ -518,14 +518,14 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
     ASSERT_TRUE(result->isParetoCurveCheckResult());
     actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
     missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
     incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:" << std::endl
-                                         << "Expected:" << std::endl
-                                         << toString(expected, true) << "Actual:" << std::endl
+    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
+                                         << "Expected:\n"
+                                         << toString(expected, true) << "Actual:\n"
                                          << toString(actual, true);
 }
 }  // namespace

--- a/src/test/storm/storage/BitVectorTest.cpp
+++ b/src/test/storm/storage/BitVectorTest.cpp
@@ -144,7 +144,7 @@ TEST(BitVectorDeathTest, GetSetAssertion) {
     EXPECT_DEATH_IF_SUPPORTED(vector.set(32), "");
 #endif
 #else
-    std::cerr << "WARNING: Not testing GetSetAssertions, as they are disabled in release mode." << std::endl;
+    std::cerr << "WARNING: Not testing GetSetAssertions, as they are disabled in release mode.\n";
     SUCCEED();
 #endif
 }

--- a/src/test/storm/transformer/EndComponentEliminatorTest.cpp
+++ b/src/test/storm/transformer/EndComponentEliminatorTest.cpp
@@ -69,8 +69,8 @@ TEST(NeutralECRemover, SimpleModelTest) {
     std::vector<uint_fast64_t> expectedNewToOldRowMapping = {6, 7, 8, 2, 3, 11, 1, 0};
     std::vector<uint_fast64_t> expectedOldToNewStateMapping = {2, 1, std::numeric_limits<uint_fast64_t>::max(), 0, 1};
 
-    // std::cout << "Original matrix:" << std::endl << matrix << std::endl << std::endl << "Computation Result: " << std::endl << res.matrix << std::endl<<
-    // std::endl << "expected Matrix" << std::endl<< expectedMatrix << std::endl;
+    // std::cout << "Original matrix:\n" << matrix << "\n\nComputation Result: \n" << res.matrix
+    // << "\n\nexpected Matrix\n"<< expectedMatrix << '\n';
 
     // Note that there are other possible solutions that yield equivalent matrices / vectors.
     // In particular, the ordering within the row groups depends on the MEC decomposition implementation.
@@ -133,8 +133,8 @@ TEST(NeutralECRemover, SimpleModelTest) {
                         }
                     }
                     EXPECT_TRUE(foundEqualEntry) << "Could not matching entry for expected entry'" << expectedEntry.getValue() << " (row " << expectedRow
-                                                 << ", column " << expectedEntry.getColumn() << "). Was searching at row " << actualRow << " of actual matrix "
-                                                 << std::endl
+                                                 << ", column " << expectedEntry.getColumn() << "). Was searching at row " << actualRow
+                                                 << " of actual matrix \n"
                                                  << res.matrix << ".";
                 }
             }


### PR DESCRIPTION
This prevents std::flush that std::endl contains, which is in all cases I've checked unnecessary can lead to extreme slowdowns.
Especially there where many chains of std::endl which are dramatically slow on some systems.

This PR was not made with just a regex which is important as it does not remove the std::endl in the FileTest and hopefully does not break the JIT implementation as there was an escaped std::endl which was also replaced with an escaped '\n'.
