### PR TITLE
Induced scheduler

### DIFF
--- a/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsLpChecker.cpp
+++ b/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsLpChecker.cpp
@@ -806,7 +806,9 @@ typename DeterministicSchedsLpChecker<ModelType, GeometryValueType>::Point Deter
             STORM_LOG_THROW(choiceFound, storm::exceptions::UnexpectedException, "No choice selected at state " << state);
         }
     }
-    auto inducedModel = model.applyScheduler(scheduler)->template as<ModelType>();
+    bool dropUnreachableStates = true;
+    bool preserveModelType = true;
+    auto inducedModel = model.applyScheduler(scheduler, dropUnreachableStates, preserveModelType)->template as<ModelType>();
     Point inducedPoint;
     for (uint64_t objIndex = 0; objIndex < objectiveHelper.size(); ++objIndex) {
         ValueType inducedValue = objectiveHelper[objIndex].evaluateOnModel(env, *inducedModel);

--- a/src/storm/models/sparse/Model.cpp
+++ b/src/storm/models/sparse/Model.cpp
@@ -69,12 +69,15 @@ void Model<ValueType, RewardModelType>::assertValidityOfComponents(
             !rewardModel.second.hasTransitionRewards() || rewardModel.second.getTransitionRewardMatrix().isSubmatrixOf(this->getTransitionMatrix()),
             "The transition reward matrix is not a submatrix of the transition matrix, i.e. there are rewards for transitions that do not exist.");
     }
