### PR TITLE
Remainder -> Modulo in accordance with Prism

### DIFF
--- a/src/storm/storage/expressions/Expression.cpp
+++ b/src/storm/storage/expressions/Expression.cpp
@@ -543,9 +543,7 @@ Expression sum(std::vector<storm::expressions::Expression> const& expressions) {
 }
 
 Expression modulo(Expression const& first, Expression const& second) {
-    return Expression(std::shared_ptr<BaseExpression>(new BinaryNumericalFunctionExpression(
-        first.getBaseExpression().getManager(), first.getType().modulo(second.getType()), first.getBaseExpressionPointer(), second.getBaseExpressionPointer(),
-        BinaryNumericalFunctionExpression::OperatorType::Modulo)));
+    return first % second;
 }
 
 Expression apply(std::vector<storm::expressions::Expression> const& expressions,

--- a/src/storm/storage/expressions/Expression.cpp
+++ b/src/storm/storage/expressions/Expression.cpp
@@ -300,9 +300,13 @@ Expression operator/(Expression const& first, Expression const& second) {
 
 Expression operator%(Expression const& first, Expression const& second) {
     assertSameManager(first.getBaseExpression(), second.getBaseExpression());
-    return Expression(std::shared_ptr<BaseExpression>(new BinaryNumericalFunctionExpression(
+    // First we compute the remainder
+    Expression remainder(std::shared_ptr<BaseExpression>(new BinaryNumericalFunctionExpression(
         first.getBaseExpression().getManager(), first.getType().modulo(second.getType()), first.getBaseExpressionPointer(), second.getBaseExpressionPointer(),
         BinaryNumericalFunctionExpression::OperatorType::Modulo)));
+
+    // Deal with negative `first` in accordance with Prism
+    return storm::expressions::ite(first >= 0, remainder, remainder + second);
 }
 
 Expression operator&&(Expression const& first, Expression const& second) {


### PR DESCRIPTION
Regarding issue #221. Correctly implements the modulo operator for expressions in accordance with Prism, by introducing an ITE for dealing with negative numbers. I added a test to check the behavior.