### PR TITLE
fix handling duplicate entries in the sparse matrix builder

### DIFF
--- a/src/storm/storage/SparseMatrix.cpp
+++ b/src/storm/storage/SparseMatrix.cpp
@@ -223,10 +223,10 @@ void SparseMatrixBuilder<ValueType>::addNextValue(index_type row, index_type col
                 }
             }
             // Then, we eliminate those duplicate entries.
-            auto it = std::unique(columnsAndValues.begin() + rowIndications.back(), columnsAndValues.end(),
-                                  [](storm::storage::MatrixEntry<index_type, ValueType> const& a, storm::storage::MatrixEntry<index_type, ValueType> const& b) {
-                                      return a.getColumn() == b.getColumn();
-                                  });
+            std::unique(columnsAndValues.begin() + rowIndications.back(), columnsAndValues.end(),
+                        [](storm::storage::MatrixEntry<index_type, ValueType> const& a, storm::storage::MatrixEntry<index_type, ValueType> const& b) {
+                            return a.getColumn() == b.getColumn();
+                        });
 
             if (elementsToRemove > 0) {
                 STORM_LOG_WARN("Unordered insertion into matrix builder caused duplicate entries.");


### PR DESCRIPTION
Fixes https://github.com/moves-rwth/storm/issues/204.

Notice that one could further clean this function as we are now not using that only one entry is out-of-order, by either 
- only cleanup after moving to the next row
- use something like insertion sort right away

Nevertheless, I think this deserves being pulled in as it fixes an open bug in the way we discussed.