### PR TITLE
Fix Gradient Descent bugs

### DIFF
--- a/src/storm-pars/derivative/GradientDescentConstraintMethod.h
+++ b/src/storm-pars/derivative/GradientDescentConstraintMethod.h
@@ -3,19 +3,19 @@
 #include <boost/optional.hpp>
 #include <string>
 namespace storm {
-	namespace derivative {
-		/**
-		 * GradientDescentConstraintMethod is the method for mitigating constraints
-		 * that the GradientDescentInstantiationSearcher uses.
-		 */
-		enum class GradientDescentConstraintMethod {
-			PROJECT_WITH_GRADIENT, //< The default.
-			PROJECT,
-			PENALTY_QUADRATIC,
-			BARRIER_LOGARITHMIC,
-			BARRIER_INFINITY,
-			LOGISTIC_SIGMOID
-		};
-	}
-}
+namespace derivative {
+/**
+ * GradientDescentConstraintMethod is the method for mitigating constraints
+ * that the GradientDescentInstantiationSearcher uses.
+ */
+enum class GradientDescentConstraintMethod {
+    PROJECT_WITH_GRADIENT,  //< The default.
+    PROJECT,
+    PENALTY_QUADRATIC,
+    BARRIER_LOGARITHMIC,
+    BARRIER_INFINITY,
+    LOGISTIC_SIGMOID
+};
+}  // namespace derivative
+}  // namespace storm
 #endif

--- a/src/storm-pars/derivative/GradientDescentInstantiationSearcher.cpp
+++ b/src/storm-pars/derivative/GradientDescentInstantiationSearcher.cpp
@@ -1,544 +1,551 @@
 #include "GradientDescentInstantiationSearcher.h"
+#include <cln/random.h>
+#include <cln/real.h>
+#include <cmath>
+#include <cstdint>
+#include <random>
 #include "analysis/GraphConditions.h"
 #include "environment/Environment.h"
-#include "environment/solver/SolverEnvironment.h"
 #include "environment/solver/GmmxxSolverEnvironment.h"
 #include "environment/solver/MinMaxSolverEnvironment.h"
 #include "environment/solver/NativeSolverEnvironment.h"
 #include "environment/solver/SolverEnvironment.h"
-#include "environment/solver/SolverEnvironment.h"
-#include "solver/helper/SoundValueIterationHelper.h"
 #include "modelchecker/results/CheckResult.h"
-#include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
 #include "settings/SettingsManager.h"
 #include "settings/modules/GeneralSettings.h"
+#include "solver/helper/SoundValueIterationHelper.h"
 #include "storm-pars/modelchecker/instantiation/SparseDtmcInstantiationModelChecker.h"
+#include "storm/exceptions/WrongFormatException.h"
+#include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
 #include "storm/solver/EliminationLinearEquationSolver.h"
+#include "storm/utility/constants.h"
 #include "utility/SignalHandler.h"
 #include "utility/graph.h"
