### PR TITLE
Fix BitVector::operator= OOB

### DIFF
--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -113,11 +113,11 @@ BitVector::BitVector(BitVector const& other) : bitCount(other.bitCount), buckets
 BitVector& BitVector::operator=(BitVector const& other) {
     // Only perform the assignment if the source and target are not identical.
     if (this != &other) {
-        bitCount = other.bitCount;
         if (buckets && bucketCount() != other.bucketCount()) {
             delete[] buckets;
             buckets = nullptr;
         }
+        bitCount = other.bitCount;
         if (!buckets) {
             buckets = new uint64_t[other.bucketCount()];
         }

--- a/src/test/storm/storage/BitVectorTest.cpp
+++ b/src/test/storm/storage/BitVectorTest.cpp
@@ -594,3 +594,10 @@ TEST(BitVectorTest, Expand) {
     ASSERT_EQ(128ul, vector2.size());
     ASSERT_EQ(2ul, vector2.getNumberOfSetBits());
 }
+
+TEST(BitVectorTest, Assignment) {
+    storm::storage::BitVector v1(10), v2(100000);
+    v1 = v2;
+    v1.set(9999);
+    ASSERT_TRUE(v1.get(9999));
+}


### PR DESCRIPTION
Currently, assigning a large BitVector to a small one causes the assignment operator to write out of bounds. This PR fixes that by making sure the `bitCount` is updated *after* we check if the two BitVectors have the same size. Note that `bucketCount()` is computed using `bitCount`. In other words, assuming buckets is not null, the condition of the if statement always false, which means that the size of the current `buckets` is never changed. This leads to OOB in the `std::copy_n` that follows. I added a simple test to check that it indeed works. The test that I added crashes without the fix.