### PR TITLE
Updated clang-format-lint-action to version 0.14

### DIFF
--- a/.github/workflows/formatapply.yml
+++ b/.github/workflows/formatapply.yml
@@ -9,16 +9,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # apply the formatting twice as a workaround for a clang-format bug
-      - uses: DoozyX/clang-format-lint-action@v0.13
+      - uses: DoozyX/clang-format-lint-action@v0.14
         with:
           source: './src'
-          clangFormatVersion: 12
+          clangFormatVersion: 14
           style: file
           inplace: True
-      - uses: DoozyX/clang-format-lint-action@v0.13
+      - uses: DoozyX/clang-format-lint-action@v0.14
         with:
           source: './src'
-          clangFormatVersion: 12
+          clangFormatVersion: 14
           style: file
           inplace: True
       - name: Commit Formatting

--- a/.github/workflows/formatcheck.yml
+++ b/.github/workflows/formatcheck.yml
@@ -8,8 +8,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.13
+    - uses: DoozyX/clang-format-lint-action@v0.14
       with:
         source: './src'
-        clangFormatVersion: 12
+        clangFormatVersion: 14
         style: file


### PR DESCRIPTION
This allows to use clang-format version 14 which is also the current version in Homebrew.
Clang-format version 14 leads to small formatting differences compared to version 12 (notably for `StandardRewardModel`).