-#include "storm/exceptions/WrongFormatException.h"
-#include "storm/utility/constants.h"
-#include <cln/random.h>
-#include <cln/real.h>
-#include <random>
-#include <cmath>
 
 namespace storm {
-    namespace derivative {
+namespace derivative {
 
-        template<typename FunctionType>
-        using VariableType = typename utility::parametric::VariableType<FunctionType>::type;
-        template<typename FunctionType>
-        using CoefficientType = typename utility::parametric::CoefficientType<FunctionType>::type;
+template<typename FunctionType>
+using VariableType = typename utility::parametric::VariableType<FunctionType>::type;
+template<typename FunctionType>
+using CoefficientType = typename utility::parametric::CoefficientType<FunctionType>::type;
 
-        template<typename FunctionType, typename ConstantType>
-        ConstantType GradientDescentInstantiationSearcher<FunctionType, ConstantType>::doStep(
-                VariableType<FunctionType> steppingParameter,
-                std::map<VariableType<FunctionType>, CoefficientType<FunctionType>> &position,
-                const std::map<VariableType<FunctionType>, ConstantType> &gradient,
-                uint64_t stepNum
-            ) {
-            const ConstantType precisionAsConstant = utility::convertNumber<ConstantType>(storm::settings::getModule<storm::settings::modules::GeneralSettings>().getPrecision());
-            const CoefficientType<FunctionType> precision = storm::utility::convertNumber<CoefficientType<FunctionType>>(storm::settings::getModule<storm::settings::modules::GeneralSettings>().getPrecision());
-            CoefficientType<FunctionType> const oldPos = position[steppingParameter];
-            ConstantType const oldPosAsConstant = utility::convertNumber<ConstantType>(position[steppingParameter]);
+template<typename FunctionType, typename ConstantType>
+ConstantType GradientDescentInstantiationSearcher<FunctionType, ConstantType>::doStep(
+    VariableType<FunctionType> steppingParameter, std::map<VariableType<FunctionType>, CoefficientType<FunctionType>>& position,
+    const std::map<VariableType<FunctionType>, ConstantType>& gradient, uint64_t stepNum) {
+    const ConstantType precisionAsConstant =
+        utility::convertNumber<ConstantType>(storm::settings::getModule<storm::settings::modules::GeneralSettings>().getPrecision());
+    const CoefficientType<FunctionType> precision =
+        storm::utility::convertNumber<CoefficientType<FunctionType>>(storm::settings::getModule<storm::settings::modules::GeneralSettings>().getPrecision());
+    CoefficientType<FunctionType> const oldPos = position[steppingParameter];
+    ConstantType const oldPosAsConstant = utility::convertNumber<ConstantType>(position[steppingParameter]);
 
-            ConstantType projectedGradient;
-            if (constraintMethod == GradientDescentConstraintMethod::PROJECT_WITH_GRADIENT) {
-                // Project gradient
-                ConstantType newPlainPosition = oldPosAsConstant + precisionAsConstant * gradient.at(steppingParameter);
-                if (newPlainPosition < utility::zero<ConstantType>() + precisionAsConstant || newPlainPosition > utility::one<ConstantType>() - precisionAsConstant) {
-                    projectedGradient = 0;
-                } else {
-                    projectedGradient = gradient.at(steppingParameter);
-                }
-            } else if (constraintMethod == GradientDescentConstraintMethod::LOGISTIC_SIGMOID) {
-                // We want the derivative of f(logit(x)), this happens to be exp(x) * f'(logit(x)) / (exp(x) + 1)^2
-                const double expX = std::exp(utility::convertNumber<double>(oldPos));
-                projectedGradient = gradient.at(steppingParameter) * utility::convertNumber<ConstantType>(expX / std::pow(expX + 1, 2));
-            } else if (constraintMethod == GradientDescentConstraintMethod::BARRIER_INFINITY) {
-                if (oldPosAsConstant < precisionAsConstant) {
-                    projectedGradient = 1000;
-                } else if (oldPosAsConstant > utility::one<ConstantType>() - precisionAsConstant) {
-                    projectedGradient = -1000;
-                } else {
-                    projectedGradient = gradient.at(steppingParameter);
-                }
-            } else if (constraintMethod == GradientDescentConstraintMethod::BARRIER_LOGARITHMIC) {
-                // Our barrier is:
-                // log(x) if 0 < x < 0.5
-                // log(1 - x) if 0.5 <= x < 1
-                // -infinity otherwise
-                // The gradient of this is
-                // 1/x, 1/(1-x), +/-infinity respectively
-                if (oldPosAsConstant >= precisionAsConstant && oldPosAsConstant <= utility::one<ConstantType>() - precisionAsConstant) {
-                    /* const double mu = (double) parameters.size() / (double) stepNum; */
-                    if (oldPosAsConstant*2 < utility::one<ConstantType>()) {
-                        projectedGradient = gradient.at(steppingParameter) + logarithmicBarrierTerm / (oldPosAsConstant - precisionAsConstant);
-                    } else {
-                        projectedGradient = gradient.at(steppingParameter) - logarithmicBarrierTerm / (utility::one<ConstantType>() - precisionAsConstant - oldPosAsConstant);
-                    }
-                } else {
-                    if (oldPosAsConstant < precisionAsConstant) {
-                        projectedGradient = utility::one<ConstantType>() / logarithmicBarrierTerm;
-                    } else if (oldPosAsConstant > utility::one<ConstantType>() - precisionAsConstant) {
-                        projectedGradient = -utility::one<ConstantType>() / logarithmicBarrierTerm;
-                    }
-                }
+    ConstantType projectedGradient;
+    if (constraintMethod == GradientDescentConstraintMethod::PROJECT_WITH_GRADIENT) {
+        // Project gradient
+        ConstantType newPlainPosition = oldPosAsConstant + precisionAsConstant * gradient.at(steppingParameter);
+        if (newPlainPosition < utility::zero<ConstantType>() + precisionAsConstant || newPlainPosition > utility::one<ConstantType>() - precisionAsConstant) {
+            projectedGradient = 0;
+        } else {
+            projectedGradient = gradient.at(steppingParameter);
+        }
+    } else if (constraintMethod == GradientDescentConstraintMethod::LOGISTIC_SIGMOID) {
+        // We want the derivative of f(logit(x)), this happens to be exp(x) * f'(logit(x)) / (exp(x) + 1)^2
+        const double expX = std::exp(utility::convertNumber<double>(oldPos));
+        projectedGradient = gradient.at(steppingParameter) * utility::convertNumber<ConstantType>(expX / std::pow(expX + 1, 2));
+    } else if (constraintMethod == GradientDescentConstraintMethod::BARRIER_INFINITY) {
+        if (oldPosAsConstant < precisionAsConstant) {
+            projectedGradient = 1000;
+        } else if (oldPosAsConstant > utility::one<ConstantType>() - precisionAsConstant) {
+            projectedGradient = -1000;
+        } else {
+            projectedGradient = gradient.at(steppingParameter);
+        }
+    } else if (constraintMethod == GradientDescentConstraintMethod::BARRIER_LOGARITHMIC) {
+        // Our barrier is:
+        // log(x) if 0 < x < 0.5
+        // log(1 - x) if 0.5 <= x < 1
+        // -infinity otherwise
+        // The gradient of this is
+        // 1/x, 1/(1-x), +/-infinity respectively
+        if (oldPosAsConstant >= precisionAsConstant && oldPosAsConstant <= utility::one<ConstantType>() - precisionAsConstant) {
+            /* const double mu = (double) parameters.size() / (double) stepNum; */
+            if (oldPosAsConstant * 2 < utility::one<ConstantType>()) {
+                projectedGradient = gradient.at(steppingParameter) + logarithmicBarrierTerm / (oldPosAsConstant - precisionAsConstant);
             } else {
-                projectedGradient = gradient.at(steppingParameter);
+                projectedGradient =
+                    gradient.at(steppingParameter) - logarithmicBarrierTerm / (utility::one<ConstantType>() - precisionAsConstant - oldPosAsConstant);
             }
+        } else {
+            if (oldPosAsConstant < precisionAsConstant) {
+                projectedGradient = utility::one<ConstantType>() / logarithmicBarrierTerm;
+            } else if (oldPosAsConstant > utility::one<ConstantType>() - precisionAsConstant) {
+                projectedGradient = -utility::one<ConstantType>() / logarithmicBarrierTerm;
+            }
+        }
+    } else {
+        projectedGradient = gradient.at(steppingParameter);
+    }
 
-            // Compute step based on used gradient descent method
-            ConstantType step;
-            if (Adam* adam = boost::get<Adam>(&gradientDescentType)) {
-                // For this algorihm, see the various sources available on the ADAM algorithm. This implementation should
-                // be correct, as it is compared with a run of keras's ADAM optimizer in the test.
-                adam->decayingStepAverage[steppingParameter] = adam->averageDecay * adam->decayingStepAverage[steppingParameter] +
-                    (utility::one<ConstantType>() - adam->averageDecay) * projectedGradient;
-                adam->decayingStepAverageSquared[steppingParameter] = adam->squaredAverageDecay * adam->decayingStepAverageSquared[steppingParameter] +
-                    (utility::one<ConstantType>() - adam->squaredAverageDecay) * utility::pow(projectedGradient, 2);
+    // Compute step based on used gradient descent method
+    ConstantType step;
+    if (Adam* adam = boost::get<Adam>(&gradientDescentType)) {
+        // For this algorihm, see the various sources available on the ADAM algorithm. This implementation should
+        // be correct, as it is compared with a run of keras's ADAM optimizer in the test.
+        adam->decayingStepAverage[steppingParameter] =
+            adam->averageDecay * adam->decayingStepAverage[steppingParameter] + (utility::one<ConstantType>() - adam->averageDecay) * projectedGradient;
+        adam->decayingStepAverageSquared[steppingParameter] = adam->squaredAverageDecay * adam->decayingStepAverageSquared[steppingParameter] +
+                                                              (utility::one<ConstantType>() - adam->squaredAverageDecay) * utility::pow(projectedGradient, 2);
 
-                const ConstantType correctedGradient = adam->decayingStepAverage[steppingParameter] / (utility::one<ConstantType>() - utility::pow(adam->averageDecay, stepNum + 1));
-                const ConstantType correctedSquaredGradient = adam->decayingStepAverageSquared[steppingParameter] / (utility::one<ConstantType>() - utility::pow(adam->squaredAverageDecay, stepNum + 1));
+        const ConstantType correctedGradient =
+            adam->decayingStepAverage[steppingParameter] / (utility::one<ConstantType>() - utility::pow(adam->averageDecay, stepNum + 1));
+        const ConstantType correctedSquaredGradient =
+            adam->decayingStepAverageSquared[steppingParameter] / (utility::one<ConstantType>() - utility::pow(adam->squaredAverageDecay, stepNum + 1));
 
-                const ConstantType toSqrt = correctedSquaredGradient;
-                ConstantType sqrtResult = constantTypeSqrt(toSqrt);
+        const ConstantType toSqrt = correctedSquaredGradient;
+        ConstantType sqrtResult = constantTypeSqrt(toSqrt);
 
-                step = (adam->learningRate / (sqrtResult + precisionAsConstant)) * correctedGradient;
-            } else if (RAdam* radam = boost::get<RAdam>(&gradientDescentType)) {
-                // You can compare this with the RAdam paper's "Algorithm 2: Rectified Adam".
-                // The line numbers and comments are matched.
-                // Initializing / Compute Gradient: Already happened.
-                // 2: Compute maximum length of approximated simple moving average
-                const ConstantType maxLengthApproxSMA = 2 / (utility::one<ConstantType>() - radam->squaredAverageDecay) - utility::one<ConstantType>();
+        step = (adam->learningRate / (sqrtResult + precisionAsConstant)) * correctedGradient;
+    } else if (RAdam* radam = boost::get<RAdam>(&gradientDescentType)) {
+        // You can compare this with the RAdam paper's "Algorithm 2: Rectified Adam".
+        // The line numbers and comments are matched.
+        // Initializing / Compute Gradient: Already happened.
+        // 2: Compute maximum length of approximated simple moving average
+        const ConstantType maxLengthApproxSMA = 2 / (utility::one<ConstantType>() - radam->squaredAverageDecay) - utility::one<ConstantType>();
 
-                // 5: Update exponential moving 2nd moment
-                radam->decayingStepAverageSquared[steppingParameter] = radam->squaredAverageDecay * radam->decayingStepAverageSquared[steppingParameter] +
-                    (utility::one<ConstantType>() - radam->squaredAverageDecay) * utility::pow(projectedGradient, 2);
-                // 6: Update exponential moving 1st moment
-                radam->decayingStepAverage[steppingParameter] = radam->averageDecay * radam->decayingStepAverage[steppingParameter] +
-                    (utility::one<ConstantType>() - radam->averageDecay) * projectedGradient;
-                // 7: Compute bias corrected moving average
-                const ConstantType biasCorrectedMovingAverage = radam->decayingStepAverage[steppingParameter] / (utility::one<ConstantType>() - utility::pow(radam->averageDecay, stepNum + 1));
-                const ConstantType squaredAverageDecayPow = utility::pow(radam->squaredAverageDecay, stepNum + 1);
-                // 8: Compute the length of the approximated single moving average
-                const ConstantType lengthApproxSMA = maxLengthApproxSMA - ((2 * (utility::convertNumber<ConstantType>(stepNum) + utility::one<ConstantType>()) * squaredAverageDecayPow) / (1 - squaredAverageDecayPow));
-                // 9: If the variance is tractable, i.e. lengthApproxSMA > 4, then
-                if (lengthApproxSMA > 4) {
-                    // 10: Compute adaptive learning rate
-                    const ConstantType adaptiveLearningRate = constantTypeSqrt((utility::one<ConstantType>() - squaredAverageDecayPow) / radam->decayingStepAverageSquared[steppingParameter]);
-                    // 11: Compute the variance rectification term
-                    const ConstantType varianceRectification = constantTypeSqrt(
-                            ((lengthApproxSMA - 4) / (maxLengthApproxSMA - 4)) *
-                            ((lengthApproxSMA - 2) / (maxLengthApproxSMA - 2)) *
-                            ((maxLengthApproxSMA) / (lengthApproxSMA))
-                    );
-                    // 12: Update parameters with adaptive momentum
-                    step = radam->learningRate * varianceRectification * biasCorrectedMovingAverage * adaptiveLearningRate;
-                } else {
-                    // 14: Update parameters with un-adapted momentum
-                    step = radam->learningRate * biasCorrectedMovingAverage;
-                }
-            } else if (RmsProp* rmsProp = boost::get<RmsProp>(&gradientDescentType)) {
-                rmsProp->rootMeanSquare[steppingParameter] = rmsProp->averageDecay * rmsProp->rootMeanSquare[steppingParameter] +
-                    (utility::one<ConstantType>() - rmsProp->averageDecay) * projectedGradient * projectedGradient;
+        // 5: Update exponential moving 2nd moment
+        radam->decayingStepAverageSquared[steppingParameter] = radam->squaredAverageDecay * radam->decayingStepAverageSquared[steppingParameter] +
+                                                               (utility::one<ConstantType>() - radam->squaredAverageDecay) * utility::pow(projectedGradient, 2);
+        // 6: Update exponential moving 1st moment
+        radam->decayingStepAverage[steppingParameter] =
+            radam->averageDecay * radam->decayingStepAverage[steppingParameter] + (utility::one<ConstantType>() - radam->averageDecay) * projectedGradient;
+        // 7: Compute bias corrected moving average
+        const ConstantType biasCorrectedMovingAverage =
+            radam->decayingStepAverage[steppingParameter] / (utility::one<ConstantType>() - utility::pow(radam->averageDecay, stepNum + 1));
+        const ConstantType squaredAverageDecayPow = utility::pow(radam->squaredAverageDecay, stepNum + 1);
+        // 8: Compute the length of the approximated single moving average
+        const ConstantType lengthApproxSMA =
+            maxLengthApproxSMA -
+            ((2 * (utility::convertNumber<ConstantType>(stepNum) + utility::one<ConstantType>()) * squaredAverageDecayPow) / (1 - squaredAverageDecayPow));
+        // 9: If the variance is tractable, i.e. lengthApproxSMA > 4, then
+        if (lengthApproxSMA > 4) {
+            // 10: Compute adaptive learning rate
+            const ConstantType adaptiveLearningRate =
+                constantTypeSqrt((utility::one<ConstantType>() - squaredAverageDecayPow) / radam->decayingStepAverageSquared[steppingParameter]);
+            // 11: Compute the variance rectification term
+            const ConstantType varianceRectification =
+                constantTypeSqrt(((lengthApproxSMA - 4) / (maxLengthApproxSMA - 4)) * ((lengthApproxSMA - 2) / (maxLengthApproxSMA - 2)) *
+                                 ((maxLengthApproxSMA) / (lengthApproxSMA)));
+            // 12: Update parameters with adaptive momentum
+            step = radam->learningRate * varianceRectification * biasCorrectedMovingAverage * adaptiveLearningRate;
+        } else {
+            // 14: Update parameters with un-adapted momentum
+            step = radam->learningRate * biasCorrectedMovingAverage;
+        }
+    } else if (RmsProp* rmsProp = boost::get<RmsProp>(&gradientDescentType)) {
+        rmsProp->rootMeanSquare[steppingParameter] = rmsProp->averageDecay * rmsProp->rootMeanSquare[steppingParameter] +
+                                                     (utility::one<ConstantType>() - rmsProp->averageDecay) * projectedGradient * projectedGradient;
 
-                const ConstantType toSqrt = rmsProp->rootMeanSquare[steppingParameter] + precisionAsConstant;
-                ConstantType sqrtResult = constantTypeSqrt(toSqrt);
+        const ConstantType toSqrt = rmsProp->rootMeanSquare[steppingParameter] + precisionAsConstant;
+        ConstantType sqrtResult = constantTypeSqrt(toSqrt);
 
-                step = (rmsProp->learningRate / sqrtResult) * projectedGradient;
-            } else if (Plain* plain = boost::get<Plain>(&gradientDescentType)) {
-                if (useSignsOnly) {
-                    if (projectedGradient < utility::zero<ConstantType>()) {
-                        step = -plain->learningRate;
-                    } else if (projectedGradient > utility::zero<ConstantType>()) {
-                        step = plain->learningRate;
-                    } else {
-                        step = utility::zero<ConstantType>();
-                    }
-                } else {
-                    step = plain->learningRate * projectedGradient;
-                }
-            } else if (Momentum* momentum = boost::get<Momentum>(&gradientDescentType)) {
-                if (useSignsOnly) {
-                    if (projectedGradient < utility::zero<ConstantType>()) {
-                        step = -momentum->learningRate;
-                    } else if (projectedGradient > utility::zero<ConstantType>()) {
-                        step = momentum->learningRate;
-                    } else {
-                        step = utility::zero<ConstantType>();
-                    }
-                } else {
-                    step = momentum->learningRate * projectedGradient;
-                }
-                step += momentum->momentumTerm * momentum->pastStep.at(steppingParameter);
-                momentum->pastStep[steppingParameter] = step;
-            } else if (Nesterov* nesterov = boost::get<Nesterov>(&gradientDescentType)) {
-                if (useSignsOnly) {
-                    if (projectedGradient < utility::zero<ConstantType>()) {
-                        step = -nesterov->learningRate;
-                    } else if (projectedGradient > utility::zero<ConstantType>()) {
-                        step = nesterov->learningRate;
-                    } else {
-                        step = utility::zero<ConstantType>();
-                    }
-                } else {
-                    step = nesterov->learningRate * projectedGradient;
-                }
-                step += nesterov->momentumTerm * nesterov->pastStep.at(steppingParameter);
-                nesterov->pastStep[steppingParameter] = step;
+        step = (rmsProp->learningRate / sqrtResult) * projectedGradient;
+    } else if (Plain* plain = boost::get<Plain>(&gradientDescentType)) {
+        if (useSignsOnly) {
+            if (projectedGradient < utility::zero<ConstantType>()) {
+                step = -plain->learningRate;
+            } else if (projectedGradient > utility::zero<ConstantType>()) {
+                step = plain->learningRate;
             } else {
-                STORM_LOG_ERROR("GradientDescentType was not a known one");
+                step = utility::zero<ConstantType>();
             }
+        } else {
+            step = plain->learningRate * projectedGradient;
+        }
+    } else if (Momentum* momentum = boost::get<Momentum>(&gradientDescentType)) {
+        if (useSignsOnly) {
+            if (projectedGradient < utility::zero<ConstantType>()) {
+                step = -momentum->learningRate;
+            } else if (projectedGradient > utility::zero<ConstantType>()) {
+                step = momentum->learningRate;
+            } else {
+                step = utility::zero<ConstantType>();
+            }
+        } else {
+            step = momentum->learningRate * projectedGradient;
+        }
+        step += momentum->momentumTerm * momentum->pastStep.at(steppingParameter);
+        momentum->pastStep[steppingParameter] = step;
+    } else if (Nesterov* nesterov = boost::get<Nesterov>(&gradientDescentType)) {
+        if (useSignsOnly) {
+            if (projectedGradient < utility::zero<ConstantType>()) {
+                step = -nesterov->learningRate;
+            } else if (projectedGradient > utility::zero<ConstantType>()) {
+                step = nesterov->learningRate;
+            } else {
+                step = utility::zero<ConstantType>();
+            }
+        } else {
+            step = nesterov->learningRate * projectedGradient;
+        }
+        step += nesterov->momentumTerm * nesterov->pastStep.at(steppingParameter);
+        nesterov->pastStep[steppingParameter] = step;
+    } else {
+        STORM_LOG_ERROR("GradientDescentType was not a known one");
+    }
 
-            const CoefficientType<FunctionType> convertedStep = utility::convertNumber<CoefficientType<FunctionType>>(step);
-            const CoefficientType<FunctionType> newPos = position[steppingParameter] + convertedStep;
-            position[steppingParameter] = newPos;
-            // Map parameter back to (0, 1).
-            if (constraintMethod == GradientDescentConstraintMethod::PROJECT || constraintMethod == GradientDescentConstraintMethod::PROJECT_WITH_GRADIENT) {
-                position[steppingParameter] = utility::max(precision, position[steppingParameter]);
-                CoefficientType<FunctionType> const upperBound = utility::one<CoefficientType<FunctionType>>() - precision;
-                position[steppingParameter] = utility::min(upperBound, position[steppingParameter]);
-            }
-            return utility::abs<ConstantType>(oldPosAsConstant - utility::convertNumber<ConstantType>(position[steppingParameter]));
+    const CoefficientType<FunctionType> convertedStep = utility::convertNumber<CoefficientType<FunctionType>>(step);
+    const CoefficientType<FunctionType> newPos = position[steppingParameter] + convertedStep;
+    position[steppingParameter] = newPos;
+    // Map parameter back to (0, 1).
+    if (constraintMethod == GradientDescentConstraintMethod::PROJECT || constraintMethod == GradientDescentConstraintMethod::PROJECT_WITH_GRADIENT) {
+        position[steppingParameter] = utility::max(precision, position[steppingParameter]);
+        CoefficientType<FunctionType> const upperBound = utility::one<CoefficientType<FunctionType>>() - precision;
+        position[steppingParameter] = utility::min(upperBound, position[steppingParameter]);
+    }
+    return utility::abs<ConstantType>(oldPosAsConstant - utility::convertNumber<ConstantType>(position[steppingParameter]));
+}
+
+template<typename FunctionType, typename ConstantType>
+ConstantType GradientDescentInstantiationSearcher<FunctionType, ConstantType>::stochasticGradientDescent(
+    Environment const& env, std::map<VariableType<FunctionType>, CoefficientType<FunctionType>>& position) {
+    uint_fast64_t initialStateModel = model.getStates("init").getNextSetIndex(0);
+
+    ConstantType currentValue;
+    switch (this->currentCheckTask->getBound().comparisonType) {
+        case logic::ComparisonType::Greater:
+        case logic::ComparisonType::GreaterEqual:
+            currentValue = -utility::infinity<ConstantType>();
+            break;
+        case logic::ComparisonType::Less:
+        case logic::ComparisonType::LessEqual:
+            currentValue = utility::infinity<ConstantType>();
+            break;
+    }
+
+    // We count the number of iterations where the value changes less than the threshold, and terminate if it is large enough.
+    uint64_t tinyChangeIterations = 0;
+
+    std::map<VariableType<FunctionType>, ConstantType> deltaVector;
+
+    std::vector<VariableType<FunctionType>> parameterEnumeration;
+    for (auto parameter : this->parameters) {
+        parameterEnumeration.push_back(parameter);
+    }
+
+    utility::Stopwatch printUpdateStopwatch;
+    printUpdateStopwatch.start();
+
+    // The index to keep track of what parameter(s) to consider next.
+    // The "mini-batch", so the parameters to consider, are parameterNum..parameterNum+miniBatchSize-1
+    uint_fast64_t parameterNum = 0;
+    for (uint_fast64_t stepNum = 0; true; ++stepNum) {
+        if (printUpdateStopwatch.getTimeInSeconds() >= 15) {
+            printUpdateStopwatch.restart();
+            std::cout << "Currently at ";
+            std::cout << currentValue << std::endl;
         }
 
-        template<typename FunctionType, typename ConstantType>
-        ConstantType GradientDescentInstantiationSearcher<FunctionType, ConstantType>::stochasticGradientDescent(
-            Environment const& env,
-            std::map<VariableType<FunctionType>, CoefficientType<FunctionType>> &position
-        ) {
-            uint_fast64_t initialState;
-            const storm::storage::BitVector initialVector = model.getInitialStates();
-            for (uint_fast64_t x : initialVector) {
-                initialState = x;
+        std::vector<VariableType<FunctionType>> miniBatch;
+        for (uint_fast64_t i = parameterNum; i < std::min((uint_fast64_t)parameterEnumeration.size(), parameterNum + miniBatchSize); i++) {
+            miniBatch.push_back(parameterEnumeration[i]);
+        }
+
+        ConstantType oldValue = currentValue;
+        CoefficientType<FunctionType> const precision = storm::utility::convertNumber<CoefficientType<FunctionType>>(
+            storm::settings::getModule<storm::settings::modules::GeneralSettings>().getPrecision());
+
+        // If nesterov is enabled, we need to compute the gradient on the predicted position
+        std::map<VariableType<FunctionType>, CoefficientType<FunctionType>> nesterovPredictedPosition(position);
+        if (Nesterov* nesterov = boost::get<Nesterov>(&gradientDescentType)) {
+            CoefficientType<FunctionType> const upperBound = (utility::one<CoefficientType<FunctionType>>() - precision);
+            for (auto const& parameter : miniBatch) {
+                ConstantType const addedTerm = nesterov->momentumTerm * nesterov->pastStep[parameter];
+                nesterovPredictedPosition[parameter] += storm::utility::convertNumber<CoefficientType<FunctionType>>(addedTerm);
+                nesterovPredictedPosition[parameter] = utility::max(precision, nesterovPredictedPosition[parameter]);
+                nesterovPredictedPosition[parameter] = utility::min(upperBound, nesterovPredictedPosition[parameter]);
+            }
+        }
+        if (constraintMethod == GradientDescentConstraintMethod::LOGISTIC_SIGMOID) {
+            // Apply sigmoid function
+            for (auto const& parameter : parameters) {
+                nesterovPredictedPosition[parameter] =
+                    utility::one<CoefficientType<FunctionType>>() /
+                    (utility::one<CoefficientType<FunctionType>>() +
+                     utility::convertNumber<CoefficientType<FunctionType>>(std::exp(-utility::convertNumber<double>(nesterovPredictedPosition[parameter]))));
+            }
+        }
+
+        // Compute the value of our position and terminate if it satisfies the bound or is
+        // zero or one when computing probabilities. The "valueVector" (just the probability/expected
+        // reward for eventually reaching the target from every state) is also used for computing
+        // the gradient later. We only need one computation of the "valueVector" per mini-batch.
+        //
+        // If nesterov is activated, we need to do this twice. First, to check the value of the current position.
+        // Second, to compute the valueVector at the nesterovPredictedPosition.
+        // If nesterov is deactivated, then nesterovPredictedPosition == position.
+
+        // Are we at a stochastic (in bounds) position?
+        bool stochasticPosition = true;
+        for (auto const& parameter : parameters) {
+            if (nesterovPredictedPosition[parameter] < 0 + precision || nesterovPredictedPosition[parameter] > 1 - precision) {
+                stochasticPosition = false;
+                break;
+            }
+        }
+
+        bool computeValue = true;
+        if (constraintMethod == GradientDescentConstraintMethod::BARRIER_INFINITY || constraintMethod == GradientDescentConstraintMethod::BARRIER_LOGARITHMIC) {
+            if (!stochasticPosition) {
+                computeValue = false;
+            }
+        }
+
+        if (computeValue) {
+            std::unique_ptr<storm::modelchecker::CheckResult> intermediateResult = instantiationModelChecker->check(env, nesterovPredictedPosition);
+            std::vector<ConstantType> valueVector = intermediateResult->asExplicitQuantitativeCheckResult<ConstantType>().getValueVector();
+            if (Nesterov* nesterov = boost::get<Nesterov>(&gradientDescentType)) {
+                std::map<VariableType<FunctionType>, CoefficientType<FunctionType>> modelCheckPosition(position);
+                if (constraintMethod == GradientDescentConstraintMethod::LOGISTIC_SIGMOID) {
+                    for (auto const& parameter : parameters) {
+                        modelCheckPosition[parameter] =
+                            utility::one<CoefficientType<FunctionType>>() /
+                            (utility::one<CoefficientType<FunctionType>>() +
+                             utility::convertNumber<CoefficientType<FunctionType>>(std::exp(-utility::convertNumber<double>(modelCheckPosition[parameter]))));
+                    }
+                }
+                std::unique_ptr<storm::modelchecker::CheckResult> terminationResult = instantiationModelChecker->check(env, modelCheckPosition);
+                std::vector<ConstantType> terminationValueVector = terminationResult->asExplicitQuantitativeCheckResult<ConstantType>().getValueVector();
+                currentValue = terminationValueVector[initialStateModel];
+            } else {
+                currentValue = valueVector[initialStateModel];
+            }
+
+            if (currentCheckTask->getBound().isSatisfied(currentValue) && stochasticPosition) {
                 break;
             }
 
-            ConstantType currentValue;
-            switch (this->currentCheckTask->getBound().comparisonType) {
-                case logic::ComparisonType::Greater:
-                case logic::ComparisonType::GreaterEqual:
-                    currentValue = -utility::infinity<ConstantType>();
-                    break;
-                case logic::ComparisonType::Less:
-                case logic::ComparisonType::LessEqual:
-                    currentValue = utility::infinity<ConstantType>();
-                    break;
+            for (auto const& parameter : miniBatch) {
+                auto checkResult = derivativeEvaluationHelper->check(env, nesterovPredictedPosition, parameter, valueVector);
+                ConstantType delta = checkResult->getValueVector()[derivativeEvaluationHelper->getInitialState()];
+                if (currentCheckTask->getBound().comparisonType == logic::ComparisonType::Less ||
+                    currentCheckTask->getBound().comparisonType == logic::ComparisonType::LessEqual) {
+                    delta = -delta;
+                }
+                deltaVector[parameter] = delta;
             }
-
-            // We count the number of iterations where the value changes less than the threshold, and terminate if it is large enough.
-            uint64_t tinyChangeIterations = 0;
-
-            std::map<VariableType<FunctionType>, ConstantType> deltaVector;
-
-            std::vector<VariableType<FunctionType>> parameterEnumeration;
-            for (auto parameter : this->parameters) {
-                parameterEnumeration.push_back(parameter);
+        } else {
+            if (currentCheckTask->getBound().comparisonType == logic::ComparisonType::Less ||
+                currentCheckTask->getBound().comparisonType == logic::ComparisonType::LessEqual) {
+                currentValue = utility::infinity<ConstantType>();
+            } else {
+                currentValue = -utility::infinity<ConstantType>();
             }
+        }
 
-            utility::Stopwatch printUpdateStopwatch;
-            printUpdateStopwatch.start();
+        // Log position and probability information for later use in visualizing the descent, if wished.
+        if (recordRun) {
+            VisualizationPoint point;
+            point.position = nesterovPredictedPosition;
+            point.value = currentValue;
+            walk.push_back(point);
+        }
 
-            // The index to keep track of what parameter(s) to consider next.
-            // The "mini-batch", so the parameters to consider, are parameterNum..parameterNum+miniBatchSize-1
-            uint_fast64_t parameterNum = 0;
-            for (uint_fast64_t stepNum = 0; true; ++stepNum) {
-                if (printUpdateStopwatch.getTimeInSeconds() >= 15) {
-                    printUpdateStopwatch.restart();
-                    std::cout << "Currently at ";
-                    std::cout << currentValue << '\n';
-                }
+        // Perform the step. The actualChange is the change in position the step caused. This is different from the
+        // delta in multiple ways: First, it's multiplied with the learning rate and stuff. Second, if the current value
+        // is at epsilon, and the delta would step out of the constrained which is then corrected, the actualChange is the
+        // change from the last to the current corrected position (so might be zero while the delta is not).
+        for (auto const& parameter : miniBatch) {
+            doStep(parameter, position, deltaVector, stepNum);
+        }
 
-                std::vector<VariableType<FunctionType>> miniBatch;
-                for (uint_fast64_t i = parameterNum; i < std::min((uint_fast64_t) parameterEnumeration.size(), parameterNum + miniBatchSize); i++) {
-                    miniBatch.push_back(parameterEnumeration[i]);
-                }
+        if (storm::utility::abs<ConstantType>(oldValue - currentValue) < terminationEpsilon) {
+            tinyChangeIterations += miniBatch.size();
+            if (tinyChangeIterations > parameterEnumeration.size()) {
+                break;
+            }
+        } else {
+            tinyChangeIterations = 0;
+        }
 
-                ConstantType oldValue = currentValue;
-                CoefficientType<FunctionType> const precision = storm::utility::convertNumber<CoefficientType<FunctionType>>(storm::settings::getModule<storm::settings::modules::GeneralSettings>().getPrecision());
+        // Consider the next parameter
+        parameterNum = parameterNum + miniBatchSize;
+        if (parameterNum >= parameterEnumeration.size()) {
+            parameterNum = 0;
+        }
 
-                // If nesterov is enabled, we need to compute the gradient on the predicted position
-                std::map<VariableType<FunctionType>, CoefficientType<FunctionType>> nesterovPredictedPosition(position);
-                if (Nesterov* nesterov = boost::get<Nesterov>(&gradientDescentType)) {
-                    CoefficientType<FunctionType> const upperBound = (utility::one<CoefficientType<FunctionType>>() - precision);
-                    for (auto const& parameter : miniBatch) {
-                        ConstantType const addedTerm = nesterov->momentumTerm * nesterov->pastStep[parameter];
-                        nesterovPredictedPosition[parameter] += storm::utility::convertNumber<CoefficientType<FunctionType>>(addedTerm);
-                        nesterovPredictedPosition[parameter] = utility::max(precision, nesterovPredictedPosition[parameter]);
-                        nesterovPredictedPosition[parameter] = utility::min(upperBound, nesterovPredictedPosition[parameter]);
-                    }
-                }
-                if (constraintMethod == GradientDescentConstraintMethod::LOGISTIC_SIGMOID) {
-                    // Apply sigmoid function
-                    for (auto const& parameter : parameters) {
-                        nesterovPredictedPosition[parameter] = utility::one<CoefficientType<FunctionType>>() /
-                                                               (utility::one<CoefficientType<FunctionType>>()
-                                                                + utility::convertNumber<CoefficientType<FunctionType>>(std::exp(-utility::convertNumber<double>(nesterovPredictedPosition[parameter]))));
-                    }
-                }
+        if (storm::utility::resources::isTerminate()) {
+            STORM_LOG_WARN("Aborting Gradient Descent, returning non-optimal value.");
+            break;
+        }
+    }
+    return currentValue;
+}
 
-                // Compute the value of our position and terminate if it satisfies the bound or is
-                // zero or one when computing probabilities. The "valueVector" (just the probability/expected
-                // reward for eventually reaching the target from every state) is also used for computing
-                // the gradient later. We only need one computation of the "valueVector" per mini-batch.
-                //
-                // If nesterov is activated, we need to do this twice. First, to check the value of the current position.
-                // Second, to compute the valueVector at the nesterovPredictedPosition.
-                // If nesterov is deactivated, then nesterovPredictedPosition == position.
+template<typename FunctionType, typename ConstantType>
+std::pair<std::map<VariableType<FunctionType>, CoefficientType<FunctionType>>, ConstantType>
+GradientDescentInstantiationSearcher<FunctionType, ConstantType>::gradientDescent(Environment const& env) {
+    STORM_LOG_ASSERT(this->currentCheckTask, "Call specifyFormula before calling gradientDescent");
 
-                // Are we at a stochastic (in bounds) position?
-                bool stochasticPosition = true;
-                for (auto const& parameter : parameters) {
-                    if (nesterovPredictedPosition[parameter] < 0 + precision || nesterovPredictedPosition[parameter] > 1 - precision) {
-                        stochasticPosition = false;
-                        break;
-                    }
-                }
+    resetDynamicValues();
 
-                bool computeValue = true;
-                if (constraintMethod == GradientDescentConstraintMethod::BARRIER_INFINITY || constraintMethod == GradientDescentConstraintMethod::BARRIER_LOGARITHMIC) {
-                    if (!stochasticPosition) {
-                        computeValue = false;
-                    }
-                }
+    STORM_LOG_ASSERT(this->currentCheckTask->isBoundSet(), "No bound on formula! E.g. P>=0.5 [F \"goal\"]");
 
-                if (computeValue) {
-                    std::unique_ptr<storm::modelchecker::CheckResult> intermediateResult = instantiationModelChecker->check(env, nesterovPredictedPosition);
-                    std::vector<ConstantType> valueVector = intermediateResult->asExplicitQuantitativeCheckResult<ConstantType>().getValueVector();
-                    if (Nesterov* nesterov = boost::get<Nesterov>(&gradientDescentType)) {
-                        std::map<VariableType<FunctionType>, CoefficientType<FunctionType>> modelCheckPosition(position);
-                        if (constraintMethod == GradientDescentConstraintMethod::LOGISTIC_SIGMOID) {
-                            for (auto const& parameter : parameters) {
-                                modelCheckPosition[parameter] = utility::one<CoefficientType<FunctionType>>() / (utility::one<CoefficientType<FunctionType>>() + utility::convertNumber<CoefficientType<FunctionType>>(std::exp(-utility::convertNumber<double>(modelCheckPosition[parameter]))));
-                            }
-                        }
-                        std::unique_ptr<storm::modelchecker::CheckResult> terminationResult = instantiationModelChecker->check(env, modelCheckPosition);
-                        std::vector<ConstantType> terminationValueVector = terminationResult->asExplicitQuantitativeCheckResult<ConstantType>().getValueVector();
-                        currentValue = terminationValueVector[initialState];
-                    } else {
-                        currentValue = valueVector[initialState];
-                    }
+    std::map<VariableType<FunctionType>, CoefficientType<FunctionType>> bestInstantiation;
+    ConstantType bestValue;
+    switch (this->currentCheckTask->getBound().comparisonType) {
+        case logic::ComparisonType::Greater:
+        case logic::ComparisonType::GreaterEqual:
+            bestValue = -utility::infinity<ConstantType>();
+            break;
+        case logic::ComparisonType::Less:
+        case logic::ComparisonType::LessEqual:
+            bestValue = utility::infinity<ConstantType>();
+            break;
+    }
 
-                    if (currentCheckTask->getBound().isSatisfied(currentValue) && stochasticPosition) {
-                        break;
-                    }
-
-                    for (auto const& parameter : miniBatch) {
-                        auto checkResult = derivativeEvaluationHelper->check(env, nesterovPredictedPosition, parameter, valueVector);
-                        ConstantType delta = checkResult->getValueVector()[0];
-                        if (currentCheckTask->getBound().comparisonType == logic::ComparisonType::Less || currentCheckTask->getBound().comparisonType == logic::ComparisonType::LessEqual) {
-                            delta = -delta;
-                        }
-                        deltaVector[parameter] = delta;
-                    }
+    std::random_device device;
+    std::default_random_engine engine(device());
+    std::uniform_real_distribution<> dist(0, 1);
+    bool initialGuess = true;
+    std::map<VariableType<FunctionType>, CoefficientType<FunctionType>> point;
+    while (true) {
+        std::cout << "Trying out a new starting point" << std::endl;
+        if (initialGuess) {
+            std::cout << "Trying initial guess (p->0.5 for every parameter p or set start point)" << std::endl;
+        }
+        // Generate random starting point
+        for (auto const& param : this->parameters) {
+            if (initialGuess) {
+                logarithmicBarrierTerm = utility::convertNumber<ConstantType>(0.1);
+                if (startPoint) {
+                    point[param] = (*startPoint)[param];
                 } else {
-                    if (currentCheckTask->getBound().comparisonType == logic::ComparisonType::Less || currentCheckTask->getBound().comparisonType == logic::ComparisonType::LessEqual) {
-                        currentValue = utility::infinity<ConstantType>();
-                    } else {
-                        currentValue = -utility::infinity<ConstantType>();
-                    }
+                    point[param] = utility::convertNumber<CoefficientType<FunctionType>>(0.5 + 1e-6);
                 }
-
-                // Log position and probability information for later use in visualizing the descent, if wished.
-                if (recordRun) {
-                    VisualizationPoint point;
-                    point.position = nesterovPredictedPosition;
-                    point.value = currentValue;
-                    walk.push_back(point);
-                }
-
-                // Perform the step. The actualChange is the change in position the step caused. This is different from the
-                // delta in multiple ways: First, it's multiplied with the learning rate and stuff. Second, if the current value
-                // is at epsilon, and the delta would step out of the constrained which is then corrected, the actualChange is the
-                // change from the last to the current corrected position (so might be zero while the delta is not).
-                for (auto const& parameter : miniBatch) {
-                    doStep(parameter, position, deltaVector, stepNum);
-                }
-
-                if (storm::utility::abs<ConstantType>(oldValue - currentValue) < terminationEpsilon) {
-                    tinyChangeIterations += miniBatch.size();
-                    if (tinyChangeIterations > parameterEnumeration.size()) {
-                        break;
-                    }
-                } else {
-                    tinyChangeIterations = 0;
-                }
-
-                // Consider the next parameter
-                parameterNum = parameterNum + miniBatchSize;
-                if (parameterNum >= parameterEnumeration.size()) {
-                    parameterNum = 0;
-                }
-
-                if (storm::utility::resources::isTerminate()) {
-                    STORM_LOG_WARN("Aborting Gradient Descent, returning non-optimal value.");
-                    break;
-                }
-            }
-            return currentValue;
-        }
-
-        template<typename FunctionType, typename ConstantType>
-        std::pair<std::map<VariableType<FunctionType>, CoefficientType<FunctionType>>, ConstantType> GradientDescentInstantiationSearcher<FunctionType, ConstantType>::gradientDescent(
-            Environment const& env
-        ) {
-            STORM_LOG_ASSERT(this->currentCheckTask, "Call specifyFormula before calling gradientDescent");
-
-            resetDynamicValues();
-
-            STORM_LOG_ASSERT(this->currentCheckTask->isBoundSet(), "No bound on formula! E.g. P>=0.5 [F \"goal\"]");
-
-            std::map<VariableType<FunctionType>, CoefficientType<FunctionType>> bestInstantiation;
-            ConstantType bestValue;
-            switch (this->currentCheckTask->getBound().comparisonType) {
-                case logic::ComparisonType::Greater:
-                case logic::ComparisonType::GreaterEqual:
-                    bestValue = -utility::infinity<ConstantType>();
-                    break;
-                case logic::ComparisonType::Less:
-                case logic::ComparisonType::LessEqual:
-                    bestValue = utility::infinity<ConstantType>();
-                    break;
-            }
-
-            std::random_device device;
-            std::default_random_engine engine(device());
-            std::uniform_real_distribution<> dist(0, 1);
-            bool initialGuess = true;
-            std::map<VariableType<FunctionType>, CoefficientType<FunctionType>> point;
-            while (true) {
-                std::cout << "Trying out a new starting point\n";
-                if (initialGuess) {
-                    std::cout << "Trying initial guess (p->0.5 for every parameter p or set start point)\n";
-                }
-                // Generate random starting point
-                for (auto const& param : this->parameters) {
-                    if (initialGuess) {
-                        logarithmicBarrierTerm = utility::convertNumber<ConstantType>(0.1);
-                        if (startPoint) {
-                            point[param] = (*startPoint)[param];
-                        } else {
-                            point[param] = utility::convertNumber<CoefficientType<FunctionType>>(0.5 + 1e-6);
-                        }
-                    } else if (!initialGuess && constraintMethod == GradientDescentConstraintMethod::BARRIER_LOGARITHMIC && logarithmicBarrierTerm > utility::convertNumber<ConstantType>(0.00001)) {
-                         // Do nothing
-                    } else {
-                        logarithmicBarrierTerm = utility::convertNumber<ConstantType>(0.1);
-                        point[param] = utility::convertNumber<CoefficientType<FunctionType>>(dist(engine));
-                    }
-                }
-                initialGuess = false;
-
-                /* walk.clear(); */
-
-                stochasticWatch.start();
-                std::cout << "Starting at " << point << '\n';
-                ConstantType prob = stochasticGradientDescent(env, point);
-                stochasticWatch.stop();
-
-                bool isFoundPointBetter = false;
-                switch (this->currentCheckTask->getBound().comparisonType) {
-                    case logic::ComparisonType::Greater:
-                    case logic::ComparisonType::GreaterEqual:
-                        isFoundPointBetter = prob > bestValue;
-                        break;
-                    case logic::ComparisonType::Less:
-                    case logic::ComparisonType::LessEqual:
-                        isFoundPointBetter = prob < bestValue;
-                        break;
-                }
-                if (isFoundPointBetter) {
-                    bestInstantiation = point;
-                    bestValue = prob;
-                }
-
-                if (currentCheckTask->getBound().isSatisfied(bestValue)) {
-                    std::cout << "Aborting because the bound is satisfied\n";
-                    break;
-                } else if (storm::utility::resources::isTerminate()) {
-                    break;
-                } else {
-                    if (constraintMethod == GradientDescentConstraintMethod::BARRIER_LOGARITHMIC) {
-                        logarithmicBarrierTerm = logarithmicBarrierTerm / 10;
-                        std::cout << "Smaller term\n";
-                        std::cout << bestValue << '\n';
-                        std::cout << logarithmicBarrierTerm << '\n';
-                        continue;
-                    }
-                    std::cout << "Sorry, couldn't satisfy the bound (yet). Best found value so far: " << bestValue << '\n';
-                    continue;
-                }
-            }
-
-            if (constraintMethod == GradientDescentConstraintMethod::LOGISTIC_SIGMOID) {
-                // Apply sigmoid function
-                for (auto const& parameter : parameters) {
-                    bestInstantiation[parameter] = utility::one<CoefficientType<FunctionType>>() / (utility::one<CoefficientType<FunctionType>>() + utility::convertNumber<CoefficientType<FunctionType>>(std::exp(-utility::convertNumber<double>(bestInstantiation[parameter]))));
-                }
-            }
-
-            return std::make_pair(bestInstantiation, bestValue);
-        }
-
-        template<typename FunctionType, typename ConstantType>
-        void GradientDescentInstantiationSearcher<FunctionType, ConstantType>::resetDynamicValues() {
-            if (Adam* adam = boost::get<Adam>(&gradientDescentType)) {
-                for (auto const& parameter : this->parameters) {
-                    adam->decayingStepAverage[parameter] = utility::zero<ConstantType>();
-                    adam->decayingStepAverageSquared[parameter] = utility::zero<ConstantType>();
-                }
-            } else if (RAdam* radam = boost::get<RAdam>(&gradientDescentType)) {
-                for (auto const& parameter : this->parameters) {
-                    radam->decayingStepAverage[parameter] = utility::zero<ConstantType>();
-                    radam->decayingStepAverageSquared[parameter] = utility::zero<ConstantType>();
-                }
-            } else if (RmsProp* rmsProp = boost::get<RmsProp>(&gradientDescentType)) {
-                for (auto const& parameter : this->parameters) {
-                    rmsProp->rootMeanSquare[parameter] = utility::zero<ConstantType>();
-                }
-            } else if (Momentum* momentum = boost::get<Momentum>(&gradientDescentType)) {
-                for (auto const& parameter : this->parameters) {
-                    momentum->pastStep[parameter] = utility::zero<ConstantType>();
-                }
-            } else if (Nesterov* nesterov = boost::get<Nesterov>(&gradientDescentType)) {
-                for (auto const& parameter : this->parameters) {
-                    nesterov->pastStep[parameter] = utility::zero<ConstantType>();
-                }
+            } else if (!initialGuess && constraintMethod == GradientDescentConstraintMethod::BARRIER_LOGARITHMIC &&
+                       logarithmicBarrierTerm > utility::convertNumber<ConstantType>(0.00001)) {
+                // Do nothing
+            } else {
+                logarithmicBarrierTerm = utility::convertNumber<ConstantType>(0.1);
+                point[param] = utility::convertNumber<CoefficientType<FunctionType>>(dist(engine));
             }
         }
+        initialGuess = false;
 
-        template<typename FunctionType, typename ConstantType>
-        void GradientDescentInstantiationSearcher<FunctionType, ConstantType>::printRunAsJson() {
-            std::cout << "[";
-            for (auto s = walk.begin(); s != walk.end(); ++s) {
-                std::cout << "{";
-                auto point = s->position;
-                for (auto iter = point.begin(); iter != point.end(); ++iter) {
-                    std::cout << "\"" << iter->first.name() << "\"";
-                    std::cout << ":";
-                    std::cout << utility::convertNumber<double>(iter->second);
-                    std::cout << ",";
-                }
-                std::cout << "\"value\":";
-                std::cout << s->value;
-                std::cout << "}";
-                if (std::next(s) != walk.end()) {
-                    std::cout << ",";
-                }
+        /* walk.clear(); */
+
+        stochasticWatch.start();
+        std::cout << "Starting at " << point << std::endl;
+        ConstantType prob = stochasticGradientDescent(env, point);
+        stochasticWatch.stop();
+
+        bool isFoundPointBetter = false;
+        switch (this->currentCheckTask->getBound().comparisonType) {
+            case logic::ComparisonType::Greater:
+            case logic::ComparisonType::GreaterEqual:
+                isFoundPointBetter = prob > bestValue;
+                break;
+            case logic::ComparisonType::Less:
+            case logic::ComparisonType::LessEqual:
+                isFoundPointBetter = prob < bestValue;
+                break;
+        }
+        if (isFoundPointBetter) {
+            bestInstantiation = point;
+            bestValue = prob;
+        }
+
+        if (currentCheckTask->getBound().isSatisfied(bestValue)) {
+            std::cout << "Aborting because the bound is satisfied" << std::endl;
+            break;
+        } else if (storm::utility::resources::isTerminate()) {
+            break;
+        } else {
+            if (constraintMethod == GradientDescentConstraintMethod::BARRIER_LOGARITHMIC) {
+                logarithmicBarrierTerm = logarithmicBarrierTerm / 10;
+                std::cout << "Smaller term" << std::endl;
+                std::cout << bestValue << std::endl;
+                std::cout << logarithmicBarrierTerm << std::endl;
+                continue;
             }
-            std::cout << "]\n";
-            // Print value at last step for data collection
-            std::cout << storm::utility::convertNumber<double>(walk.at(walk.size() - 1).value) << '\n';
+            std::cout << "Sorry, couldn't satisfy the bound (yet). Best found value so far: " << bestValue << std::endl;
+            continue;
         }
+    }
 
-        template<typename FunctionType, typename ConstantType>
-        std::vector<typename GradientDescentInstantiationSearcher<FunctionType, ConstantType>::VisualizationPoint> GradientDescentInstantiationSearcher<FunctionType, ConstantType>::getVisualizationWalk() {
-            return walk;
+    if (constraintMethod == GradientDescentConstraintMethod::LOGISTIC_SIGMOID) {
+        // Apply sigmoid function
+        for (auto const& parameter : parameters) {
+            bestInstantiation[parameter] =
+                utility::one<CoefficientType<FunctionType>>() /
+                (utility::one<CoefficientType<FunctionType>>() +
+                 utility::convertNumber<CoefficientType<FunctionType>>(std::exp(-utility::convertNumber<double>(bestInstantiation[parameter]))));
         }
+    }
 
-        template class GradientDescentInstantiationSearcher<RationalFunction, RationalNumber>;
-        template class GradientDescentInstantiationSearcher<RationalFunction, double>;
+    return std::make_pair(bestInstantiation, bestValue);
+}
+
+template<typename FunctionType, typename ConstantType>
+void GradientDescentInstantiationSearcher<FunctionType, ConstantType>::resetDynamicValues() {
+    if (Adam* adam = boost::get<Adam>(&gradientDescentType)) {
+        for (auto const& parameter : this->parameters) {
+            adam->decayingStepAverage[parameter] = utility::zero<ConstantType>();
+            adam->decayingStepAverageSquared[parameter] = utility::zero<ConstantType>();
+        }
+    } else if (RAdam* radam = boost::get<RAdam>(&gradientDescentType)) {
+        for (auto const& parameter : this->parameters) {
+            radam->decayingStepAverage[parameter] = utility::zero<ConstantType>();
+            radam->decayingStepAverageSquared[parameter] = utility::zero<ConstantType>();
+        }
+    } else if (RmsProp* rmsProp = boost::get<RmsProp>(&gradientDescentType)) {
+        for (auto const& parameter : this->parameters) {
+            rmsProp->rootMeanSquare[parameter] = utility::zero<ConstantType>();
+        }
+    } else if (Momentum* momentum = boost::get<Momentum>(&gradientDescentType)) {
+        for (auto const& parameter : this->parameters) {
+            momentum->pastStep[parameter] = utility::zero<ConstantType>();
+        }
+    } else if (Nesterov* nesterov = boost::get<Nesterov>(&gradientDescentType)) {
+        for (auto const& parameter : this->parameters) {
+            nesterov->pastStep[parameter] = utility::zero<ConstantType>();
+        }
     }
 }
+
+template<typename FunctionType, typename ConstantType>
+void GradientDescentInstantiationSearcher<FunctionType, ConstantType>::printRunAsJson() {
+    std::cout << "[";
+    for (auto s = walk.begin(); s != walk.end(); ++s) {
+        std::cout << "{";
+        auto point = s->position;
+        for (auto iter = point.begin(); iter != point.end(); ++iter) {
+            std::cout << "\"" << iter->first.name() << "\"";
+            std::cout << ":";
+            std::cout << utility::convertNumber<double>(iter->second);
+            std::cout << ",";
+        }
+        std::cout << "\"value\":";
+        std::cout << s->value;
+        std::cout << "}";
+        if (std::next(s) != walk.end()) {
+            std::cout << ",";
+        }
+    }
+    std::cout << "]" << std::endl;
+    // Print value at last step for data collection
+    std::cout << storm::utility::convertNumber<double>(walk.at(walk.size() - 1).value) << std::endl;
+}
+
+template<typename FunctionType, typename ConstantType>
+std::vector<typename GradientDescentInstantiationSearcher<FunctionType, ConstantType>::VisualizationPoint>
+GradientDescentInstantiationSearcher<FunctionType, ConstantType>::getVisualizationWalk() {
+    return walk;
+}
+
+template class GradientDescentInstantiationSearcher<RationalFunction, RationalNumber>;
+template class GradientDescentInstantiationSearcher<RationalFunction, double>;
+}  // namespace derivative
+}  // namespace storm

--- a/src/storm-pars/derivative/GradientDescentInstantiationSearcher.h
+++ b/src/storm-pars/derivative/GradientDescentInstantiationSearcher.h
@@ -3,278 +3,273 @@
 
 #include <map>
 #include <memory>
+#include "GradientDescentConstraintMethod.h"
+#include "GradientDescentMethod.h"
 #include "analysis/GraphConditions.h"
-#include "settings/modules/GeneralSettings.h"
-#include "storm-parsers/parser/FormulaParser.h"
-#include "storm/exceptions/WrongFormatException.h"
 #include "logic/Formula.h"
+#include "settings/modules/GeneralSettings.h"
 #include "solver/LinearEquationSolver.h"
 #include "storm-pars/analysis/MonotonicityHelper.h"
 #include "storm-pars/derivative/SparseDerivativeInstantiationModelChecker.h"
 #include "storm-pars/modelchecker/instantiation/SparseDtmcInstantiationModelChecker.h"
 #include "storm-pars/utility/parametric.h"
+#include "storm-parsers/parser/FormulaParser.h"
+#include "storm/exceptions/WrongFormatException.h"
 #include "storm/models/sparse/Dtmc.h"
 #include "storm/utility/Stopwatch.h"
-#include "GradientDescentMethod.h"
-#include "GradientDescentConstraintMethod.h"
 
 namespace storm {
-    namespace derivative {
-        template <typename FunctionType, typename ConstantType>
-        class GradientDescentInstantiationSearcher {
-
-        public:
-            /**
-             * The GradientDescentInstantiationSearcher can find extrema and feasible instantiations in pMCs,
-             * for either rewards or probabilities.
-             * Internally uses the SparseDerivativeInstantiationModelChecker to evaluate derivatives at instantiations.
-             * @param env The environment. Always pass the same environment to the gradientDescent call!
-             * @param model The Dtmc to optimize.
-             * @param method The method of gradient descent that is used. 
-             * @param learningRate The learning rate of the Gradient Descent.
-             * @param averageDecay Decay of ADAM's decaying average.
-             * @param squaredAverageDecay Decay of ADAM's squared decaying average.
-             * @param miniBatchSize Size of a minibatch.
-             * @param terminationEpsilon A value step smaller than this is considered a "tiny step", after
-             * a number of these the algorithm will terminate.
-             * @param startPoint Start point of the search (default: all parameters set to 0.5)
-             * @param recordRun Records the run into a global variable, which can be converted into JSON
-             * using the printRunAsJson function 
-             */
-            GradientDescentInstantiationSearcher<FunctionType, ConstantType>(
-                    storm::models::sparse::Dtmc<FunctionType> const model,
-                    GradientDescentMethod method = GradientDescentMethod::ADAM,
-                    ConstantType learningRate = 0.1,
-                    ConstantType averageDecay = 0.9,
-                    ConstantType squaredAverageDecay = 0.999,
-                    uint_fast64_t miniBatchSize = 32,
-                    ConstantType terminationEpsilon = 1e-6,
-                    boost::optional<std::map<typename utility::parametric::VariableType<FunctionType>::type, typename utility::parametric::CoefficientType<FunctionType>::type>> startPoint = boost::none,
-                    GradientDescentConstraintMethod constraintMethod = GradientDescentConstraintMethod::PROJECT_WITH_GRADIENT,
-                    bool recordRun = false
-            ) : model(model)
-              , derivativeEvaluationHelper(std::make_unique<SparseDerivativeInstantiationModelChecker<FunctionType, ConstantType>>(model))
-              , instantiationModelChecker(std::make_unique<modelchecker::SparseDtmcInstantiationModelChecker<models::sparse::Dtmc<FunctionType>, ConstantType>>(model))
-              , startPoint(startPoint)
-              , miniBatchSize(miniBatchSize)
-              , terminationEpsilon(terminationEpsilon)
-              , constraintMethod(constraintMethod)
-              , recordRun(recordRun) {
-                switch (method) {
-                    case GradientDescentMethod::ADAM: {
-                        Adam adam;
-                        adam.learningRate = learningRate;
-                        adam.averageDecay = averageDecay;
-                        adam.averageDecay = averageDecay;
-                        adam.squaredAverageDecay = squaredAverageDecay;
-                        gradientDescentType = adam;
-                        break;
-                    }
-                    case GradientDescentMethod::RADAM: {
-                        RAdam radam;
-                        radam.learningRate = learningRate;
-                        radam.averageDecay = averageDecay;
-                        radam.squaredAverageDecay = squaredAverageDecay;
-                        gradientDescentType = radam;
-                        break;
-                    }
-                    case GradientDescentMethod::RMSPROP: {
-                        RmsProp rmsProp;
-                        rmsProp.learningRate = learningRate;
-                        rmsProp.averageDecay = averageDecay;
-                        gradientDescentType = rmsProp;
-                        break;
-                    }
-                    case GradientDescentMethod::PLAIN:
-                    case GradientDescentMethod::PLAIN_SIGN: {
-                        Plain plain;
-                        plain.learningRate = learningRate;
-                        gradientDescentType = plain;
-                        if (method == GradientDescentMethod::PLAIN_SIGN) {
-                            useSignsOnly = true;
-                        } else {
-                            useSignsOnly = false;
-                        }
-                        break;
-                    }
-                    case GradientDescentMethod::MOMENTUM: 
-                    case GradientDescentMethod::MOMENTUM_SIGN: {
-                        Momentum momentum;
-                        momentum.learningRate = learningRate;
-                        // TODO Document this
-                        momentum.momentumTerm = averageDecay;
-                        gradientDescentType = momentum;
-                        if (method == GradientDescentMethod::MOMENTUM_SIGN) {
-                            useSignsOnly = true;
-                        } else {
-                            useSignsOnly = false;
-                        }
-                        break;
-                    }
-                    case GradientDescentMethod::NESTEROV:
-                    case GradientDescentMethod::NESTEROV_SIGN: {
-                        Nesterov nesterov;
-                        nesterov.learningRate = learningRate;
-                        // TODO Document this
-                        nesterov.momentumTerm = averageDecay;
-                        gradientDescentType = nesterov;
-                        if (method == GradientDescentMethod::NESTEROV_SIGN) {
-                            useSignsOnly = true;
-                        } else {
-                            useSignsOnly = false;
-                        }
-                        break;
-                    }
-                }
+namespace derivative {
+template<typename FunctionType, typename ConstantType>
+class GradientDescentInstantiationSearcher {
+   public:
+    /**
+     * The GradientDescentInstantiationSearcher can find extrema and feasible instantiations in pMCs,
+     * for either rewards or probabilities.
+     * Internally uses the SparseDerivativeInstantiationModelChecker to evaluate derivatives at instantiations.
+     * @param env The environment. Always pass the same environment to the gradientDescent call!
+     * @param model The Dtmc to optimize.
+     * @param method The method of gradient descent that is used.
+     * @param learningRate The learning rate of the Gradient Descent.
+     * @param averageDecay Decay of ADAM's decaying average.
+     * @param squaredAverageDecay Decay of ADAM's squared decaying average.
+     * @param miniBatchSize Size of a minibatch.
+     * @param terminationEpsilon A value step smaller than this is considered a "tiny step", after
+     * a number of these the algorithm will terminate.
+     * @param startPoint Start point of the search (default: all parameters set to 0.5)
+     * @param recordRun Records the run into a global variable, which can be converted into JSON
+     * using the printRunAsJson function
+     */
+    GradientDescentInstantiationSearcher<FunctionType, ConstantType>(
+        storm::models::sparse::Dtmc<FunctionType> const model, GradientDescentMethod method = GradientDescentMethod::ADAM, ConstantType learningRate = 0.1,
+        ConstantType averageDecay = 0.9, ConstantType squaredAverageDecay = 0.999, uint_fast64_t miniBatchSize = 32, ConstantType terminationEpsilon = 1e-6,
+        boost::optional<
+            std::map<typename utility::parametric::VariableType<FunctionType>::type, typename utility::parametric::CoefficientType<FunctionType>::type>>
+            startPoint = boost::none,
+        GradientDescentConstraintMethod constraintMethod = GradientDescentConstraintMethod::PROJECT_WITH_GRADIENT, bool recordRun = false)
+        : model(model),
+          derivativeEvaluationHelper(std::make_unique<SparseDerivativeInstantiationModelChecker<FunctionType, ConstantType>>(model)),
+          instantiationModelChecker(
+              std::make_unique<modelchecker::SparseDtmcInstantiationModelChecker<models::sparse::Dtmc<FunctionType>, ConstantType>>(model)),
+          startPoint(startPoint),
+          miniBatchSize(miniBatchSize),
+          terminationEpsilon(terminationEpsilon),
+          constraintMethod(constraintMethod),
+          recordRun(recordRun) {
+        switch (method) {
+            case GradientDescentMethod::ADAM: {
+                Adam adam;
+                adam.learningRate = learningRate;
+                adam.averageDecay = averageDecay;
+                adam.averageDecay = averageDecay;
+                adam.squaredAverageDecay = squaredAverageDecay;
+                gradientDescentType = adam;
+                break;
             }
-
-            /**
-             * specifyFormula specifies a CheckTask.
-             * This will setup the matrices used for computing the derivatives by constructing the
-             * SparseDerivativeInstantiationModelChecker. Note this can consume a substantial amount of memory if the model is
-             * big and there's a large number of parameters.
-             * @param env The environment. Pass the same environment as to gradientDescent. We need this because we need to know what kind of
-             * equation solver we are dealing with.
-             * @param checkTask The CheckTask.
-             */
-            void specifyFormula(Environment const& env, modelchecker::CheckTask<logic::Formula, FunctionType> const& checkTask) {
-                this->currentFormula = checkTask.getFormula().asSharedPointer();
-                this->currentCheckTask = std::make_unique<storm::modelchecker::CheckTask<storm::logic::Formula, FunctionType>>(checkTask.substituteFormula(*currentFormula).template convertValueType<FunctionType>());
-
-                if (!checkTask.getFormula().isRewardOperatorFormula()) {
-                    this->currentFormulaNoBound = std::make_shared<storm::logic::ProbabilityOperatorFormula>(
-                        checkTask.getFormula().asProbabilityOperatorFormula().getSubformula().asSharedPointer(), storm::logic::OperatorInformation(boost::none, boost::none));
+            case GradientDescentMethod::RADAM: {
+                RAdam radam;
+                radam.learningRate = learningRate;
+                radam.averageDecay = averageDecay;
+                radam.squaredAverageDecay = squaredAverageDecay;
+                gradientDescentType = radam;
+                break;
+            }
+            case GradientDescentMethod::RMSPROP: {
+                RmsProp rmsProp;
+                rmsProp.learningRate = learningRate;
+                rmsProp.averageDecay = averageDecay;
+                gradientDescentType = rmsProp;
+                break;
+            }
+            case GradientDescentMethod::PLAIN:
+            case GradientDescentMethod::PLAIN_SIGN: {
+                Plain plain;
+                plain.learningRate = learningRate;
+                gradientDescentType = plain;
+                if (method == GradientDescentMethod::PLAIN_SIGN) {
+                    useSignsOnly = true;
                 } else {
-                    // No worries, this works as intended, the API is just weird.
-                    this->currentFormulaNoBound = std::make_shared<storm::logic::RewardOperatorFormula>(
-                        checkTask.getFormula().asRewardOperatorFormula().getSubformula().asSharedPointer());
+                    useSignsOnly = false;
                 }
-                this->currentCheckTaskNoBound = std::make_unique<storm::modelchecker::CheckTask<storm::logic::Formula, FunctionType>>(*currentFormulaNoBound);
-                this->currentCheckTaskNoBoundConstantType = std::make_unique<storm::modelchecker::CheckTask<storm::logic::Formula, ConstantType>>(*currentFormulaNoBound);
-
-                this->parameters = storm::models::sparse::getProbabilityParameters(model);
-                if (checkTask.getFormula().isRewardOperatorFormula()) {
-                    for (auto const& rewardParameter : storm::models::sparse::getRewardParameters(model)) {
-                        this->parameters.insert(rewardParameter);
-                    }
-                }
-                instantiationModelChecker->specifyFormula(*this->currentCheckTaskNoBound);
-                derivativeEvaluationHelper->specifyFormula(env, *this->currentCheckTaskNoBound);
+                break;
             }
-
-
-            /**
-             * Perform Gradient Descent.
-             * @param env The environment. Pass the same environment as to specifyFormula.
-             */
-            std::pair<std::map<typename utility::parametric::VariableType<FunctionType>::type, typename utility::parametric::CoefficientType<FunctionType>::type>, ConstantType> gradientDescent(
-                Environment const& env
-            );
-
-            /**
-             * Print the previously done run as JSON. This run can be retrieved using getVisualizationWalk.
-             */
-            void printRunAsJson();
-
-            /**
-             * A point in the Gradient Descent walk, recorded if recordRun is set to true in the constructor (false by default).
-             */
-            struct VisualizationPoint {
-                std::map<typename utility::parametric::VariableType<FunctionType>::type, typename utility::parametric::CoefficientType<FunctionType>::type> position;
-                ConstantType value;
-            };
-            /**
-             * Get the visualization walk that is recorded if recordRun is set to true in the constructor (false by default).
-             */
-            std::vector<VisualizationPoint> getVisualizationWalk();
-            
-        private:
-            void resetDynamicValues();
-
-            std::unique_ptr<modelchecker::CheckTask<storm::logic::Formula, FunctionType>> currentCheckTask;
-            std::unique_ptr<modelchecker::CheckTask<storm::logic::Formula, FunctionType>> currentCheckTaskNoBound;
-            std::unique_ptr<modelchecker::CheckTask<storm::logic::Formula, ConstantType>> currentCheckTaskNoBoundConstantType;
-            std::shared_ptr<storm::logic::Formula const> currentFormula;
-            std::shared_ptr<storm::logic::Formula const> currentFormulaNoBound;
-
-            const models::sparse::Dtmc<FunctionType> model;
-            std::set<typename utility::parametric::VariableType<FunctionType>::type> parameters;
-            std::unique_ptr<storm::derivative::SparseDerivativeInstantiationModelChecker<FunctionType, ConstantType>> derivativeEvaluationHelper;
-            std::unique_ptr<storm::analysis::MonotonicityHelper<FunctionType, ConstantType>> monotonicityHelper;
-            const std::unique_ptr<modelchecker::SparseDtmcInstantiationModelChecker<models::sparse::Dtmc<FunctionType>, ConstantType>> instantiationModelChecker;
-            boost::optional<std::map<typename utility::parametric::VariableType<FunctionType>::type, typename utility::parametric::CoefficientType<FunctionType>::type>> startPoint;
-            const uint_fast64_t miniBatchSize;
-            const ConstantType terminationEpsilon;
-            const GradientDescentConstraintMethod constraintMethod;
-
-            // This is for visualizing data
-            const bool recordRun;
-            std::vector<VisualizationPoint> walk; 
-
-
-            // Gradient Descent types and data that belongs to them, with hyperparameters and running data.
-            struct Adam {
-                ConstantType averageDecay;
-                ConstantType squaredAverageDecay;
-                ConstantType learningRate;
-                std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType> decayingStepAverageSquared;
-                std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType> decayingStepAverage;
-            };
-            struct RAdam {
-                ConstantType averageDecay;
-                ConstantType squaredAverageDecay;
-                ConstantType learningRate;
-                std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType> decayingStepAverageSquared;
-                std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType> decayingStepAverage;
-            };
-            struct RmsProp {
-                ConstantType averageDecay;
-                ConstantType learningRate;
-                std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType> rootMeanSquare;
-            };
-            struct Plain {
-                ConstantType learningRate;
-            };
-            struct Momentum {
-                ConstantType learningRate;
-                ConstantType momentumTerm;
-                std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType> pastStep;
-            };
-            struct Nesterov {
-                ConstantType learningRate;
-                ConstantType momentumTerm;
-                std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType> pastStep;
-            };
-            typedef boost::variant<Adam, RAdam, RmsProp, Plain, Momentum, Nesterov> GradientDescentType;
-            GradientDescentType gradientDescentType;
-            // Only respected by some Gradient Descent methods, the ones that have a "sign" version in the GradientDescentMethod enum
-            bool useSignsOnly;
-
-            ConstantType logarithmicBarrierTerm;
-
-            ConstantType stochasticGradientDescent(
-                Environment const& env,
-                std::map<typename utility::parametric::VariableType<FunctionType>::type, typename utility::parametric::CoefficientType<FunctionType>::type> &position
-            );
-            ConstantType doStep(
-                typename utility::parametric::VariableType<FunctionType>::type steppingParameter,
-                std::map<typename utility::parametric::VariableType<FunctionType>::type, typename utility::parametric::CoefficientType<FunctionType>::type> &position,
-                const std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType> &gradient,
-                uint_fast64_t stepNum
-            );
-            ConstantType constantTypeSqrt(ConstantType input) {
-                if (std::is_same<ConstantType, double>::value) {
-                    return utility::sqrt(input);
+            case GradientDescentMethod::MOMENTUM:
+            case GradientDescentMethod::MOMENTUM_SIGN: {
+                Momentum momentum;
+                momentum.learningRate = learningRate;
+                // TODO Document this
+                momentum.momentumTerm = averageDecay;
+                gradientDescentType = momentum;
+                if (method == GradientDescentMethod::MOMENTUM_SIGN) {
+                    useSignsOnly = true;
                 } else {
-                    return carl::sqrt(input);
+                    useSignsOnly = false;
                 }
+                break;
             }
-
-            utility::Stopwatch stochasticWatch;
-            utility::Stopwatch batchWatch;
-            utility::Stopwatch startingPointCalculationWatch;
-        };
+            case GradientDescentMethod::NESTEROV:
+            case GradientDescentMethod::NESTEROV_SIGN: {
+                Nesterov nesterov;
+                nesterov.learningRate = learningRate;
+                // TODO Document this
+                nesterov.momentumTerm = averageDecay;
+                gradientDescentType = nesterov;
+                if (method == GradientDescentMethod::NESTEROV_SIGN) {
+                    useSignsOnly = true;
+                } else {
+                    useSignsOnly = false;
+                }
+                break;
+            }
+        }
     }
-}
 
-#endif //STORM_DERIVATIVECHECKER_H
+    /**
+     * specifyFormula specifies a CheckTask.
+     * This will setup the matrices used for computing the derivatives by constructing the
+     * SparseDerivativeInstantiationModelChecker. Note this can consume a substantial amount of memory if the model is
+     * big and there's a large number of parameters.
+     * @param env The environment. Pass the same environment as to gradientDescent. We need this because we need to know what kind of
+     * equation solver we are dealing with.
+     * @param checkTask The CheckTask.
+     */
+    void specifyFormula(Environment const& env, modelchecker::CheckTask<logic::Formula, FunctionType> const& checkTask) {
+        this->currentFormula = checkTask.getFormula().asSharedPointer();
+        this->currentCheckTask = std::make_unique<storm::modelchecker::CheckTask<storm::logic::Formula, FunctionType>>(
+            checkTask.substituteFormula(*currentFormula).template convertValueType<FunctionType>());
+
+        if (!checkTask.getFormula().isRewardOperatorFormula()) {
+            this->currentFormulaNoBound = std::make_shared<storm::logic::ProbabilityOperatorFormula>(
+                checkTask.getFormula().asProbabilityOperatorFormula().getSubformula().asSharedPointer(),
+                storm::logic::OperatorInformation(boost::none, boost::none));
+        } else {
+            // No worries, this works as intended, the API is just weird.
+            this->currentFormulaNoBound =
+                std::make_shared<storm::logic::RewardOperatorFormula>(checkTask.getFormula().asRewardOperatorFormula().getSubformula().asSharedPointer());
+        }
+        this->currentCheckTaskNoBound = std::make_unique<storm::modelchecker::CheckTask<storm::logic::Formula, FunctionType>>(*currentFormulaNoBound);
+        this->currentCheckTaskNoBoundConstantType =
+            std::make_unique<storm::modelchecker::CheckTask<storm::logic::Formula, ConstantType>>(*currentFormulaNoBound);
+
+        this->parameters = storm::models::sparse::getProbabilityParameters(model);
+        if (checkTask.getFormula().isRewardOperatorFormula()) {
+            for (auto const& rewardParameter : storm::models::sparse::getRewardParameters(model)) {
+                this->parameters.insert(rewardParameter);
+            }
+        }
+        instantiationModelChecker->specifyFormula(*this->currentCheckTaskNoBound);
+        derivativeEvaluationHelper->specifyFormula(env, *this->currentCheckTaskNoBound);
+    }
+
+    /**
+     * Perform Gradient Descent.
+     * @param env The environment. Pass the same environment as to specifyFormula.
+     */
+    std::pair<std::map<typename utility::parametric::VariableType<FunctionType>::type, typename utility::parametric::CoefficientType<FunctionType>::type>,
+              ConstantType>
+    gradientDescent(Environment const& env);
+
+    /**
+     * Print the previously done run as JSON. This run can be retrieved using getVisualizationWalk.
+     */
+    void printRunAsJson();
+
+    /**
+     * A point in the Gradient Descent walk, recorded if recordRun is set to true in the constructor (false by default).
+     */
+    struct VisualizationPoint {
+        std::map<typename utility::parametric::VariableType<FunctionType>::type, typename utility::parametric::CoefficientType<FunctionType>::type> position;
+        ConstantType value;
+    };
+    /**
+     * Get the visualization walk that is recorded if recordRun is set to true in the constructor (false by default).
+     */
+    std::vector<VisualizationPoint> getVisualizationWalk();
+
+   private:
+    void resetDynamicValues();
+
+    std::unique_ptr<modelchecker::CheckTask<storm::logic::Formula, FunctionType>> currentCheckTask;
+    std::unique_ptr<modelchecker::CheckTask<storm::logic::Formula, FunctionType>> currentCheckTaskNoBound;
+    std::unique_ptr<modelchecker::CheckTask<storm::logic::Formula, ConstantType>> currentCheckTaskNoBoundConstantType;
+    std::shared_ptr<storm::logic::Formula const> currentFormula;
+    std::shared_ptr<storm::logic::Formula const> currentFormulaNoBound;
+
+    const models::sparse::Dtmc<FunctionType> model;
+    std::set<typename utility::parametric::VariableType<FunctionType>::type> parameters;
+    const std::unique_ptr<storm::derivative::SparseDerivativeInstantiationModelChecker<FunctionType, ConstantType>> derivativeEvaluationHelper;
+    std::unique_ptr<storm::analysis::MonotonicityHelper<FunctionType, ConstantType>> monotonicityHelper;
+    const std::unique_ptr<modelchecker::SparseDtmcInstantiationModelChecker<models::sparse::Dtmc<FunctionType>, ConstantType>> instantiationModelChecker;
+    boost::optional<std::map<typename utility::parametric::VariableType<FunctionType>::type, typename utility::parametric::CoefficientType<FunctionType>::type>>
+        startPoint;
+    const uint_fast64_t miniBatchSize;
+    const ConstantType terminationEpsilon;
+    const GradientDescentConstraintMethod constraintMethod;
+
+    // This is for visualizing data
+    const bool recordRun;
+    std::vector<VisualizationPoint> walk;
+
+    // Gradient Descent types and data that belongs to them, with hyperparameters and running data.
+    struct Adam {
+        ConstantType averageDecay;
+        ConstantType squaredAverageDecay;
+        ConstantType learningRate;
+        std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType> decayingStepAverageSquared;
+        std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType> decayingStepAverage;
+    };
+    struct RAdam {
+        ConstantType averageDecay;
+        ConstantType squaredAverageDecay;
+        ConstantType learningRate;
+        std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType> decayingStepAverageSquared;
+        std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType> decayingStepAverage;
+    };
+    struct RmsProp {
+        ConstantType averageDecay;
+        ConstantType learningRate;
+        std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType> rootMeanSquare;
+    };
+    struct Plain {
+        ConstantType learningRate;
+    };
+    struct Momentum {
+        ConstantType learningRate;
+        ConstantType momentumTerm;
+        std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType> pastStep;
+    };
+    struct Nesterov {
+        ConstantType learningRate;
+        ConstantType momentumTerm;
+        std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType> pastStep;
+    };
+    typedef boost::variant<Adam, RAdam, RmsProp, Plain, Momentum, Nesterov> GradientDescentType;
+    GradientDescentType gradientDescentType;
+    // Only respected by some Gradient Descent methods, the ones that have a "sign" version in the GradientDescentMethod enum
+    bool useSignsOnly;
+
+    ConstantType logarithmicBarrierTerm;
+
+    ConstantType stochasticGradientDescent(
+        Environment const& env,
+        std::map<typename utility::parametric::VariableType<FunctionType>::type, typename utility::parametric::CoefficientType<FunctionType>::type>& position);
+    ConstantType doStep(
+        typename utility::parametric::VariableType<FunctionType>::type steppingParameter,
+        std::map<typename utility::parametric::VariableType<FunctionType>::type, typename utility::parametric::CoefficientType<FunctionType>::type>& position,
+        const std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType>& gradient, uint_fast64_t stepNum);
+    ConstantType constantTypeSqrt(ConstantType input) {
+        if (std::is_same<ConstantType, double>::value) {
+            return utility::sqrt(input);
+        } else {
+            return carl::sqrt(input);
+        }
+    }
+
+    utility::Stopwatch stochasticWatch;
+    utility::Stopwatch batchWatch;
+    utility::Stopwatch startingPointCalculationWatch;
+};
+}  // namespace derivative
+}  // namespace storm
+
+#endif  // STORM_DERIVATIVECHECKER_H

--- a/src/storm-pars/derivative/GradientDescentMethod.h
+++ b/src/storm-pars/derivative/GradientDescentMethod.h
@@ -3,23 +3,23 @@
 #include <boost/optional.hpp>
 #include <string>
 namespace storm {
-	namespace derivative {
-		/**
-		 * GradientDescentMethod is the method of Gradient Descent the GradientDescentInstantiationSearcher
-		 * shall use. 
-		 */
-		enum class GradientDescentMethod {
-			ADAM, ///< The default.
-			RADAM,
-			RMSPROP,
-			PLAIN,
-			PLAIN_SIGN,
-			MOMENTUM,
-			MOMENTUM_SIGN,
-			NESTEROV,
-			NESTEROV_SIGN
-		};
+namespace derivative {
+/**
+ * GradientDescentMethod is the method of Gradient Descent the GradientDescentInstantiationSearcher
+ * shall use.
+ */
+enum class GradientDescentMethod {
+    ADAM,  ///< The default.
+    RADAM,
+    RMSPROP,
+    PLAIN,
+    PLAIN_SIGN,
+    MOMENTUM,
+    MOMENTUM_SIGN,
+    NESTEROV,
+    NESTEROV_SIGN
+};
 
-	}
-}
+}  // namespace derivative
+}  // namespace storm
 #endif

--- a/src/storm-pars/derivative/SparseDerivativeInstantiationModelChecker.cpp
+++ b/src/storm-pars/derivative/SparseDerivativeInstantiationModelChecker.cpp
@@ -1,282 +1,335 @@
 #include "SparseDerivativeInstantiationModelChecker.h"
 #include "analysis/GraphConditions.h"
 #include "environment/Environment.h"
-#include "environment/solver/SolverEnvironment.h"
 #include "environment/solver/GmmxxSolverEnvironment.h"
 #include "environment/solver/MinMaxSolverEnvironment.h"
 #include "environment/solver/NativeSolverEnvironment.h"
 #include "environment/solver/SolverEnvironment.h"
-#include "environment/solver/SolverEnvironment.h"
 #include "environment/solver/TopologicalSolverEnvironment.h"
+#include "logic/Formula.h"
+#include "modelchecker/results/CheckResult.h"
+#include "modelchecker/results/ExplicitQualitativeCheckResult.h"
+#include "settings/SettingsManager.h"
 #include "settings/modules/CoreSettings.h"
+#include "settings/modules/GeneralSettings.h"
 #include "solver/GmmxxLinearEquationSolver.h"
-#include "solver/multiplier/GmmxxMultiplier.h"
 #include "solver/SolverSelectionOptions.h"
 #include "solver/helper/SoundValueIterationHelper.h"
-#include "modelchecker/results/CheckResult.h"
-#include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
-#include "settings/SettingsManager.h"
-#include "settings/modules/GeneralSettings.h"
+#include "solver/multiplier/GmmxxMultiplier.h"
+#include "storage/BitVector.h"
 #include "storm-pars/modelchecker/instantiation/SparseDtmcInstantiationModelChecker.h"
+#include "storm/exceptions/WrongFormatException.h"
+#include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
 #include "storm/solver/EliminationLinearEquationSolver.h"
 #include "storm/solver/LinearEquationSolver.h"
-#include "utility/graph.h"
 #include "storm/utility/vector.h"
-#include "storm/exceptions/WrongFormatException.h"
+#include "utility/constants.h"
+#include "utility/graph.h"
 #include "utility/logging.h"
 
 namespace storm {
-    namespace derivative {
+namespace derivative {
 
-        template<typename FunctionType>
-        using VariableType = typename utility::parametric::VariableType<FunctionType>::type;
-        template<typename FunctionType>
-        using CoefficientType = typename utility::parametric::CoefficientType<FunctionType>::type;
+template<typename FunctionType>
+using VariableType = typename utility::parametric::VariableType<FunctionType>::type;
+template<typename FunctionType>
+using CoefficientType = typename utility::parametric::CoefficientType<FunctionType>::type;
 
-        template<typename FunctionType, typename ConstantType>
-        std::unique_ptr<modelchecker::ExplicitQuantitativeCheckResult<ConstantType>> SparseDerivativeInstantiationModelChecker<FunctionType, ConstantType>::check(Environment const& env, storm::utility::parametric::Valuation<FunctionType> const& valuation, VariableType<FunctionType> const& parameter, boost::optional<std::vector<ConstantType>> const& valueVector) {
-            storm::solver::GeneralLinearEquationSolverFactory<ConstantType> factory;
-
-
-            std::vector<ConstantType> reachabilityProbabilities;
-            if (!valueVector.is_initialized()) {
-                storm::modelchecker::SparseDtmcInstantiationModelChecker<storm::models::sparse::Dtmc<FunctionType>, ConstantType> instantiationModelChecker(model);
-                instantiationModelChecker.specifyFormula(*currentCheckTask);
-                std::unique_ptr<storm::modelchecker::CheckResult> result = instantiationModelChecker.check(env, valuation);
-                reachabilityProbabilities = result->asExplicitQuantitativeCheckResult<ConstantType>().getValueVector();
-            } else {
-                STORM_LOG_ASSERT(valueVector->size() == model.getNumberOfStates(), "Size of reachability probability vector must be equal to the size of the model.");
-                reachabilityProbabilities = *valueVector;
-            }
-
-            // Convert reachabilityProbabilities into our format - we only care for the states of which the
-            // bits are 1 in the next vector. The order is kept, so doing this is fine:
-            std::vector<ConstantType> interestingReachabilityProbabilities;
-            for (uint64_t i = 0; i < reachabilityProbabilities.size(); i++) {
-                if (next.get(i)) {
-                    interestingReachabilityProbabilities.push_back(reachabilityProbabilities[i]);
-                }
-            }
-
-            // Instantiate the matrices with the given instantiation
-            
-            instantiationWatch.start();
-
-            // Write results into the placeholders
-            for(auto& functionResult : this->functions) {
-                functionResult.second=storm::utility::convertNumber<ConstantType>(
-                        storm::utility::parametric::evaluate(functionResult.first, valuation));
-            }
-
-            auto deltaConstrainedMatrixInstantiated = deltaConstrainedMatricesInstantiated->at(parameter);
-
-            // Write the instantiated values to the matrices and vectors according to the stored mappings
-            for(auto& entryValuePair : this->matrixMapping){
-                entryValuePair.first->setValue(*(entryValuePair.second));
-            }
-
-            std::vector<ConstantType> instantiatedDerivedOutputVec(derivedOutputVecs->at(parameter).size());
-            for (uint_fast64_t i = 0; i < derivedOutputVecs->at(parameter).size(); i++) {
-                instantiatedDerivedOutputVec[i] = utility::convertNumber<ConstantType>(derivedOutputVecs->at(parameter)[i].evaluate(valuation));
-            }
-
-            instantiationWatch.stop();
-
-            approximationWatch.start();
-
-            std::vector<ConstantType> resultVec(interestingReachabilityProbabilities.size());
-            deltaConstrainedMatrixInstantiated.multiplyWithVector(interestingReachabilityProbabilities, resultVec);
-            for (uint_fast64_t i = 0; i < instantiatedDerivedOutputVec.size(); ++i) {
-                resultVec[i] += instantiatedDerivedOutputVec[i];
-            }
-
-            // Here's where the real magic happens - the solver call!
-
-            // Calculate (1-M)^-1 * resultVec
-            std::vector<ConstantType> finalResult(resultVec.size());
-            linearEquationSolvers[parameter]->setMatrix(constrainedMatrixInstantiated);
-            linearEquationSolvers[parameter]->solveEquations(env, finalResult, resultVec);
-
-            approximationWatch.stop();
-
-            return std::make_unique<modelchecker::ExplicitQuantitativeCheckResult<ConstantType>>(finalResult);
-        }
-
-        template<typename FunctionType, typename ConstantType>
-        void SparseDerivativeInstantiationModelChecker<FunctionType, ConstantType>::specifyFormula(
-                Environment const& env, 
-                modelchecker::CheckTask<storm::logic::Formula, FunctionType> const& checkTask)  {
-            this->currentFormula = checkTask.getFormula().asSharedPointer();
-            this->currentCheckTask = std::make_unique<storm::modelchecker::CheckTask<storm::logic::Formula, FunctionType>>(checkTask.substituteFormula(*currentFormula).template convertValueType<FunctionType>());
-            this->parameters = storm::models::sparse::getProbabilityParameters(model);
-            if (checkTask.getFormula().isRewardOperatorFormula()) {
-                for (auto const& rewardParameter : storm::models::sparse::getRewardParameters(model)) {
-                    this->parameters.insert(rewardParameter);
-                }
-            }
-            storm::logic::OperatorInformation opInfo(boost::none, boost::none);
-            if (checkTask.getFormula().isRewardOperatorFormula()) {
-                model.reduceToStateBasedRewards();
-            } else {
-                /* this->formulaWithoutBound = std::make_shared<storm::logic::ProbabilityOperatorFormula>( */
-                /*         formula->asProbabilityOperatorFormula().getSubformula().asSharedPointer(), opInfo); */
-            }
-
-            generalSetupWatch.start();
-
-            storm::solver::GeneralLinearEquationSolverFactory<ConstantType> factory;
-
-            auto coreSettings = storm::settings::getModule<storm::settings::modules::CoreSettings>();
-            bool convertToEquationSystem = factory.getEquationProblemFormat(env) == storm::solver::LinearEquationSolverProblemFormat::EquationSystem;
-
-            std::map<VariableType<FunctionType>, storage::SparseMatrix<FunctionType>> equationSystems;
-            // Get initial and target states
-            storage::BitVector target = model.getStates("target");
-            initialState = model.getStates("init").getNextSetIndex(0);
-
-            if (!checkTask.getFormula().isRewardOperatorFormula()) {
-                next = target;
-                next.complement();
-                storm::storage::BitVector atSomePointTarget = storm::utility::graph::performProbGreater0(model.getBackwardTransitions(), storm::storage::BitVector(model.getNumberOfStates(), true), target);
-                next &= atSomePointTarget;
-            } else {
-                next = target;
-                next.complement();
-                storm::storage::BitVector targetProbOne = storm::utility::graph::performProb1(model.getBackwardTransitions(), storm::storage::BitVector(model.getNumberOfStates(), true), target);
-                next &= targetProbOne;
-            }
-
-            auto transitionMatrix = model.getTransitionMatrix();
-            std::map<uint_fast64_t, uint_fast64_t> stateNumToEquationSystemRow;
-            uint_fast64_t newRow = 0;
-            for (uint_fast64_t row = 0; row < transitionMatrix.getRowCount(); ++row) {
-                if (!next.get(row)) continue;
-                stateNumToEquationSystemRow[row] = newRow;
-                newRow++;
-            }
-            storage::SparseMatrix<FunctionType> constrainedMatrix = transitionMatrix.getSubmatrix(false, next, next, true);
-            // If necessary, convert the matrix from the fixpoint notation to the form needed for the equation system.
-            this->constrainedMatrixEquationSystem = constrainedMatrix;
-            if (convertToEquationSystem) {
-                // go from x = A*x + b to (I-A)x = b.
-                constrainedMatrixEquationSystem.convertToEquationSystem();
-            }
-
-            // Setup instantiated constrained matrix
-            storage::SparseMatrixBuilder<ConstantType> instantiatedSystemBuilder;
-            const ConstantType dummyValue = storm::utility::one<ConstantType>();
-            for (uint_fast64_t row = 0; row < constrainedMatrixEquationSystem.getRowCount(); ++row) {
-                for (auto const& entry : constrainedMatrixEquationSystem.getRow(row)) {
-                    instantiatedSystemBuilder.addNextValue(row, entry.getColumn(), dummyValue);
-                }
-            }
-            constrainedMatrixInstantiated = instantiatedSystemBuilder.build();
-            initializeInstantiatedMatrix(constrainedMatrixEquationSystem, constrainedMatrixInstantiated);
-            // The resulting equation systems
-            this->deltaConstrainedMatrices = std::make_unique<std::map<VariableType<FunctionType>, storage::SparseMatrix<FunctionType>>>();
-            this->deltaConstrainedMatricesInstantiated = std::make_unique<std::map<VariableType<FunctionType>, storage::SparseMatrix<ConstantType>>>();
-            this->derivedOutputVecs = std::make_unique<std::map<VariableType<FunctionType>, std::vector<FunctionType>>>();
-
-            // The following is a nessecary optimization for deriving the constrainedMatrix w.r.t. all parameters.
-            // We will traverse the constrainedMatrix once and inspect all entries, counting their number of parameters.
-            // Then, we will insert the correct polynomials into the correct matrix builders.
-            std::map<VariableType<FunctionType>, storage::SparseMatrixBuilder<FunctionType>> matrixBuilders;
-            std::map<VariableType<FunctionType>, storage::SparseMatrixBuilder<ConstantType>> instantiatedMatrixBuilders;
-            for (auto const& var : this->parameters) {
-                matrixBuilders[var] = storage::SparseMatrixBuilder<FunctionType>(constrainedMatrix.getRowCount());
-                instantiatedMatrixBuilders[var] = storage::SparseMatrixBuilder<ConstantType>(constrainedMatrix.getRowCount());
-            }
-
-            for (uint_fast64_t row = 0; row < constrainedMatrix.getRowCount(); ++row) {
-                for (storage::MatrixEntry<uint_fast64_t, storm::RationalFunction> const& entry : constrainedMatrix.getRow(row)) {
-                    const storm::RationalFunction rationalFunction = entry.getValue();
-                    auto variables = rationalFunction.gatherVariables();
-                    for (auto const& var : variables) {
-                        matrixBuilders.at(var).addNextValue(row, entry.getColumn(), rationalFunction.derivative(var));
-                        instantiatedMatrixBuilders.at(var).addNextValue(row, entry.getColumn(), dummyValue);
-                    }
-                }
-            }
-
-            for (auto const& var : this->parameters) {
-                auto builtMatrix = matrixBuilders[var].build();
-                auto builtMatrixInstantiated = instantiatedMatrixBuilders[var].build();
-                initializeInstantiatedMatrix(builtMatrix, builtMatrixInstantiated);
-                deltaConstrainedMatrices->emplace(var, builtMatrix);
-                deltaConstrainedMatricesInstantiated->emplace(var, builtMatrixInstantiated);
-            }
-
-            for (auto const& var : this->parameters) {
-                (*derivedOutputVecs)[var] = std::vector<FunctionType>(constrainedMatrix.getRowCount());
-            }
-
-            for (uint_fast64_t x = 0; x < constrainedMatrix.getRowCount(); ++x) {
-                    if (!stateNumToEquationSystemRow.count(x)) continue;
-                    uint_fast64_t state = stateNumToEquationSystemRow[x];
-                    // PROBABILITY -> For every state, the one-step probability to reach the target goes into the output vector
-                    // REWARD -> For every state, the reward goes into the output vector
-                    FunctionType rationalFunction;
-                    if (!checkTask.getFormula().isRewardOperatorFormula()) {
-                        FunctionType vectorValue = utility::zero<FunctionType>();
-                        for (auto const& entry : transitionMatrix.getRow(state)) {
-                            if (target.get(entry.getColumn())) {
-                                vectorValue += entry.getValue();
-                            }
-                        }
-                        rationalFunction = vectorValue;
-                    } else {
-                        std::vector<FunctionType> stateRewards;
-                        if (checkTask.isRewardModelSet()) {
-                            stateRewards = model.getRewardModel(checkTask.getRewardModel()).getStateRewardVector();
-                        } else {
-                            stateRewards = model.getRewardModel("").getStateRewardVector();
-                        }
-                        
-                        rationalFunction = stateRewards[state];
-                    }
-                    for (auto const& var : rationalFunction.gatherVariables()) {
-                        (*derivedOutputVecs)[var][x] = rationalFunction.derivative(var);
-                    }
-            }
-
-            generalSetupWatch.stop();
-            
-
-            for (auto const& param : this->parameters) {
-                this->linearEquationSolvers[param] = factory.create(env);
-                this->linearEquationSolvers[param]->setCachingEnabled(true);
-            }
-        }
-
-
-        template<typename FunctionType, typename ConstantType>
-        void SparseDerivativeInstantiationModelChecker<FunctionType, ConstantType>::initializeInstantiatedMatrix(
-            storage::SparseMatrix<FunctionType> &matrix,
-            storage::SparseMatrix<ConstantType> &matrixInstantiated
-        )  {
-            ConstantType dummyValue = storm::utility::one<ConstantType>();
-            auto constantEntryIt = matrixInstantiated.begin();
-            auto parametricEntryIt = matrix.begin();
-            while(parametricEntryIt != matrix.end()) {
-                STORM_LOG_ASSERT(parametricEntryIt->getColumn() == constantEntryIt->getColumn(), "Entries of parametric and constant matrix are not at the same position");
-                if(storm::utility::isConstant(parametricEntryIt->getValue())){
-                    //Constant entries can be inserted directly
-                    constantEntryIt->setValue(storm::utility::convertNumber<ConstantType>(parametricEntryIt->getValue()));
-                    /* std::cout << "Setting constant entry\n"; */
-                } else {
-                    //insert the new function and store that the current constantMatrix entry needs to be set to the value of this function
-                    auto functionsIt = functions.insert(std::make_pair(parametricEntryIt->getValue(), dummyValue)).first;
-                    matrixMapping.emplace_back(std::make_pair(constantEntryIt, &(functionsIt->second)));
-                    //Note that references to elements of an unordered map remain valid after calling unordered_map::insert.
-                    /* std::cout << "Setting non-constant entry\n"; */
-                }
-                ++constantEntryIt;
-                ++parametricEntryIt;
-            }
-            STORM_LOG_ASSERT(constantEntryIt == matrixInstantiated.end(), "Parametric matrix seems to have more or less entries then the constant matrix");
-        }
-
-        template class SparseDerivativeInstantiationModelChecker<RationalFunction, RationalNumber>;
-        template class SparseDerivativeInstantiationModelChecker<RationalFunction, double>;
+template<typename FunctionType, typename ConstantType>
+std::unique_ptr<modelchecker::ExplicitQuantitativeCheckResult<ConstantType>> SparseDerivativeInstantiationModelChecker<FunctionType, ConstantType>::check(
+    Environment const& env, storm::utility::parametric::Valuation<FunctionType> const& valuation, VariableType<FunctionType> const& parameter,
+    boost::optional<std::vector<ConstantType>> const& valueVector) {
+    std::vector<ConstantType> reachabilityProbabilities;
+    if (!valueVector.is_initialized()) {
+        storm::modelchecker::SparseDtmcInstantiationModelChecker<storm::models::sparse::Dtmc<FunctionType>, ConstantType> instantiationModelChecker(model);
+        instantiationModelChecker.specifyFormula(*currentCheckTask);
+        std::unique_ptr<storm::modelchecker::CheckResult> result = instantiationModelChecker.check(env, valuation);
+        reachabilityProbabilities = result->asExplicitQuantitativeCheckResult<ConstantType>().getValueVector();
+    } else {
+        STORM_LOG_ASSERT(valueVector->size() == model.getNumberOfStates(), "Size of reachability probability vector must be equal to the size of the model.");
+        reachabilityProbabilities = *valueVector;
     }
+
+    // Convert reachabilityProbabilities into our format - we only care for the states of which the
+    // bits are 1 in the next vector. The order is kept, so doing this is fine:
+    std::vector<ConstantType> interestingReachabilityProbabilities;
+    for (uint64_t i = 0; i < reachabilityProbabilities.size(); i++) {
+        if (next.get(i)) {
+            interestingReachabilityProbabilities.push_back(reachabilityProbabilities[i]);
+        }
+    }
+    // Instantiate the matrices with the given instantiation
+
+    instantiationWatch.start();
+
+    // std::cout << valuation << std::endl;
+
+    // Write results into the placeholders
+    for (auto& functionResult : this->functionsUnderived) {
+        functionResult.second = storm::utility::convertNumber<ConstantType>(storm::utility::parametric::evaluate(functionResult.first, valuation));
+    }
+    for (auto& functionResult : this->functionsDerived.at(parameter)) {
+        functionResult.second = storm::utility::convertNumber<ConstantType>(storm::utility::parametric::evaluate(functionResult.first, valuation));
+    }
+
+    auto deltaConstrainedMatrixInstantiated = deltaConstrainedMatricesInstantiated->at(parameter);
+
+    // Write the instantiated values to the matrices and vectors according to the stored mappings
+    for (auto& entryValuePair : this->matrixMappingUnderived) {
+        entryValuePair.first->setValue(*(entryValuePair.second));
+    }
+    for (auto& entryValuePair : this->matrixMappingsDerived.at(parameter)) {
+        entryValuePair.first->setValue(*(entryValuePair.second));
+    }
+
+    std::vector<ConstantType> instantiatedDerivedOutputVec(derivedOutputVecs->at(parameter).size());
+    for (uint_fast64_t i = 0; i < derivedOutputVecs->at(parameter).size(); i++) {
+        instantiatedDerivedOutputVec[i] = utility::convertNumber<ConstantType>(derivedOutputVecs->at(parameter)[i].evaluate(valuation));
+    }
+
+    instantiationWatch.stop();
+
+    approximationWatch.start();
+
+    std::vector<ConstantType> resultVec(interestingReachabilityProbabilities.size());
+    deltaConstrainedMatrixInstantiated.multiplyWithVector(interestingReachabilityProbabilities, resultVec);
+    for (uint_fast64_t i = 0; i < instantiatedDerivedOutputVec.size(); ++i) {
+        resultVec[i] += instantiatedDerivedOutputVec[i];
+    }
+
+    // Here's where the real magic happens - the solver call!
+    storm::solver::GeneralLinearEquationSolverFactory<ConstantType> factory;
+    auto solver = factory.create(env);
+
+    // Calculate (1-M)^-1 * resultVec
+    // std::cout << constrainedMatrixInstantiated << std::endl;
+    // std::cout << "calling solver" << std::endl;
+    solver->setMatrix(constrainedMatrixInstantiated);
+    std::vector<ConstantType> finalResult(resultVec.size());
+    solver->solveEquations(env, finalResult, resultVec);
+
+    approximationWatch.stop();
+
+    return std::make_unique<modelchecker::ExplicitQuantitativeCheckResult<ConstantType>>(finalResult);
 }
+
+template<typename FunctionType, typename ConstantType>
+void SparseDerivativeInstantiationModelChecker<FunctionType, ConstantType>::specifyFormula(
+    Environment const& env, modelchecker::CheckTask<storm::logic::Formula, FunctionType> const& checkTask) {
+    this->currentFormula = checkTask.getFormula().asSharedPointer();
+    this->currentCheckTask = std::make_unique<storm::modelchecker::CheckTask<storm::logic::Formula, FunctionType>>(
+        checkTask.substituteFormula(*currentFormula).template convertValueType<FunctionType>());
+    this->parameters = storm::models::sparse::getProbabilityParameters(model);
+    if (checkTask.getFormula().isRewardOperatorFormula()) {
+        for (auto const& rewardParameter : storm::models::sparse::getRewardParameters(model)) {
+            this->parameters.insert(rewardParameter);
+        }
+    }
+    storm::logic::OperatorInformation opInfo(boost::none, boost::none);
+    if (checkTask.getFormula().isRewardOperatorFormula()) {
+        model.reduceToStateBasedRewards();
+    } else {
+        /* this->formulaWithoutBound = std::make_shared<storm::logic::ProbabilityOperatorFormula>( */
+        /*         formula->asProbabilityOperatorFormula().getSubformula().asSharedPointer(), opInfo); */
+    }
+
+    generalSetupWatch.start();
+
+    storm::solver::GeneralLinearEquationSolverFactory<ConstantType> factory;
+
+    auto coreSettings = storm::settings::getModule<storm::settings::modules::CoreSettings>();
+    bool convertToEquationSystem = factory.getEquationProblemFormat(env) == storm::solver::LinearEquationSolverProblemFormat::EquationSystem;
+
+    std::map<VariableType<FunctionType>, storage::SparseMatrix<FunctionType>> equationSystems;
+    // Get initial and target states
+    storm::modelchecker::SparsePropositionalModelChecker<models::sparse::Dtmc<FunctionType>> propositionalChecker(model);
+    storage::BitVector target;
+    storage::BitVector avoid(model.getNumberOfStates());
+    if (this->currentFormula->isRewardOperatorFormula()) {
+        auto subformula = modelchecker::CheckTask<storm::logic::Formula, FunctionType>(
+            this->currentFormula->asRewardOperatorFormula().getSubformula().asEventuallyFormula().getSubformula());
+        target = propositionalChecker.check(subformula)->asExplicitQualitativeCheckResult().getTruthValuesVector();
+    } else {
+        if (this->currentFormula->asProbabilityOperatorFormula().getSubformula().isUntilFormula()) {
+            auto rightSubformula = modelchecker::CheckTask<storm::logic::Formula, FunctionType>(
+                this->currentFormula->asProbabilityOperatorFormula().getSubformula().asUntilFormula().getRightSubformula());
+            auto leftSubformula = modelchecker::CheckTask<storm::logic::Formula, FunctionType>(
+                this->currentFormula->asProbabilityOperatorFormula().getSubformula().asUntilFormula().getLeftSubformula());
+            target = propositionalChecker.check(rightSubformula)->asExplicitQualitativeCheckResult().getTruthValuesVector();
+            avoid = propositionalChecker.check(leftSubformula)->asExplicitQualitativeCheckResult().getTruthValuesVector();
+            avoid.complement();
+        } else {
+            auto subformula = modelchecker::CheckTask<storm::logic::Formula, FunctionType>(
+                this->currentFormula->asProbabilityOperatorFormula().getSubformula().asEventuallyFormula().getSubformula());
+            target = propositionalChecker.check(subformula)->asExplicitQualitativeCheckResult().getTruthValuesVector();
+        }
+    }
+    initialStateModel = model.getStates("init").getNextSetIndex(0);
+
+    if (!checkTask.getFormula().isRewardOperatorFormula()) {
+        next = target;
+        next.complement();
+
+        avoid.complement();
+        next &= avoid;
+
+        storm::storage::BitVector atSomePointTarget =
+            storm::utility::graph::performProbGreater0(model.getBackwardTransitions(), storm::storage::BitVector(model.getNumberOfStates(), true), target);
+        next &= atSomePointTarget;
+    } else {
+        next = target;
+        next.complement();
+
+        avoid.complement();
+        next &= avoid;
+
+        storm::storage::BitVector targetProbOne =
+            storm::utility::graph::performProb1(model.getBackwardTransitions(), storm::storage::BitVector(model.getNumberOfStates(), true), target);
+        next &= targetProbOne;
+    }
+
+    auto transitionMatrix = model.getTransitionMatrix();
+    std::map<uint_fast64_t, uint_fast64_t> stateNumToEquationSystemRow;
+    uint_fast64_t newRow = 0;
+    for (uint_fast64_t row = 0; row < transitionMatrix.getRowCount(); ++row) {
+        if (!next.get(row))
+            continue;
+        stateNumToEquationSystemRow[row] = newRow;
+        newRow++;
+    }
+    initialStateEqSystem = stateNumToEquationSystemRow[initialStateModel];
+    storage::SparseMatrix<FunctionType> constrainedMatrix = transitionMatrix.getSubmatrix(false, next, next, true);
+    // If necessary, convert the matrix from the fixpoint notation to the form needed for the equation system.
+    this->constrainedMatrixEquationSystem = constrainedMatrix;
+    if (convertToEquationSystem) {
+        // go from x = A*x + b to (I-A)x = b.
+        constrainedMatrixEquationSystem.convertToEquationSystem();
+    }
+
+    // Setup instantiated constrained matrix
+    storage::SparseMatrixBuilder<ConstantType> instantiatedSystemBuilder;
+    const ConstantType dummyValue = storm::utility::one<ConstantType>();
+    for (uint_fast64_t row = 0; row < constrainedMatrixEquationSystem.getRowCount(); ++row) {
+        for (auto const& entry : constrainedMatrixEquationSystem.getRow(row)) {
+            instantiatedSystemBuilder.addNextValue(row, entry.getColumn(), dummyValue);
+        }
+    }
+    constrainedMatrixInstantiated = instantiatedSystemBuilder.build();
+    initializeInstantiatedMatrix(constrainedMatrixEquationSystem, constrainedMatrixInstantiated, matrixMappingUnderived, functionsUnderived);
+    // The resulting equation systems
+    this->deltaConstrainedMatrices = std::make_unique<std::map<VariableType<FunctionType>, storage::SparseMatrix<FunctionType>>>();
+    this->deltaConstrainedMatricesInstantiated = std::make_unique<std::map<VariableType<FunctionType>, storage::SparseMatrix<ConstantType>>>();
+    this->derivedOutputVecs = std::make_unique<std::map<VariableType<FunctionType>, std::vector<FunctionType>>>();
+
+    // The following is a nessecary optimization for deriving the constrainedMatrix w.r.t. all parameters.
+    // We will traverse the constrainedMatrix once and inspect all entries, counting their number of parameters.
+    // Then, we will insert the correct polynomials into the correct matrix builders.
+    std::map<VariableType<FunctionType>, storage::SparseMatrixBuilder<FunctionType>> matrixBuilders;
+    std::map<VariableType<FunctionType>, storage::SparseMatrixBuilder<ConstantType>> instantiatedMatrixBuilders;
+    for (auto const& var : this->parameters) {
+        matrixBuilders[var] = storage::SparseMatrixBuilder<FunctionType>(constrainedMatrix.getRowCount());
+        instantiatedMatrixBuilders[var] = storage::SparseMatrixBuilder<ConstantType>(constrainedMatrix.getRowCount());
+    }
+
+    for (uint_fast64_t row = 0; row < constrainedMatrix.getRowCount(); ++row) {
+        for (storage::MatrixEntry<uint_fast64_t, storm::RationalFunction> const& entry : constrainedMatrix.getRow(row)) {
+            const storm::RationalFunction rationalFunction = entry.getValue();
+            auto variables = rationalFunction.gatherVariables();
+            for (auto const& var : variables) {
+                matrixBuilders.at(var).addNextValue(row, entry.getColumn(), rationalFunction.derivative(var));
+                instantiatedMatrixBuilders.at(var).addNextValue(row, entry.getColumn(), dummyValue);
+            }
+        }
+    }
+
+    for (auto const& var : this->parameters) {
+        auto builtMatrix = matrixBuilders[var].build();
+        auto builtMatrixInstantiated = instantiatedMatrixBuilders[var].build();
+        initializeInstantiatedMatrix(builtMatrix, builtMatrixInstantiated, matrixMappingsDerived[var], functionsDerived[var]);
+        deltaConstrainedMatrices->emplace(var, std::move(builtMatrix));
+        deltaConstrainedMatricesInstantiated->emplace(var, std::move(builtMatrixInstantiated));
+    }
+
+    for (auto const& var : this->parameters) {
+        (*derivedOutputVecs)[var] = std::vector<FunctionType>(constrainedMatrix.getRowCount());
+    }
+
+    // storage::BitVector constrainedTarget(next.size());
+    // for (uint_fast64_t i = 0; i < transitionMatrix.getRowCount(); i++) {
+    //     if (!stateNumToEquationSystemRow.count(i)) continue;
+    //     constrainedTarget.set(stateNumToEquationSystemRow[i], target[i]);
+    // }
+
+    for (uint_fast64_t state = 0; state < transitionMatrix.getRowCount(); ++state) {
+        if (!stateNumToEquationSystemRow.count(state))
+            continue;
+        uint_fast64_t row = stateNumToEquationSystemRow[state];
+        // PROBABILITY -> For every state, the one-step probability to reach the target goes into the output vector
+        // REWARD -> For every state, the reward goes into the output vector
+        FunctionType rationalFunction;
+        if (!checkTask.getFormula().isRewardOperatorFormula()) {
+            FunctionType vectorValue = utility::zero<FunctionType>();
+            for (auto const& entry : transitionMatrix.getRow(state)) {
+                if (target.get(entry.getColumn())) {
+                    vectorValue += entry.getValue();
+                }
+            }
+            rationalFunction = vectorValue;
+        } else {
+            std::vector<FunctionType> stateRewards;
+            if (checkTask.isRewardModelSet()) {
+                stateRewards = model.getRewardModel(checkTask.getRewardModel()).getStateRewardVector();
+            } else {
+                stateRewards = model.getRewardModel("").getStateRewardVector();
+            }
+
+            rationalFunction = stateRewards[state];
+        }
+        for (auto const& var : rationalFunction.gatherVariables()) {
+            (*derivedOutputVecs)[var][row] = rationalFunction.derivative(var);
+        }
+    }
+
+    generalSetupWatch.stop();
+
+    // for (auto const& param : this->parameters) {
+    //     this->linearEquationSolvers[param] = factory.create(env);
+    //     // this->linearEquationSolvers[param]->setCachingEnabled(true);
+    //     // std::unique_ptr<solver::TerminationCondition<ConstantType>> terminationCondition =
+    //     //     std::make_unique<SignedGradientDescentTerminationCondition<ConstantType>>(initialState);
+    //     // this->linearEquationSolvers[param]->setTerminationCondition(std::move(terminationCondition));
+    // }
+}
+
+template<typename FunctionType, typename ConstantType>
+void SparseDerivativeInstantiationModelChecker<FunctionType, ConstantType>::initializeInstantiatedMatrix(
+    storage::SparseMatrix<FunctionType>& matrix, storage::SparseMatrix<ConstantType>& matrixInstantiated,
+    std::vector<std::pair<typename storm::storage::SparseMatrix<ConstantType>::iterator, ConstantType*>>& matrixMapping,
+    std::unordered_map<FunctionType, ConstantType>& functions) {
+    ConstantType dummyValue = storm::utility::one<ConstantType>();
+    auto constantEntryIt = matrixInstantiated.begin();
+    auto parametricEntryIt = matrix.begin();
+    while (parametricEntryIt != matrix.end()) {
+        STORM_LOG_ASSERT(parametricEntryIt->getColumn() == constantEntryIt->getColumn(),
+                         "Entries of parametric and constant matrix are not at the same position");
+        if (storm::utility::isConstant(parametricEntryIt->getValue())) {
+            // Constant entries can be inserted directly
+            constantEntryIt->setValue(storm::utility::convertNumber<ConstantType>(parametricEntryIt->getValue()));
+            /* std::cout << "Setting constant entry" << std::endl; */
+        } else {
+            // insert the new function and store that the current constantMatrix entry needs to be set to the value of this function
+            auto functionsIt = functions.insert(std::make_pair(parametricEntryIt->getValue(), dummyValue)).first;
+            matrixMapping.emplace_back(std::make_pair(constantEntryIt, &(functionsIt->second)));
+            // Note that references to elements of an unordered map remain valid after calling unordered_map::insert.
+            /* std::cout << "Setting non-constant entry" << std::endl; */
+        }
+        ++constantEntryIt;
+        ++parametricEntryIt;
+    }
+    STORM_LOG_ASSERT(constantEntryIt == matrixInstantiated.end(), "Parametric matrix seems to have more or less entries then the constant matrix");
+}
+
+template class SparseDerivativeInstantiationModelChecker<RationalFunction, RationalNumber>;
+template class SparseDerivativeInstantiationModelChecker<RationalFunction, double>;
+}  // namespace derivative
+}  // namespace storm

--- a/src/storm-pars/derivative/SparseDerivativeInstantiationModelChecker.h
+++ b/src/storm-pars/derivative/SparseDerivativeInstantiationModelChecker.h
@@ -1,81 +1,113 @@
 #ifndef STORM_DERIVATIVEEVALUATIONHELPER_H
 #define STORM_DERIVATIVEEVALUATIONHELPER_H
 
+#include <cstdint>
 #include <map>
 #include "analysis/GraphConditions.h"
 #include "logic/Formula.h"
 #include "modelchecker/CheckTask.h"
 #include "solver/LinearEquationSolver.h"
 #include "storm-pars/utility/parametric.h"
-#include "storm/models/sparse/Dtmc.h"
-#include "storm/utility/Stopwatch.h"
 #include "storm/modelchecker/results/CheckResult.h"
+#include "storm/models/sparse/Dtmc.h"
+#include "storm/solver/TerminationCondition.h"
+#include "storm/utility/Stopwatch.h"
 
 namespace storm {
-    namespace derivative {
-        template <typename FunctionType, typename ConstantType>
-        class SparseDerivativeInstantiationModelChecker {
-        public:
-            /**
-             * Instantiates a new SparseDerivativeInstantiationModelChecker.
-             * @param model The Dtmc to compute the derivatives of.
-             */
-            SparseDerivativeInstantiationModelChecker(storm::models::sparse::Dtmc<FunctionType> const& model) : model(model) {
-                // Intentionally left empty.
-            }
-            virtual ~SparseDerivativeInstantiationModelChecker() = default;
-
-            /**
-             * specifyFormula specifies a CheckTask.
-             * The SparseDerivativeInstantiationModelChecker will need to setup the matrices for it.
-             * Note this can consume a substantial amount of memory if the model is big and there's a large number of parameters.
-             * @param env The environment. Pass the same environment as to check. We need this because we need to know what kind of
-             * equation solver we are dealing with.
-             * @param checkTask The CheckTask.
-             */
-            void specifyFormula(Environment const& env, modelchecker::CheckTask<logic::Formula, FunctionType> const& checkTask);
-            
-            /**
-             * check calculates the deriative of the model w.r.t. a parameter at an instantiation.
-             * Call specifyFormula first!
-             * @param env The environment.
-             */
-            std::unique_ptr<modelchecker::ExplicitQuantitativeCheckResult<ConstantType>> check(Environment const& env, storm::utility::parametric::Valuation<FunctionType> const& valuation, typename utility::parametric::VariableType<FunctionType>::type const& parameter, boost::optional<std::vector<ConstantType>> const& valueVector = boost::none);
-
-        private:
-            models::sparse::Dtmc<FunctionType> model;
-            std::unique_ptr<modelchecker::CheckTask<storm::logic::Formula, FunctionType>> currentCheckTask;
-            // store the current formula. Note that currentCheckTask only stores a reference to the formula.
-            std::shared_ptr<storm::logic::Formula const> currentFormula;
-
-            std::set<typename utility::parametric::VariableType<FunctionType>::type> parameters;
-            std::map<typename utility::parametric::VariableType<FunctionType>::type, std::unique_ptr<storm::solver::LinearEquationSolver<ConstantType>>> linearEquationSolvers;
-            std::vector<std::pair<typename storm::storage::SparseMatrix<ConstantType>::iterator, ConstantType*>> matrixMapping; 
-            std::unordered_map<FunctionType, ConstantType> functions; 
-            storage::SparseMatrix<FunctionType> constrainedMatrixEquationSystem;
-            storage::SparseMatrix<ConstantType> constrainedMatrixInstantiated;
-            std::unique_ptr<std::map<typename utility::parametric::VariableType<FunctionType>::type, storage::SparseMatrix<FunctionType>>> deltaConstrainedMatrices;
-            std::unique_ptr<std::map<typename utility::parametric::VariableType<FunctionType>::type, storage::SparseMatrix<ConstantType>>> deltaConstrainedMatricesInstantiated;
-            std::unique_ptr<std::map<typename utility::parametric::VariableType<FunctionType>::type, std::vector<FunctionType>>> derivedOutputVecs;
-
-            // next states: states that have a relevant successor
-            storage::BitVector next;
-            uint_fast64_t initialState;
-
-            void initializeInstantiatedMatrix(
-                storage::SparseMatrix<FunctionType> &matrix,
-                storage::SparseMatrix<ConstantType> &matrixInstantiated
-            );
-            void setup(
-                Environment const& env,
-                modelchecker::CheckTask<storm::logic::Formula, FunctionType> const& checkTask
-            );
-
-            utility::Stopwatch instantiationWatch;
-            utility::Stopwatch approximationWatch;
-            utility::Stopwatch generalSetupWatch;
-        };
+namespace derivative {
+template<typename FunctionType, typename ConstantType>
+class SparseDerivativeInstantiationModelChecker {
+   public:
+    /**
+     * Instantiates a new SparseDerivativeInstantiationModelChecker.
+     * @param model The Dtmc to compute the derivatives of.
+     */
+    SparseDerivativeInstantiationModelChecker(storm::models::sparse::Dtmc<FunctionType> const& model) : model(model) {
+        // Intentionally left empty.
     }
-}
+    virtual ~SparseDerivativeInstantiationModelChecker() = default;
 
-#endif // STORM_DERIVATIVEEVALUATIONHELPER_H
+    /**
+     * specifyFormula specifies a CheckTask.
+     * The SparseDerivativeInstantiationModelChecker will need to setup the matrices for it.
+     * Note this can consume a substantial amount of memory if the model is big and there's a large number of parameters.
+     * @param env The environment. Pass the same environment as to check. We need this because we need to know what kind of
+     * equation solver we are dealing with.
+     * @param checkTask The CheckTask.
+     */
+    void specifyFormula(Environment const& env, modelchecker::CheckTask<logic::Formula, FunctionType> const& checkTask);
+
+    /**
+     * check calculates the deriative of the model w.r.t. a parameter at an instantiation.
+     * Call specifyFormula first!
+     * @param env The environment.
+     */
+    std::unique_ptr<modelchecker::ExplicitQuantitativeCheckResult<ConstantType>> check(
+        Environment const& env, storm::utility::parametric::Valuation<FunctionType> const& valuation,
+        typename utility::parametric::VariableType<FunctionType>::type const& parameter,
+        boost::optional<std::vector<ConstantType>> const& valueVector = boost::none);
+    
+    uint64_t getInitialState() {
+        return initialStateEqSystem;
+    }
+
+   private:
+    models::sparse::Dtmc<FunctionType> model;
+    std::unique_ptr<modelchecker::CheckTask<storm::logic::Formula, FunctionType>> currentCheckTask;
+    // store the current formula. Note that currentCheckTask only stores a reference to the formula.
+    std::shared_ptr<storm::logic::Formula const> currentFormula;
+
+    std::set<typename utility::parametric::VariableType<FunctionType>::type> parameters;
+    std::map<typename utility::parametric::VariableType<FunctionType>::type, std::unique_ptr<storm::solver::LinearEquationSolver<ConstantType>>>
+        linearEquationSolvers;
+    std::vector<std::pair<typename storm::storage::SparseMatrix<ConstantType>::iterator, ConstantType*>> matrixMappingUnderived;
+    std::map<typename utility::parametric::VariableType<FunctionType>::type, std::vector<std::pair<typename storm::storage::SparseMatrix<ConstantType>::iterator, ConstantType*>>> matrixMappingsDerived;
+    std::unordered_map<FunctionType, ConstantType> functionsUnderived;
+    std::map<typename utility::parametric::VariableType<FunctionType>::type, std::unordered_map<FunctionType, ConstantType>> functionsDerived;
+    storage::SparseMatrix<FunctionType> constrainedMatrixEquationSystem;
+    storage::SparseMatrix<ConstantType> constrainedMatrixInstantiated;
+    std::unique_ptr<std::map<typename utility::parametric::VariableType<FunctionType>::type, storage::SparseMatrix<FunctionType>>> deltaConstrainedMatrices;
+    std::unique_ptr<std::map<typename utility::parametric::VariableType<FunctionType>::type, storage::SparseMatrix<ConstantType>>>
+        deltaConstrainedMatricesInstantiated;
+    std::unique_ptr<std::map<typename utility::parametric::VariableType<FunctionType>::type, std::vector<FunctionType>>> derivedOutputVecs;
+
+    // next states: states that have a relevant successor
+    storage::BitVector next;
+    uint_fast64_t initialStateEqSystem;
+    uint_fast64_t initialStateModel;
+
+    void initializeInstantiatedMatrix(storage::SparseMatrix<FunctionType>& matrix, storage::SparseMatrix<ConstantType>& matrixInstantiated,
+        std::vector<std::pair<typename storm::storage::SparseMatrix<ConstantType>::iterator, ConstantType*>>& matrixMapping,
+        std::unordered_map<FunctionType, ConstantType>& functions);
+    void setup(Environment const& env, modelchecker::CheckTask<storm::logic::Formula, FunctionType> const& checkTask);
+
+    utility::Stopwatch instantiationWatch;
+    utility::Stopwatch approximationWatch;
+    utility::Stopwatch generalSetupWatch;
+};
+
+template<typename ValueType>
+class SignedGradientDescentTerminationCondition : public solver::TerminationCondition<ValueType> {
+   public:
+    SignedGradientDescentTerminationCondition(uint64_t initialState) : initialState(initialState){};
+
+    bool terminateNow(std::function<ValueType(uint64_t const&)> const& valueGetter, solver::SolverGuarantee const& guarantee) const {
+        if (guarantee == solver::SolverGuarantee::GreaterOrEqual && valueGetter(initialState) > utility::convertNumber<ValueType>(1e-6)) {
+            return true;
+        }
+        if (guarantee == solver::SolverGuarantee::LessOrEqual && valueGetter(initialState) < utility::convertNumber<ValueType>(-1e-6)) {
+            return true;
+        }
+        return false;
+    };
+    bool requiresGuarantee(solver::SolverGuarantee const& guarantee) const {
+        return guarantee == solver::SolverGuarantee::LessOrEqual || guarantee == solver::SolverGuarantee::GreaterOrEqual;
+    }
+
+   private:
+    uint64_t initialState;
+};
+}  // namespace derivative
+}  // namespace storm
+
+#endif  // STORM_DERIVATIVEEVALUATIONHELPER_H

--- a/src/test/storm-pars/derivative/GradientDescentInstantiationSearcherTest.cpp
+++ b/src/test/storm-pars/derivative/GradientDescentInstantiationSearcherTest.cpp
@@ -140,7 +140,9 @@ TYPED_TEST(GradientDescentInstantiationSearcherTest, Crowds) {
     auto simplifier = storm::transformer::SparseParametricDtmcSimplifier<storm::models::sparse::Dtmc<storm::RationalFunction>>(*dtmc);
     ASSERT_TRUE(simplifier.simplify(*formulas[0]));
     model = simplifier.getSimplifiedModel();
-    dtmc = model->as<storm::models::sparse::Dtmc<storm::RationalFunction>>();
+    
+    dtmc = storm::api::performBisimulationMinimization<storm::RationalFunction>(model, formulas)->as<storm::models::sparse::Dtmc<storm::RationalFunction>>();
+
     storm::modelchecker::CheckTask<storm::logic::Formula, typename TestFixture::FunctionType> checkTask(*formulas[0]);
 
     auto vars = storm::models::sparse::getProbabilityParameters(*dtmc);


### PR DESCRIPTION
I've fixed some bugs in Gradient Descent, e.g.
- used to fail when the initial state wasn't zero
- used to fail when the formula wasn't "at some point target" (so storm-pars.cpp preprocessing), now it supports arbitrary labels and until formulas
- used to fail when there are transitions that have higher degree than one
- applied code formatting (makes the diff quite unreadable though :( )

These are all things that never hold for pMCs coming out of storm-pomdp, so I didn't catch these bugs previously.

I added a test for the first bug (applying bisimulation in a test, which results in the initial state not being zero), but not for the other ones yet - that's something I still need to do.