### PR TITLE
POMDP to pMC with constant rewards

### DIFF
--- a/src/storm-pomdp-cli/settings/modules/ToParametricSettings.cpp
+++ b/src/storm-pomdp-cli/settings/modules/ToParametricSettings.cpp
@@ -19,6 +19,7 @@ namespace storm {
             std::vector<std::string> fscModes = {"standard", "simple-linear", "simple-linear-inverse"};
             const std::string transformBinaryOption = "transformbinary";
             const std::string transformSimpleOption = "transformsimple";
+            const std::string constantRewardsOption = "constant-reward";
             const std::string allowSimplificationOption = "simplify-pmc";
 
             ToParametricSettings::ToParametricSettings() : ModuleSettings(moduleName) {
@@ -26,6 +27,7 @@ namespace storm {
                 this->addOption(storm::settings::OptionBuilder(moduleName, fscmode, false, "Sets the way the pMC is obtained").addArgument(storm::settings::ArgumentBuilder::createStringArgument("type", "type name").addValidatorString(ArgumentValidatorFactory::createMultipleChoiceValidator(fscModes)).setDefaultValueString("standard").build()).build());
                 this->addOption(storm::settings::OptionBuilder(moduleName, transformBinaryOption, false, "Transforms the pomdp to a binary pomdp.").build());
                 this->addOption(storm::settings::OptionBuilder(moduleName, transformSimpleOption, false, "Transforms the pomdp to a binary and simple pomdp.").build());
+                this->addOption(storm::settings::OptionBuilder(moduleName, constantRewardsOption, false, "Transforms the resulting pMC to a pMC with constant rewards.").build());
                 this->addOption(storm::settings::OptionBuilder(moduleName, allowSimplificationOption, false, "After obtaining a pMC, should further simplifications be applied?.").build());
 
             }
@@ -45,6 +47,10 @@ namespace storm {
 
             bool ToParametricSettings::isTransformSimpleSet() const {
                 return this->getOption(transformSimpleOption).getHasOptionBeenSet();
+            }
+
+            bool ToParametricSettings::isConstantRewardsSet() const {
+                return this->getOption(constantRewardsOption).getHasOptionBeenSet();
             }
 
             bool ToParametricSettings::allowPostSimplifications() const {

--- a/src/storm-pomdp-cli/settings/modules/ToParametricSettings.h
+++ b/src/storm-pomdp-cli/settings/modules/ToParametricSettings.h
@@ -31,6 +31,7 @@ namespace storm {
                 bool isMecReductionSet() const;
                 bool isTransformSimpleSet() const;
                 bool isTransformBinarySet() const;
+                bool isConstantRewardsSet() const;
                 bool allowPostSimplifications() const;
                 std::string getFscApplicationTypeString() const;
 

--- a/src/storm-pomdp-cli/storm-pomdp.cpp
+++ b/src/storm-pomdp-cli/storm-pomdp.cpp
@@ -303,8 +303,109 @@ namespace storm {
                 }
                 return analysisPerformed;
             }
-            
-            
+
+            template<typename ValueType, storm::dd::DdType DdType>
+            std::shared_ptr<storm::models::sparse::Model<storm::RationalFunction>> makeRewardsConstant( std::shared_ptr<storm::models::sparse::Model<storm::RationalFunction>> pMC) {
+                STORM_LOG_THROW(pMC->hasUniqueRewardModel(), storm::exceptions::IllegalArgumentException, "pMC need to have a rewqrad model");
+                storm::storage::sparse::ModelComponents<storm::RationalFunction> modelComponents;
+
+                uint64_t nrStates = pMC->getTransitionMatrix().getColumnCount();
+                uint_fast64_t nrOfNewStates = 0;
+                auto rewardModel = pMC->getUniqueRewardModel();
+                for (uint64_t state = 0; state < nrStates; ++state) {
+                    if (rewardModel.hasStateActionRewards() && !rewardModel.getStateActionReward(state).isConstant()) {
+                        nrOfNewStates = nrOfNewStates + 2;
+                    } else if (rewardModel.hasStateRewards() && !rewardModel.getStateReward(state).isConstant()) {
+                        nrOfNewStates = nrOfNewStates + 2;
+                    }
+                }
+
+                storm::storage::SparseMatrixBuilder<storm::RationalFunction> smb(nrStates + nrOfNewStates, nrStates + nrOfNewStates, 0, true);
+
+                uint64_t offset = 0;
+                std::vector<storm::RationalFunction> stateRewards(nrStates + nrOfNewStates, storm::RationalFunction(0));
+                storm::models::sparse::StateLabeling stateLabeling(nrStates + nrOfNewStates);
+                STORM_LOG_THROW(!pMC->getOptionalStateValuations(), storm::exceptions::NotImplementedException, "Keeping rewards constant while having state valuations is not implemented");
+                for (uint64_t state = 0; state < nrStates; ++state) {
+                    storm::RationalFunction reward = storm::RationalFunction(0);
+                    if (rewardModel.hasStateActionRewards()) {
+                        reward = rewardModel.getStateActionReward(state);
+                    } else {
+                        STORM_LOG_ASSERT(rewardModel.hasStateRewards(), "Expecting model to have either state rewards or state action rewards");
+                        reward = rewardModel.getStateReward(state);
+                    }
+                    for (auto& label : pMC->getStateLabeling().getLabelsOfState(state)) {
+                        if (!stateLabeling.containsLabel(label)) {
+                            stateLabeling.addLabel(label);
+                        }
+                        stateLabeling.addLabelToState(label, state + offset);
+                    }
+
+                    if (!reward.isConstant()) {
+                        /*
+                         * We want to transform a state s with parametric reward r to 3 states, s0, s1 and s2.
+                         * s1 and s2 have as successor states the successor states of s
+                         * the reward of s2 is always 0 (rew2 = 0)
+                         * f1 and f2 represent the prob from s0 to s1/s2
+                         * val0 is the valuation of the reward at p=0 (same for val1, p=1)
+                         *  rew s     | val0 | val1      | constant | rew0  | rew1 | f1    | f2 |
+                         *  p * a + b | b    | a + b     | b        | b     | a    | p     | 1 - p
+                         *  b - p * a | b    | b - a     | b        | b - a | a    | 1 - p | p
+                         */
+                        auto vars = reward.gatherVariables();
+                        auto b = reward.constantPart();
+                        STORM_LOG_THROW(vars.size() == 1, storm::exceptions::NotImplementedException, "Making rewards constant for rewards with more than 1 parameter not implemented");
+                        std::map<RationalFunctionVariable, RationalFunctionCoefficient> val0, val1;
+                        val0[*vars.begin()] = 0;
+                        val1[*vars.begin()] = 1;
+                        auto value0 = reward.evaluate(val0);
+                        auto value1 = reward.evaluate(val1);
+                        if (value1 - b >= 0) {
+                            auto a = value1 - b;
+                            // Reward is b + p * a
+                            stateRewards[state + offset] = storm::utility::convertNumber<storm::RationalFunction>(b);
+                            stateRewards[state + offset + 1] = storm::utility::convertNumber<storm::RationalFunction>(a);
+                            stateRewards[state + offset + 2] = storm::RationalFunction(0);
+
+                            // probs are p and 1-p
+                            storm::RationalFunction funcP = (reward - b) / a ;
+                            smb.addNextValue(state + offset, state + 1, funcP);
+                            smb.addNextValue(state + offset, state + 2, storm::RationalFunction(1) - funcP);
+                        } else {
+                            // Reward is b - p * a
+                            auto a = b - value1;
+                            stateRewards[state + offset] = storm::utility::convertNumber<storm::RationalFunction>(value1);
+                            stateRewards[state + offset + 1] = storm::utility::convertNumber<storm::RationalFunction>(a);
+                            stateRewards[state + offset + 2] = storm::RationalFunction(0);
+                            storm::RationalFunction funcP = (- (reward - b)) / a ;
+                            smb.addNextValue(state + offset, state + 1, storm::RationalFunction(1) - funcP);
+                            smb.addNextValue(state + offset, state + 2, funcP);
+                        }
+                        auto row = pMC->getTransitionMatrix().getRow(state);
+                        for (auto const& entry : row) {
+                            smb.addNextValue(state + offset + 1, entry.getColumn(), entry.getValue());
+                        }
+                        for (auto const& entry : row) {
+                            smb.addNextValue(state + offset + 2, entry.getColumn(), entry.getValue());
+                        }
+                        offset += 2;
+                    } else {
+                        stateRewards[state + offset] = reward;
+                        for (auto const& entry : pMC->getTransitionMatrix().getRow(state)) {
+                            smb.addNextValue(state + offset, entry.getColumn(), entry.getValue());
+                        }
+                    }
+
+
+                }
+                modelComponents.transitionMatrix = smb.build();
+                modelComponents.rewardModels.emplace(pMC->getUniqueRewardModelName(), std::move(stateRewards)) ;
+
+                modelComponents.stateLabeling = std::move(stateLabeling);
+                modelComponents.stateValuations = pMC->getOptionalStateValuations();
+                return std::make_shared<storm::models::sparse::Dtmc<storm::RationalFunction>>(modelComponents);
+            }
+
             template<typename ValueType, storm::dd::DdType DdType>
             bool performTransformation(std::shared_ptr<storm::models::sparse::Pomdp<ValueType>>& pomdp, storm::logic::Formula const& formula) {
                 auto const& pomdpSettings = storm::settings::getModule<storm::settings::modules::POMDPSettings>();
@@ -357,13 +458,19 @@ namespace storm {
                     std::string transformMode = transformSettings.getFscApplicationTypeString();
                     auto pmc = toPMCTransformer.transform(storm::transformer::parsePomdpFscApplicationMode(transformMode));
                     STORM_PRINT_AND_LOG(" done.\n");
-                    pmc->printModelInformationToStream(std::cout);
+                    uint_fast64_t numberOfStates = pmc->getTransitionMatrix().getColumnCount();
+
+
                     if (transformSettings.allowPostSimplifications()) {
                         STORM_PRINT_AND_LOG("Simplifying pMC...");
                         pmc = storm::api::performBisimulationMinimization<storm::RationalFunction>(pmc->template as<storm::models::sparse::Dtmc<storm::RationalFunction>>(),{formula.asSharedPointer()}, storm::storage::BisimulationType::Strong)->template as<storm::models::sparse::Dtmc<storm::RationalFunction>>();
                         STORM_PRINT_AND_LOG(" done.\n");
                         pmc->printModelInformationToStream(std::cout);
                     }
+                    if (transformSettings.isConstantRewardsSet()) {
+                        pmc = makeRewardsConstant<ValueType, DdType>(pmc);
+                    }
+                    pmc->printModelInformationToStream(std::cout);
                     STORM_PRINT_AND_LOG("Exporting pMC...");
                     storm::analysis::ConstraintCollector<storm::RationalFunction> constraints(*pmc);
                     auto const& parameterSet = constraints.getVariables();


### PR DESCRIPTION
Adds option to create a pmc out of a pomdp with constant rewards (i.e. no parameters occur at the reward of a state)