### PR TITLE
Support 'relevant' in DFT Json format

### DIFF
--- a/src/storm-dft/parser/DFTJsonParser.cpp
+++ b/src/storm-dft/parser/DFTJsonParser.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 
 #include "storm-dft/builder/DFTBuilder.h"
+#include "storm-dft/utility/RelevantEvents.h"
 #include "storm/exceptions/FileIoException.h"
 #include "storm/exceptions/NotSupportedException.h"
 #include "storm/io/file.h"
@@ -34,6 +35,7 @@ storm::dft::storage::DFT<ValueType> DFTJsonParser<ValueType>::parseJson(Json con
     storm::dft::builder::DFTBuilder<ValueType> builder;
     storm::parser::ValueParser<ValueType> valueParser;
     std::string toplevelName = "";
+    storm::dft::utility::RelevantEvents relevantEvents;
 
     std::string currentLocation;
     try {
@@ -67,6 +69,10 @@ storm::dft::storage::DFT<ValueType> DFTJsonParser<ValueType>::parseJson(Json con
             currentLocation = parseValue(element);
             Json const& data = element.at("data");
             std::string name = parseName(data.at("name"));
+            // TODO: use contains() if modernjson is updated
+            if (data.count("relevant") > 0) {
+                relevantEvents.insert(name);
+            }
             // Create list of children
             std::vector<std::string> childNames;
             // TODO: use contains() if modernjson is updated
@@ -148,6 +154,8 @@ storm::dft::storage::DFT<ValueType> DFTJsonParser<ValueType>::parseJson(Json con
     storm::dft::storage::DFT<ValueType> dft = builder.build();
     STORM_LOG_DEBUG("DFT elements:\n" << dft.getElementsString());
     STORM_LOG_DEBUG("Spare modules:\n" << dft.getModulesString());
+    // Set relevant events
+    dft.setRelevantEvents(relevantEvents, false);
     return dft;
 }
 

--- a/src/storm-dft/simulator/DFTTraceSimulator.cpp
+++ b/src/storm-dft/simulator/DFTTraceSimulator.cpp
@@ -35,7 +35,7 @@ std::tuple<storm::dft::storage::FailableElements::const_iterator, double, bool> 
     // - either no relevant event remains (i.e., all relevant events have failed already), or
     // - no BE can fail
     if (!state->hasOperationalRelevantEvent() || iterFailable == state->getFailableElements().end()) {
-        STORM_LOG_TRACE("No sucessor states available for " << state->getId());
+        STORM_LOG_TRACE("No successor states available for " << state->getId());
         return std::make_tuple(iterFailable, -1, true);
     }
 

--- a/src/storm-dft/storage/DftJsonExporter.cpp
+++ b/src/storm-dft/storage/DftJsonExporter.cpp
@@ -66,6 +66,9 @@ typename DftJsonExporter<ValueType>::Json DftJsonExporter<ValueType>::translateE
     // Make lower case
     std::transform(type.begin(), type.end(), type.begin(), ::tolower);
     nodeData["type"] = type;
+    if (element->isRelevant()) {
+        nodeData["relevant"] = true;
+    }
 
     if (element->isGate() || element->isRestriction()) {
         // Set children for gate/restriction


### PR DESCRIPTION
Relevant events in DFT can be imported/exported from Json format.