### PR TITLE
Updated Dockerfile with Spot support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # The Docker image can be built by executing:
 # docker build -t yourusername/storm .
 
-FROM movesrwth/storm-basesystem:ubuntu-22.04
+FROM movesrwth/storm-basesystem:latest
 MAINTAINER Matthias Volk <m.volk@utwente.nl>
 
 # Specify number of threads to use for parallel compilation
@@ -26,7 +26,7 @@ RUN mkdir -p /opt/carl/build
 WORKDIR /opt/carl/build
 
 # Configure Carl
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_CLN_NUMBERS=ON -DUSE_GINAC=ON
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_CLN_NUMBERS=ON -DUSE_GINAC=ON -DTHREAD_SAFE=ON
 
 # Build Carl library
 RUN make lib_carl -j $no_threads
@@ -46,9 +46,12 @@ RUN mkdir -p /opt/storm/build
 WORKDIR /opt/storm/build
 
 # Configure Storm
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DSTORM_DEVELOPER=OFF -DSTORM_LOG_DISABLE_DEBUG=ON -DSTORM_PORTABLE=ON
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DSTORM_DEVELOPER=OFF -DSTORM_LOG_DISABLE_DEBUG=ON -DSTORM_PORTABLE=ON -DSTORM_USE_SPOT_SHIPPED=ON
 
-# Build binaries of Storm
+# Build external dependencies of Storm
+RUN make resources -j $no_threads
+
+# Build Storm binary
 RUN make storm -j $no_threads
 
 # Build additional binaries of Storm


### PR DESCRIPTION
- Use `storm-basesystem:latest` as common base now. This avoids having to update the Dockerfile every time a new Ubuntu version is released.
- Added missing flag for carl
- Build with Spot