### PR TITLE
CI: Disable 'build and test' workflow for ubuntu 18-04

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: ["debian-10", "debian-11", "ubuntu-18.04", "ubuntu-20.04"]
+        distro: ["debian-10", "debian-11", "ubuntu-20.04"]
         debugOrRelease: ["release"]
     steps:
       - name: Setup cmake arguments


### PR DESCRIPTION
~PR #233~ PR #273 breaks support for ubuntu 18-04.
This PR removes 18-04 from our CI workflow.

**EDIT:** Apparently, #233 does not actually break ubuntu 18-04 builds. 
**EDIT2:** But #273 does!