### PR TITLE
Updated deprecated std::iterator

### DIFF
--- a/src/storm/storage/BitVector.h
+++ b/src/storm/storage/BitVector.h
@@ -20,11 +20,18 @@ class BitVector {
      * A class that enables iterating over the indices of the bit vector whose corresponding bits are set to
      * true. Note that this is a const iterator, which cannot alter the bit vector.
      */
-    class const_iterator : public std::iterator<std::input_iterator_tag, uint_fast64_t> {
+    class const_iterator {
         // Declare the BitVector class as a friend class to access its internal storage.
         friend class BitVector;
 
        public:
+        // Define iterator
+        using iterator_category = std::input_iterator_tag;
+        using value_type = uint_fast64_t;
+        using difference_type = std::ptrdiff_t;
+        using pointer = uint_fast64_t*;
+        using reference = uint_fast64_t&;
+
         /*!
          * Constructs an iterator over the indices of the set bits in the given bit vector, starting and
          * stopping, respectively, at the given indices.

--- a/src/storm/storage/expressions/ExpressionManager.h
+++ b/src/storm/storage/expressions/ExpressionManager.h
@@ -20,8 +20,15 @@ namespace expressions {
 // Forward-declare manager class for iterator class.
 class ExpressionManager;
 
-class VariableIterator : public std::iterator<std::input_iterator_tag, std::pair<storm::expressions::Variable, storm::expressions::Type> const> {
+class VariableIterator {
    public:
+    // Define iterator
+    using iterator_category = std::input_iterator_tag;
+    using value_type = std::pair<storm::expressions::Variable, storm::expressions::Type> const;
+    using difference_type = std::ptrdiff_t;
+    using pointer = std::pair<storm::expressions::Variable, storm::expressions::Type> const*;
+    using reference = std::pair<storm::expressions::Variable, storm::expressions::Type> const&;
+
     enum class VariableSelection { OnlyRegularVariables, OnlyAuxiliaryVariables, AllVariables };
 
     VariableIterator(ExpressionManager const& manager, std::unordered_map<std::string, uint_fast64_t>::const_iterator nameIndexIterator,

--- a/src/storm/utility/shortestPaths.h
+++ b/src/storm/utility/shortestPaths.h
@@ -185,7 +185,7 @@ class ShortestPathsGenerator {
     // --- tiny helper fcts ---
 
     inline bool isInitialState(state_t node) const {
-        return find(initialStates.begin(), initialStates.end(), node) != initialStates.end();
+        return std::find(initialStates.begin(), initialStates.end(), node) != initialStates.end();
     }
 
     inline bool isMetaTargetPredecessor(state_t node) const {


### PR DESCRIPTION
`std::iterator` is deprecated since C++17. Updated it according to https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/