### PR TITLE
Enable automatic code formatting for storm-dft

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,9 +1,6 @@
-./src/storm-dft/*
-./src/storm-dft-cli/*
 ./src/storm-pars/*
 ./src/storm-pars-cli/*
 ./src/storm-pomdp/*
 ./src/storm-pomdp-cli/*
-./src/test/storm-dft/*
 ./src/test/storm-pars/*
 ./src/test/storm-pomdp/*

--- a/src/storm-dft/storage/dft/DFTStateGenerationInfo.h
+++ b/src/storm-dft/storage/dft/DFTStateGenerationInfo.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "storm-dft/storage/dft/SymmetricUnits.h"
+
 namespace storm {
     namespace storage {
         class DFTStateGenerationInfo {


### PR DESCRIPTION
Enable automatic code formatting for storm-dft, storm-dft-cli and test/storm-dft.
Actual code formatting will be automatically performed by Github workflow.

New PR following the suggestions in PR #211.