### PR TITLE
Allow step-bounded until formulas in LTL.

### DIFF
--- a/resources/examples/testfiles/mdp/coin_flips.nm
+++ b/resources/examples/testfiles/mdp/coin_flips.nm
@@ -1,0 +1,20 @@
+// flip a coin N times
+
+mdp
+
+const N=20;
+
+module count
+	x : [0..N] init 0;
+	[flip] x<N -> (x'=x+1);
+endmodule
+
+module coin
+	heads : bool init false;
+	tails : bool init false;
+
+	[flip] true -> 0.5: (heads'=true) & (tails'=false) + 0.5: (heads'=false) & (tails'=true);
+	[] true -> (heads'=false) & (tails'=false);
+endmodule
+
+label "done" = x=N;


### PR DESCRIPTION
With this PR, step-bounded until formulas are  supported within LTL formulas.

This is realised using a transformation to nested `X` operators. 
Unfortunately, this is the best way to do this right now, because we currently transform the formula into a prefix string that is then parsed by spot. This prefix syntax (also used by e.g. ltl2dstar) does not support step-bounds.

In principle, it would be possible to avoid the prefix string transformation and directly use the spot API (which supports at least step bounded `F` operators). However, I looked into the src of spot and it seems that they also just transform to nested `X`s.