### PR TITLE
prism-to-jani: fixed detection of variables to make global

### DIFF
--- a/src/storm/storage/prism/ToJaniConverter.cpp
+++ b/src/storm/storage/prism/ToJaniConverter.cpp
@@ -174,7 +174,7 @@ storm::jani::Model ToJaniConverter::convert(storm::prism::Program const& program
         storm::prism::Module const& module = program.getModule(index);
 
         // Gather all variables occurring in this module
-        std::set<storm::expressions::Variable> variables;
+        std::set<storm::expressions::Variable> variables = module.getAllExpressionVariables();
         for (auto const& command : module.getCommands()) {
             command.getGuardExpression().getBaseExpression().gatherVariables(variables);
             for (auto const& update : command.getUpdates()) {


### PR DESCRIPTION
fixes #205

The issue was that variable declarations were not considered when finding the set of modules that access a given variable.
As a consequence, if a variable `x` is declared in a module `A` but *only* used in a different module `B`, then we assumed that only a single module accesses `x` and hence `x` was not made a global variable.

Now we also consider variable declarations, so `x` is accessed by both modules `A` and `B`.

I did consider further optimisations (like moving `x` to the scope of `B`; or even making `x` a constant since it is never written to). However, I consider this a rare edge case so I did not want to make things unnecessarily complicated.