### PR TITLE
Printing finite-state schedulers requires model 

### DIFF
--- a/src/storm/storage/Scheduler.cpp
+++ b/src/storm/storage/Scheduler.cpp
@@ -268,6 +268,8 @@ void Scheduler<ValueType>::printToStream(std::ostream& out, std::shared_ptr<stor
 
             // Print memory updates
             if (!isMemorylessScheduler()) {
+                STORM_LOG_THROW(model != nullptr, storm::exceptions::InvalidOperationException,
+                                "Schedulers with memory can only be printed when the model is passed.");
                 out << std::setw(widthOfStates) << "";
                 // The memory updates do not depend on the actual choice, they only depend on the current model- and memory state as well as the successor model
                 // state.
@@ -352,6 +354,8 @@ void Scheduler<ValueType>::printJsonToStream(std::ostream& out, std::shared_ptr<
 
                     // Memory updates
                     if (!isMemorylessScheduler()) {
+                        STORM_LOG_THROW(model != nullptr, storm::exceptions::InvalidOperationException,
+                                        "Schedulers with memory can only be printed when the model is passed.");
                         choiceJson["memory-updates"] = std::vector<storm::json<storm::RationalNumber>>();
                         uint64_t row = model->getTransitionMatrix().getRowGroupIndices()[state] + choiceProbPair.first;
                         for (auto entryIt = model->getTransitionMatrix().getRow(row).begin(); entryIt < model->getTransitionMatrix().getRow(row).end();

--- a/src/storm/storage/Scheduler.h
+++ b/src/storm/storage/Scheduler.h
@@ -9,7 +9,7 @@ namespace storm {
 
 namespace storage {
 
-/*
+/**
  * This class defines which action is chosen in a particular state of a non-deterministic model. More concretely, a scheduler maps a state s to i
  * if the scheduler takes the i-th action available in s (i.e. the choices are relative to the states).
  * A Choice can be undefined, deterministic
@@ -128,7 +128,8 @@ class Scheduler {
     /*!
      * Prints the scheduler to the given output stream.
      * @param out The output stream
-     * @param model If given, provides additional information for printing (e.g., displaying the state valuations instead of state indices)
+     * @param model If given, provides additional information for printing (e.g., displaying the state valuations instead of state indices).
+     *              Must be passed if the scheduler is not memoryless.
      * @param skipUniqueChoices If true, the (unique) choice for deterministic states (i.e., states with only one enabled choice) is not printed explicitly.
      *                          Requires a model to be given.
      * @param skipDontCareStates If true, the choice for dontCareStates states is not printed explicitly.
@@ -138,6 +139,12 @@ class Scheduler {
 
     /*!
      * Prints the scheduler in json format to the given output stream.
+     * @param out The output stream
+     * @param model If given, provides additional information for printing (e.g., displaying the state valuations instead of state indices).
+     *              Must be passed if the scheduler is not memoryless.
+     * @param skipUniqueChoices If true, the (unique) choice for deterministic states (i.e., states with only one enabled choice) is not printed explicitly.
+     *                          Requires a model to be given.
+     * @param skipDontCareStates If true, the choice for dontCareStates states is not printed explicitly.
      */
     void printJsonToStream(std::ostream& out, std::shared_ptr<storm::models::sparse::Model<ValueType>> model = nullptr, bool skipUniqueChoices = false,
                            bool skipDontCareStates = false) const;


### PR DESCRIPTION
This prints an error if this is not the case, instead of segfaulting. 