### PR TITLE
virtual destructors added

### DIFF
--- a/resources/3rdparty/cpptemplate/cpptempl.h
+++ b/resources/3rdparty/cpptemplate/cpptempl.h
@@ -126,7 +126,7 @@ namespace cpptempl
 	class Data
 	{
 	public:
-		virtual ~Data() {}
+		virtual ~Data() = default;
 		virtual bool empty() = 0 ;
 		virtual std::string getvalue();
 		virtual data_list& getlist();

--- a/src/storm/models/Model.h
+++ b/src/storm/models/Model.h
@@ -16,6 +16,8 @@ class Model : public ModelBase {
     Model(ModelType const& modelType) : ModelBase(modelType) {
         // Intentionally left empty.
     }
+
+    virtual ~Model() = default;
 };
 
 }  // namespace models

--- a/src/storm/models/sparse/DeterministicModel.h
+++ b/src/storm/models/sparse/DeterministicModel.h
@@ -29,6 +29,8 @@ class DeterministicModel : public Model<ValueType, RewardModelType> {
     DeterministicModel(DeterministicModel<ValueType, RewardModelType>&& other) = default;
     DeterministicModel<ValueType, RewardModelType>& operator=(DeterministicModel<ValueType, RewardModelType>&& model) = default;
 
+    virtual ~DeterministicModel() = default;
+
     virtual void writeDotToStream(std::ostream& outStream, size_t maxWidthLabel = 30, bool includeLabeling = true,
                                   storm::storage::BitVector const* subsystem = nullptr, std::vector<ValueType> const* firstValue = nullptr,
                                   std::vector<ValueType> const* secondValue = nullptr, std::vector<uint_fast64_t> const* stateColoring = nullptr,

--- a/src/storm/models/sparse/Dtmc.h
+++ b/src/storm/models/sparse/Dtmc.h
@@ -47,6 +47,8 @@ class Dtmc : public DeterministicModel<ValueType, RewardModelType> {
     Dtmc(Dtmc<ValueType, RewardModelType>&& dtmc) = default;
     Dtmc& operator=(Dtmc<ValueType, RewardModelType>&& dtmc) = default;
 
+    virtual ~Dtmc() = default;
+
     virtual void reduceToStateBasedRewards() override;
 };
 

--- a/src/storm/models/sparse/Mdp.h
+++ b/src/storm/models/sparse/Mdp.h
@@ -47,6 +47,8 @@ class Mdp : public NondeterministicModel<ValueType, RewardModelType> {
 
     Mdp(Mdp<ValueType, RewardModelType>&& other) = default;
     Mdp& operator=(Mdp<ValueType, RewardModelType>&& other) = default;
+
+    virtual ~Mdp() = default;
 };
 
 }  // namespace sparse

--- a/src/storm/models/sparse/Model.h
+++ b/src/storm/models/sparse/Model.h
@@ -49,6 +49,8 @@ class Model : public storm::models::Model<CValueType> {
     Model(ModelType modelType, storm::storage::sparse::ModelComponents<ValueType, RewardModelType> const& components);
     Model(ModelType modelType, storm::storage::sparse::ModelComponents<ValueType, RewardModelType>&& components);
 
+    virtual ~Model() = default;
+
     /*!
      * Retrieves the backward transition relation of the model, i.e. a set of transitions between states
      * that correspond to the reversed transition relation of this model.

--- a/src/storm/models/sparse/NondeterministicModel.h
+++ b/src/storm/models/sparse/NondeterministicModel.h
@@ -30,6 +30,8 @@ class NondeterministicModel : public Model<ValueType, RewardModelType> {
     NondeterministicModel(ModelType modelType, storm::storage::sparse::ModelComponents<ValueType, RewardModelType> const& components);
     NondeterministicModel(ModelType modelType, storm::storage::sparse::ModelComponents<ValueType, RewardModelType>&& components);
 
+    virtual ~NondeterministicModel() = default;
+
     /*!
      * Retrieves the vector indicating which matrix rows represent non-deterministic choices of a certain state.
      *


### PR DESCRIPTION
Towards supporting an update of stormpy, these base classes are missing virtual destructors even though this is strongly recommended.