### PR TITLE
DRN Parser: Fix off-by-one issue

### DIFF
--- a/resources/examples/testfiles/dtmc/crowds-5-5.drn
+++ b/resources/examples/testfiles/dtmc/crowds-5-5.drn
@@ -7,6 +7,8 @@
 
 @nr_states
 8607
+@nr_choices
+8607
 @model
 state 0 init
 	action 0

--- a/resources/examples/testfiles/ma/jobscheduler.drn
+++ b/resources/examples/testfiles/ma/jobscheduler.drn
@@ -7,6 +7,8 @@
 avg_waiting_time 
 @nr_states
 17
+@nr_choices
+19
 @model
 state 0 !0 [1] init
 	action 0 [0]

--- a/src/storm-parsers/parser/DirectEncodingParser.cpp
+++ b/src/storm-parsers/parser/DirectEncodingParser.cpp
@@ -205,7 +205,7 @@ std::shared_ptr<storm::storage::sparse::ModelComponents<ValueType, RewardModelTy
             if (nonDeterministic) {
                 STORM_LOG_TRACE("new Row Group starts at " << row << ".");
                 builder.newRowGroup(row);
-                STORM_LOG_THROW(nrChoices == 0 || builder.getCurrentRowGroupCount() < nrChoices, storm::exceptions::WrongFormatException,
+                STORM_LOG_THROW(nrChoices == 0 || builder.getCurrentRowGroupCount() <= nrChoices, storm::exceptions::WrongFormatException,
                                 "More actions detected than declared (in @nr_choices).");
             }
 


### PR DESCRIPTION
The current code throws a
```
ERROR (DirectEncodingParser.cpp:209): More actions detected than declared (in @nr_choices).
```
when parsing the very last choice, even if the `@nr_choices` hint is correct.
This PR fixes the issue.