### PR TITLE
Updated ubuntu base system and debian version in buildtest

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: ["ubuntu-18.04", "debian-11", "debian-10", "ubuntu-20.04"]
+        distro: ["debian-10", "debian-11", "ubuntu-18.04", "ubuntu-20.04"]
         debugOrRelease: ["release"]
     steps:
       - name: Setup cmake arguments

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -31,7 +31,7 @@ jobs:
     name: Indepth Tests (${{ matrix.cmakeArgs.name }})
     runs-on: ubuntu-latest
     env:
-      DISTRO: "ubuntu-20.10"
+      DISTRO: "ubuntu-21.10"
     strategy:
       matrix:
         cmakeArgs:
@@ -101,7 +101,7 @@ jobs:
     name: Build, Test and Deploy
     runs-on: ubuntu-latest
     env:
-      DISTRO: "ubuntu-20.10"
+      DISTRO: "ubuntu-21.10"
     strategy:
       matrix:
         debugOrRelease: ["debug", "release"]

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: ["ubuntu-18.04", "debian-10", "debian-9", "ubuntu-20.04"]
+        distro: ["ubuntu-18.04", "debian-11", "debian-10", "ubuntu-20.04"]
         debugOrRelease: ["release"]
     steps:
       - name: Setup cmake arguments


### PR DESCRIPTION
Previously, ubuntu 20-10 was used which reached end of life.

We now also run our tests for debian 11, but I decided to no longer test for debian 9.

Note that the latter ships with GCC 6 which has quite limited c++17 support, so I think that we should eventually drop support for debian 9, anyway.