-    STORM_LOG_THROW(!this->hasChoiceLabeling() || this->getChoiceLabeling().getNumberOfItems() == choiceCount, storm::exceptions::IllegalArgumentException,
-                    "Invalid choice count of choice labeling (choices: " << choiceCount << " vs. labeling:" << this->getChoiceLabeling().getNumberOfItems() << ").");
-    STORM_LOG_THROW(!this->hasStateValuations() || this->getStateValuations().getNumberOfStates() == stateCount, storm::exceptions::IllegalArgumentException,
-                    "Invalid state count for state valuations (states: " << stateCount << " vs. valuations:" << this->getStateValuations().getNumberOfStates() << ")." );
-    STORM_LOG_THROW(!this->hasChoiceOrigins() || this->getChoiceOrigins()->getNumberOfChoices() == choiceCount, storm::exceptions::IllegalArgumentException,
-                    "Invalid choice count for choice origins. (choices: " << choiceCount << " vs. origins:" << this->getChoiceOrigins()->getNumberOfChoices()<< ").");
+    STORM_LOG_THROW(
+        !this->hasChoiceLabeling() || this->getChoiceLabeling().getNumberOfItems() == choiceCount, storm::exceptions::IllegalArgumentException,
+        "Invalid choice count of choice labeling (choices: " << choiceCount << " vs. labeling:" << this->getChoiceLabeling().getNumberOfItems() << ").");
+    STORM_LOG_THROW(
+        !this->hasStateValuations() || this->getStateValuations().getNumberOfStates() == stateCount, storm::exceptions::IllegalArgumentException,
+        "Invalid state count for state valuations (states: " << stateCount << " vs. valuations:" << this->getStateValuations().getNumberOfStates() << ").");
+    STORM_LOG_THROW(
+        !this->hasChoiceOrigins() || this->getChoiceOrigins()->getNumberOfChoices() == choiceCount, storm::exceptions::IllegalArgumentException,
+        "Invalid choice count for choice origins. (choices: " << choiceCount << " vs. origins:" << this->getChoiceOrigins()->getNumberOfChoices() << ").");
 
     // Branch on type of nondeterminism
     if (this->isOfType(ModelType::Dtmc) || this->isOfType(ModelType::Ctmc)) {

--- a/src/storm/models/sparse/Model.cpp
+++ b/src/storm/models/sparse/Model.cpp
@@ -70,11 +70,11 @@ void Model<ValueType, RewardModelType>::assertValidityOfComponents(
             "The transition reward matrix is not a submatrix of the transition matrix, i.e. there are rewards for transitions that do not exist.");
     }
     STORM_LOG_THROW(!this->hasChoiceLabeling() || this->getChoiceLabeling().getNumberOfItems() == choiceCount, storm::exceptions::IllegalArgumentException,
-                    "Invalid item count of choice labeling.");
+                    "Invalid choice count of choice labeling (choices: " << choiceCount << " vs. labeling:" << this->getChoiceLabeling().getNumberOfItems() << ").");
     STORM_LOG_THROW(!this->hasStateValuations() || this->getStateValuations().getNumberOfStates() == stateCount, storm::exceptions::IllegalArgumentException,
-                    "Invalid choice count for choice origins.");
+                    "Invalid state count for state valuations (states: " << stateCount << " vs. valuations:" << this->getStateValuations().getNumberOfStates() << ")." );
     STORM_LOG_THROW(!this->hasChoiceOrigins() || this->getChoiceOrigins()->getNumberOfChoices() == choiceCount, storm::exceptions::IllegalArgumentException,
-                    "Invalid choice count for choice origins.");
+                    "Invalid choice count for choice origins. (choices: " << choiceCount << " vs. origins:" << this->getChoiceOrigins()->getNumberOfChoices()<< ").");
 
     // Branch on type of nondeterminism
     if (this->isOfType(ModelType::Dtmc) || this->isOfType(ModelType::Ctmc)) {

--- a/src/storm/models/sparse/NondeterministicModel.cpp
+++ b/src/storm/models/sparse/NondeterministicModel.cpp
@@ -48,12 +48,14 @@ void NondeterministicModel<ValueType, RewardModelType>::reduceToStateBasedReward
 
 template<typename ValueType, typename RewardModelType>
 std::shared_ptr<storm::models::sparse::Model<ValueType, RewardModelType>> NondeterministicModel<ValueType, RewardModelType>::applyScheduler(
-    storm::storage::Scheduler<ValueType> const& scheduler, bool dropUnreachableStates) const {
+    storm::storage::Scheduler<ValueType> const& scheduler, bool dropUnreachableStates, bool preserveModelType) const {
     if (scheduler.isMemorylessScheduler() && scheduler.isDeterministicScheduler() && !scheduler.isPartialScheduler()) {
         // Special case with improved handling.
         storm::storage::BitVector actionSelection = scheduler.computeActionSupport(getNondeterministicChoiceIndices());
         storm::storage::BitVector allStates(this->getNumberOfStates(), true);
-        auto res = storm::transformer::buildSubsystem(*this, allStates, actionSelection, !dropUnreachableStates);
+        transformer::SubsystemBuilderOptions options;
+        options.makeRowGroupingTrivial = !preserveModelType;
+        auto res = storm::transformer::buildSubsystem(*this, allStates, actionSelection, !dropUnreachableStates, options);
         return res.model;
     } else {
         storm::storage::SparseModelMemoryProduct<ValueType, RewardModelType> memoryProduct(*this, scheduler);

--- a/src/storm/models/sparse/NondeterministicModel.h
+++ b/src/storm/models/sparse/NondeterministicModel.h
@@ -58,9 +58,12 @@ class NondeterministicModel : public Model<ValueType, RewardModelType> {
      * Applies the given scheduler to this model.
      * @param scheduler the considered scheduler.
      * @param dropUnreachableStates if set, the resulting model only considers the states that are reachable from an initial state
+     * @param preserveModelType if set, the resulting model has the same type as the original (this) model,
+     *                          even when all nondeterminism is resolved and independent of the scheduler. Otherwise, the model type may differ.
      */
     std::shared_ptr<storm::models::sparse::Model<ValueType, RewardModelType>> applyScheduler(storm::storage::Scheduler<ValueType> const& scheduler,
-                                                                                             bool dropUnreachableStates = true) const;
+                                                                                             bool dropUnreachableStates = true,
+                                                                                             bool preserveModelType = false) const;
 
     virtual void printModelInformationToStream(std::ostream& out) const override;
 

--- a/src/storm/transformer/SubsystemBuilder.cpp
+++ b/src/storm/transformer/SubsystemBuilder.cpp
@@ -134,6 +134,10 @@ SubsystemBuilderReturnType<ValueType, RewardModelType> internalBuildSubsystem(st
     } else {
         components.transitionMatrix = originalModel.getTransitionMatrix().getSubmatrix(false, keptActions, subsystemStates);
     }
+    if (options.makeRowGroupingTrivial) {
+        components.transitionMatrix.makeRowGroupingTrivial();
+    }
+
     components.stateLabeling = originalModel.getStateLabeling().getSubLabeling(subsystemStates);
     for (auto const& rewardModel : originalModel.getRewardModels()) {
         components.rewardModels.insert(std::make_pair(rewardModel.first, transformRewardModel(rewardModel.second, subsystemStates, keptActions)));
@@ -182,9 +186,11 @@ SubsystemBuilderReturnType<ValueType, RewardModelType> internalBuildSubsystem(st
     }
 
     transformModelSpecificComponents<ValueType, RewardModelType>(originalModel, subsystemStates, components);
-
-    result.model = storm::utility::builder::buildModelFromComponents(originalModel.getType(), std::move(components));
-
+    models::ModelType newModelType = originalModel.getType();
+    if (components.transitionMatrix.hasTrivialRowGrouping() && originalModel.getType() == models::ModelType::Mdp) {
+        newModelType = models::ModelType::Dtmc;
+    }
+    result.model = storm::utility::builder::buildModelFromComponents(newModelType, std::move(components));
     STORM_LOG_DEBUG("Subsystem Builder is done. Resulting model has " << result.model->getNumberOfStates() << " states.");
     return result;
 }

--- a/src/storm/transformer/SubsystemBuilder.cpp
+++ b/src/storm/transformer/SubsystemBuilder.cpp
@@ -135,6 +135,7 @@ SubsystemBuilderReturnType<ValueType, RewardModelType> internalBuildSubsystem(st
         components.transitionMatrix = originalModel.getTransitionMatrix().getSubmatrix(false, keptActions, subsystemStates);
     }
     if (options.makeRowGroupingTrivial) {
+        STORM_LOG_ASSERT(components.transitionMatrix.getColumnCount() == components.transitionMatrix.getRowCount(), "Matrix should be square");
         components.transitionMatrix.makeRowGroupingTrivial();
     }
 

--- a/src/storm/transformer/SubsystemBuilder.h
+++ b/src/storm/transformer/SubsystemBuilder.h
@@ -31,6 +31,7 @@ struct SubsystemBuilderOptions {
     bool buildActionMapping = false;
     bool buildKeptActions = true;
     bool fixDeadlocks = false;
+    bool makeRowGroupingTrivial = false;
 };
 
 /*

--- a/src/test/storm/modelchecker/prctl/mdp/SchedulerGenerationMdpPrctlModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/prctl/mdp/SchedulerGenerationMdpPrctlModelCheckerTest.cpp
@@ -178,10 +178,10 @@ TYPED_TEST(SchedulerGenerationMdpPrctlModelCheckerTest, lra) {
         EXPECT_TRUE(!scheduler.isPartialScheduler());
 
         auto inducedModel = mdp->applyScheduler(scheduler);
-        ASSERT_EQ(inducedModel->getType(), storm::models::ModelType::Mdp);
-        auto const& inducedMdp = inducedModel->template as<storm::models::sparse::Mdp<ValueType>>();
+        ASSERT_EQ(inducedModel->getType(), storm::models::ModelType::Dtmc);
+        auto const& inducedMdp = inducedModel->template as<storm::models::sparse::Dtmc<ValueType>>();
         EXPECT_EQ(inducedMdp->getNumberOfChoices(), inducedMdp->getNumberOfStates());
-        storm::modelchecker::SparseMdpPrctlModelChecker<storm::models::sparse::Mdp<ValueType>> inducedChecker(*inducedMdp);
+        storm::modelchecker::SparseDtmcPrctlModelChecker<storm::models::sparse::Dtmc<ValueType>> inducedChecker(*inducedMdp);
         auto inducedResult = inducedChecker.check(this->env(), tasks[0]);
         ASSERT_TRUE(inducedResult->isExplicitQuantitativeCheckResult());
         EXPECT_NEAR(this->parseNumber("333/1000"), inducedResult->template asExplicitQuantitativeCheckResult<ValueType>()[*mdp->getInitialStates().begin()],
@@ -198,10 +198,10 @@ TYPED_TEST(SchedulerGenerationMdpPrctlModelCheckerTest, lra) {
         EXPECT_TRUE(scheduler.isMemorylessScheduler());
         EXPECT_TRUE(!scheduler.isPartialScheduler());
         auto inducedModel = mdp->applyScheduler(scheduler);
-        ASSERT_EQ(inducedModel->getType(), storm::models::ModelType::Mdp);
-        auto const& inducedMdp = inducedModel->template as<storm::models::sparse::Mdp<ValueType>>();
+        ASSERT_EQ(inducedModel->getType(), storm::models::ModelType::Dtmc);
+        auto const& inducedMdp = inducedModel->template as<storm::models::sparse::Dtmc<ValueType>>();
         EXPECT_EQ(inducedMdp->getNumberOfChoices(), inducedMdp->getNumberOfStates());
-        storm::modelchecker::SparseMdpPrctlModelChecker<storm::models::sparse::Mdp<ValueType>> inducedChecker(*inducedMdp);
+        storm::modelchecker::SparseDtmcPrctlModelChecker<storm::models::sparse::Dtmc<ValueType>> inducedChecker(*inducedMdp);
         auto inducedResult = inducedChecker.check(this->env(), tasks[1]);
         ASSERT_TRUE(inducedResult->isExplicitQuantitativeCheckResult());
         EXPECT_NEAR(this->parseNumber("0"), inducedResult->template asExplicitQuantitativeCheckResult<ValueType>()[*mdp->getInitialStates().begin()],
@@ -384,11 +384,11 @@ TYPED_TEST(SchedulerGenerationMdpPrctlModelCheckerTest, ltlUnsat) {
         EXPECT_TRUE(!scheduler.isPartialScheduler());
         auto inducedModel = mdp->applyScheduler(scheduler);
 
-        ASSERT_EQ(inducedModel->getType(), storm::models::ModelType::Mdp);
-        auto const& inducedMdp = inducedModel->template as<storm::models::sparse::Mdp<ValueType>>();
+        ASSERT_EQ(inducedModel->getType(), storm::models::ModelType::Dtmc);
+        auto const& inducedMdp = inducedModel->template as<storm::models::sparse::Dtmc<ValueType>>();
         EXPECT_EQ(inducedMdp->getNumberOfChoices(), inducedMdp->getNumberOfStates());
 
-        storm::modelchecker::SparseMdpPrctlModelChecker<storm::models::sparse::Mdp<ValueType>> inducedChecker(*inducedMdp);
+        storm::modelchecker::SparseDtmcPrctlModelChecker<storm::models::sparse::Dtmc<ValueType>> inducedChecker(*inducedMdp);
         auto inducedResult = inducedChecker.check(this->env(), tasks[0]);
         ASSERT_TRUE(inducedResult->isExplicitQuantitativeCheckResult());
         EXPECT_NEAR(this->parseNumber("0"), inducedResult->template asExplicitQuantitativeCheckResult<ValueType>()[*inducedMdp->getInitialStates().begin()],
@@ -409,11 +409,11 @@ TYPED_TEST(SchedulerGenerationMdpPrctlModelCheckerTest, ltlUnsat) {
         EXPECT_TRUE(!scheduler.isPartialScheduler());
         auto inducedModel = mdp->applyScheduler(scheduler);
 
-        ASSERT_EQ(inducedModel->getType(), storm::models::ModelType::Mdp);
-        auto const& inducedMdp = inducedModel->template as<storm::models::sparse::Mdp<ValueType>>();
+        ASSERT_EQ(inducedModel->getType(), storm::models::ModelType::Dtmc);
+        auto const& inducedMdp = inducedModel->template as<storm::models::sparse::Dtmc<ValueType>>();
         EXPECT_EQ(inducedMdp->getNumberOfChoices(), inducedMdp->getNumberOfStates());
 
-        storm::modelchecker::SparseMdpPrctlModelChecker<storm::models::sparse::Mdp<ValueType>> inducedChecker(*inducedMdp);
+        storm::modelchecker::SparseDtmcPrctlModelChecker<storm::models::sparse::Dtmc<ValueType>> inducedChecker(*inducedMdp);
         auto inducedResult = inducedChecker.check(this->env(), tasks[1]);
         ASSERT_TRUE(inducedResult->isExplicitQuantitativeCheckResult());
         EXPECT_NEAR(this->parseNumber("1"), inducedResult->template asExplicitQuantitativeCheckResult<ValueType>()[*inducedMdp->getInitialStates().begin()],


### PR DESCRIPTION
When applying a fully defined scheduler to an MDP, we obtain a DTMC; this allows applying DTMC-specific code on this model.