### PR TITLE
Add AddressSanitizer as build configuration option

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -25,7 +25,6 @@ env:
   CARL_CMAKE_DEBUG: "-DCMAKE_BUILD_TYPE=Debug -DUSE_CLN_NUMBERS=ON -DUSE_GINAC=ON -DTHREAD_SAFE=ON -DBUILD_ADDONS=ON -DBUILD_ADDON_PARSER=ON"
   CARL_CMAKE_RELEASE: "-DCMAKE_BUILD_TYPE=Release -DUSE_CLN_NUMBERS=ON -DUSE_GINAC=ON -DTHREAD_SAFE=ON -DBUILD_ADDONS=ON -DBUILD_ADDON_PARSER=ON"
 
-
 jobs:
   indepthTests:
     name: Indepth Tests (${{ matrix.cmakeArgs.name }})
@@ -35,12 +34,12 @@ jobs:
     strategy:
       matrix:
         cmakeArgs:
-          - {name: "GMP exact; GMP rational functions; Spot", args: "-DCMAKE_BUILD_TYPE=Debug -DSTORM_DEVELOPER=ON -DSTORM_PORTABLE=ON -DSTORM_USE_CLN_EA=OFF -DSTORM_USE_CLN_RF=OFF -DSTORM_USE_SPOT_SHIPPED=ON"}
+          - {name: "GMP exact; GMP rational functions; Spot", args: "-DCMAKE_BUILD_TYPE=Debug -DSTORM_DEVELOPER=ON -DSTORM_PORTABLE=ON -DSTORM_USE_CLN_EA=OFF -DSTORM_USE_CLN_RF=OFF -DSTORM_USE_SPOT_SHIPPED=ON -DSTORM_COMPILE_WITH_ALL_SANITIZERS=ON"}
           # This is the standard config
           # - {name: "GMP exact; CLN rational functions; Spot", args: "-DCMAKE_BUILD_TYPE=Debug -DSTORM_DEVELOPER=ON -DSTORM_PORTABLE=ON -DSTORM_USE_CLN_EA=OFF -DSTORM_USE_CLN_RF=ON -DSTORM_USE_SPOT_SHIPPED=ON"}
-          - {name: "CLN exact; GMP rational functions; Spot", args: "-DCMAKE_BUILD_TYPE=Debug -DSTORM_DEVELOPER=ON -DSTORM_PORTABLE=ON -DSTORM_USE_CLN_EA=ON -DSTORM_USE_CLN_RF=OFF -DSTORM_USE_SPOT_SHIPPED=ON"}
-          - {name: "CLN exact; CLN rational functions; Spot", args: "-DCMAKE_BUILD_TYPE=Debug -DSTORM_DEVELOPER=ON -DSTORM_PORTABLE=ON -DSTORM_USE_CLN_EA=ON -DSTORM_USE_CLN_RF=ON -DSTORM_USE_SPOT_SHIPPED=ON"}
-          - {name: "GMP exact; CLN rational functions; No Spot", args: "-DCMAKE_BUILD_TYPE=Debug -DSTORM_DEVELOPER=ON -DSTORM_PORTABLE=ON -DSTORM_USE_CLN_EA=ON -DSTORM_USE_CLN_RF=ON -DSTORM_USE_SPOT_SHIPPED=OFF"}
+          - {name: "CLN exact; GMP rational functions; Spot", args: "-DCMAKE_BUILD_TYPE=Debug -DSTORM_DEVELOPER=ON -DSTORM_PORTABLE=ON -DSTORM_USE_CLN_EA=ON -DSTORM_USE_CLN_RF=OFF -DSTORM_USE_SPOT_SHIPPED=ON -DSTORM_COMPILE_WITH_ALL_SANITIZERS=ON"}
+          - {name: "CLN exact; CLN rational functions; Spot", args: "-DCMAKE_BUILD_TYPE=Debug -DSTORM_DEVELOPER=ON -DSTORM_PORTABLE=ON -DSTORM_USE_CLN_EA=ON -DSTORM_USE_CLN_RF=ON -DSTORM_USE_SPOT_SHIPPED=ON -DSTORM_COMPILE_WITH_ALL_SANITIZERS=ON"}
+          - {name: "GMP exact; CLN rational functions; No Spot", args: "-DCMAKE_BUILD_TYPE=Debug -DSTORM_DEVELOPER=ON -DSTORM_PORTABLE=ON -DSTORM_USE_CLN_EA=ON -DSTORM_USE_CLN_RF=ON -DSTORM_USE_SPOT_SHIPPED=OFF -DSTORM_COMPILE_WITH_ALL_SANITIZERS=ON"}
     steps:
       - name: Init Docker
         run: sudo docker run -d -it --name storm --privileged movesrwth/storm-basesystem:${DISTRO}
@@ -54,7 +53,7 @@ jobs:
       - name: Build storm
         run: sudo docker exec storm bash -c "cd /opt/storm/build; make -j ${NR_JOBS}"
       - name: Run unit tests
-        run: sudo docker exec storm bash -c "cd /opt/storm/build; ctest test --output-on-failure"
+        run: sudo docker exec storm bash -c "cd /opt/storm/build; ASAN_OPTIONS=detect_leaks=0,detect_odr_violation=0 ctest test --output-on-failure"
 
   noDeploy:
     name: Build and Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,12 @@ set(ADDITIONAL_INCLUDE_DIRS "" CACHE STRING "Additional directories added to the
 set(ADDITIONAL_LINK_DIRS "" CACHE STRING "Additional directories added to the link directories.")
 set(USE_XERCESC ${XML_SUPPORT})
 mark_as_advanced(USE_XERCESC)
+option(STORM_COMPILE_WITH_ADDRESS_SANITIZER "Sets whether to compile with AddressSanitizer enabled" OFF)
+option(STORM_COMPILE_WITH_ALL_SANITIZERS "Sets whether to compile with all sanitizers enabled" OFF)
+
+if (STORM_COMPILE_WITH_ALL_SANITIZERS)
+    set(STORM_COMPILE_WITH_ADDRESS_SANITIZER ON)
+endif()
 
 # Get an approximation of the number of available processors (used for parallel build of shipped resources)
 ProcessorCount(STORM_RESOURCES_BUILD_JOBCOUNT_DEFAULT)
@@ -242,6 +248,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
 	message(FATAL_ERROR "Intel compiler is currently not supported.")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	message(FATAL_ERROR "Visual Studio compiler is currently not supported.")
+else()
+    message(FATAL_ERROR "Unknown compiler '${CMAKE_CXX_COMPILER_ID}' is not supported")
 endif()
 set(STORM_COMPILER_VERSION ${CMAKE_CXX_COMPILER_VERSION})
 
@@ -317,6 +325,11 @@ elseif (STORM_USE_LTO)
     message(STATUS "Storm - Enabling link-time optimizations.")
 else()
     message(STATUS "Storm - Disabling link-time optimizations.")
+endif()
+
+if (STORM_COMPILE_WITH_ADDRESS_SANITIZER)
+    message(STATUS "Storm - Enabling AddressSanitizer")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
 endif()
 
 # In release mode, we turn on even more optimizations if we do not have to provide a portable binary.


### PR DESCRIPTION
Adds AddressSanitizer as build configuration option and enables it for the 'indepthTests' jobs inside the 'Build Test' workflow. See related issue #194. For now the memory leak detection is turned off while running the tests as the current code does have some memory leaks, but that is another issue.

You can see the new workflow passing at [my fork](https://github.com/Marckvdv/storm/actions/workflows/buildtest.yml).