### PR TITLE
Updated description of auto PR

### DIFF
--- a/.github/workflows/formatapply.yml
+++ b/.github/workflows/formatapply.yml
@@ -41,4 +41,4 @@ jobs:
           delete-branch: true
           title: 'Code formatting'
           body: |
-            Auto-generated pull request triggered by the `apply-code-format` workflow.
+            Auto-generated pull request triggered by the `apply-code-format` workflow. Make sure to **merge** (and not rebase) this PR so that the added commit hash in `.git-blame-ignore-revs`  remains valid. 


### PR DESCRIPTION
emphasizes that the PR generated by the `apply-code-format` workflow should be merged and not rebased (cf PR #211)