### PR TITLE
Fix UB as found by AddressSanitizer

### DIFF
--- a/src/storm/modelchecker/exploration/SparseExplorationModelChecker.cpp
+++ b/src/storm/modelchecker/exploration/SparseExplorationModelChecker.cpp
@@ -601,7 +601,7 @@ void SparseExplorationModelChecker<ModelType, StateType>::collapseMec(storm::sto
         std::pair<ValueType, ValueType> stateBounds = getLowestBounds(explorationInformation.getOptimizationDirection());
         for (auto const& action : leavingActions) {
             explorationInformation.moveActionToBackOfMatrix(action);
-            std::pair<ValueType, ValueType> const& actionBounds = bounds.getBoundsForAction(action);
+            std::pair<ValueType, ValueType> actionBounds = bounds.getBoundsForAction(action);
             bounds.initializeBoundsForNextAction(actionBounds);
             stateBounds = combineBounds(explorationInformation.getOptimizationDirection(), stateBounds, actionBounds);
         }

--- a/src/storm/storage/Decomposition.h
+++ b/src/storm/storage/Decomposition.h
@@ -27,6 +27,11 @@ class Decomposition {
     Decomposition();
 
     /*!
+     * Default (virtual) deconstructor
+     */
+    virtual ~Decomposition() = default;
+
+    /*!
      * Creates a decomposition by copying the given decomposition.
      *
      * @param other The decomposition to copy.

--- a/src/storm/utility/KwekMehlhorn.cpp
+++ b/src/storm/utility/KwekMehlhorn.cpp
@@ -18,11 +18,11 @@ std::pair<IntegerType, IntegerType> findRational(IntegerType const& alpha, Integ
 
     if (alphaDivBetaPair.first == gammaDivDeltaPair.first && !storm::utility::isZero(alphaDivBetaPair.second)) {
         std::pair<IntegerType, IntegerType> subresult = findRational(delta, gammaDivDeltaPair.second, beta, alphaDivBetaPair.second);
-        auto result = std::make_pair(alphaDivBetaPair.first * subresult.first + subresult.second, subresult.first);
+        std::pair<IntegerType, IntegerType> result(alphaDivBetaPair.first * subresult.first + subresult.second, subresult.first);
 
         return result;
     } else {
-        auto result = std::make_pair(
+        std::pair<IntegerType, IntegerType> result(
             storm::utility::isZero(alphaDivBetaPair.second) ? alphaDivBetaPair.first : alphaDivBetaPair.first + storm::utility::one<IntegerType>(),
             storm::utility::one<IntegerType>());
         return result;


### PR DESCRIPTION
This PR fixes 3 cases of UB as found by running the tests while compiling with [AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer) (i.e. `-fsanitize=address` in gcc or clang). I've merged these changes into one commit and PR because they are relatively minor, if separate PRs are preferred that is also fine. The changes I made summarized:

* `SparseExplorationModelChecker.cpp`:
The current code retrieves the `actionBounds` by reference, which is an entry in a vector. Afterwards, the `initializeBoundsForNextAction` calls `push_back` on this vector which can make the previously obtained reference invalid. This happens when the vector needs to reallocate.

* `Decomposition.h`:
Missing virtual deconstructor of base class.

* `KwekMehlhorn.cpp`:
Using `auto` in combination with `mpz_class` (one of the underlying arbitrary precision types) is generally a bad idea (see last paragraph in [link](https://gmplib.org/manual/C_002b_002b-Interface-Limitations)). In this file, the type of `auto result = std::make_pair(...)` is not `std::pair<IntegerType, IntegerType>` as you might expect, but a pair of expressions, for which the temporary expressions that are contained within go out of scope. Assigning to a `mpz_class` (= `IntegerType`) directly causes the right conversion to be made.

I will create an issue soon on integrating AddressSanitizer (and perhaps other tools) into the build configuration, which I think would be helpful, especially in combination with CI. 