### PR TITLE
Storm-dft: treat single BEs as modules

### DIFF
--- a/src/storm-dft/storage/DftModule.cpp
+++ b/src/storm-dft/storage/DftModule.cpp
@@ -32,10 +32,11 @@ std::string DftModule::toString(storm::dft::storage::DFT<ValueType> const& dft) 
     return stream.str();
 }
 DftIndependentModule::DftIndependentModule(size_t representative, std::set<size_t> const& elements, std::set<DftIndependentModule> const& submodules,
-                                           bool staticElements, bool fullyStatic)
-    : DftModule(representative, elements), staticElements(staticElements), fullyStatic(fullyStatic), submodules(submodules) {
+                                           bool staticElements, bool fullyStatic, bool singleBE)
+    : DftModule(representative, elements), staticElements(staticElements), fullyStatic(fullyStatic), singleBE(singleBE), submodules(submodules) {
     STORM_LOG_ASSERT(std::find(this->elements.begin(), this->elements.end(), representative) != this->elements.end(),
                      "Representative " + std::to_string(representative) + " must be contained in module.");
+    STORM_LOG_ASSERT(!singleBE || (submodules.empty() && elements.size() == 1), "Module " + std::to_string(representative) + " is not a single BE.");
 }
 
 std::set<size_t> DftIndependentModule::getAllElements() const {

--- a/src/storm-dft/storage/DftModule.h
+++ b/src/storm-dft/storage/DftModule.h
@@ -72,9 +72,10 @@ class DftIndependentModule : public DftModule {
      * @param submodules Set of sub-modules contained in the module.
      * @param staticElements Whether the module contains only static elements. Dynamic elements in sub-modules are allowed.
      * @param fullyStatic Whether the independent module contains only static static elements and all sub-modules also contain only static elements.
+     * @param singleBE Whether the independent module consists of a single BE.
      */
     DftIndependentModule(size_t representative, std::set<size_t> const& elements, std::set<DftIndependentModule> const& submodules, bool staticElements,
-                         bool fullyStatic);
+                         bool fullyStatic, bool singleBE);
 
     /*!
      * Returns whether the module contains only static elements (except in sub-modules).
@@ -99,6 +100,14 @@ class DftIndependentModule : public DftModule {
      */
     std::set<DftIndependentModule> const& getSubModules() const {
         return submodules;
+    }
+
+    /*!
+     * Returns whether the module is a single BE, i.e., a trivial module.
+     * @return Whether it is a single BE.
+     */
+    bool isSingleBE() const {
+        return singleBE;
     }
 
     /*!
@@ -131,6 +140,7 @@ class DftIndependentModule : public DftModule {
    private:
     bool staticElements;
     bool fullyStatic;
+    bool singleBE;
     std::set<DftIndependentModule> submodules;
 };
 

--- a/src/storm-dft/utility/DftModularizer.cpp
+++ b/src/storm-dft/utility/DftModularizer.cpp
@@ -96,15 +96,13 @@ void DftModularizer<ValueType>::obtainModules(DFTElementCPointer const element) 
         }
 
         if (counter.firstVisit < counter.minFirstVisit && counter.maxLastVisit < counter.secondVisit) {
-            if (!element->isBasicElement()) {
-                // Consider only non-trivial modules
-                // Create new module
-                storm::dft::storage::DftIndependentModule module(element->id(), modInfo.elements, modInfo.submodules, modInfo.isStatic, modInfo.fullyStatic);
-                // Update information
-                modInfo.elements = {};
-                modInfo.submodules = {module};
-                modInfo.isModule = true;
-            }
+            // Create new module
+            storm::dft::storage::DftIndependentModule module(element->id(), modInfo.elements, modInfo.submodules, modInfo.isStatic, modInfo.fullyStatic,
+                                                             element->isBasicElement());
+            // Update information
+            modInfo.elements = {};
+            modInfo.submodules = {module};
+            modInfo.isModule = true;
         }
     }
 }

--- a/src/storm-dft/utility/DftModularizer.h
+++ b/src/storm-dft/utility/DftModularizer.h
@@ -11,8 +11,7 @@ namespace utility {
  * The computation follows the LTA/DR algorithm from:
  * Dutuit, Rauzy: "A linear-time algorithm to find modules of fault trees"
  * @see http://doi.org/10.1109/24.537011
- *
- * @note BEs are trivial modules and therefore not explicitly listed.
+ * Trivial modules containing single BEs are also contained.
  */
 template<typename ValueType>
 class DftModularizer {

--- a/src/test/storm-dft/storage/DftModuleTest.cpp
+++ b/src/test/storm-dft/storage/DftModuleTest.cpp
@@ -22,18 +22,22 @@ TEST(DftModuleTest, Modularization) {
     EXPECT_EQ(it->getRepresentative(), 8ul);
     EXPECT_FALSE(it->isStatic());
     EXPECT_FALSE(it->isFullyStatic());
+    EXPECT_EQ(it->getSubModules().size(), 3ul);
     ++it;
     EXPECT_EQ(it->getRepresentative(), 17ul);
     EXPECT_FALSE(it->isStatic());
     EXPECT_FALSE(it->isFullyStatic());
+    EXPECT_EQ(it->getSubModules().size(), 3ul);
     ++it;
     EXPECT_EQ(it->getRepresentative(), 28ul);
     EXPECT_FALSE(it->isStatic());
     EXPECT_FALSE(it->isFullyStatic());
+    EXPECT_EQ(it->getSubModules().size(), 6ul);
     ++it;
     EXPECT_EQ(it->getRepresentative(), 36ul);
     EXPECT_FALSE(it->isStatic());
     EXPECT_FALSE(it->isFullyStatic());
+    EXPECT_EQ(it->getSubModules().size(), 7ul);
 }
 
 TEST(DftModuleTest, ModularizationCycle) {
@@ -43,7 +47,7 @@ TEST(DftModuleTest, ModularizationCycle) {
     storm::dft::utility::DftModularizer<double> modularizer;
     auto topModule = modularizer.computeModules(*dft);
     EXPECT_EQ(topModule.getRepresentative(), 2ul);
-    EXPECT_TRUE(topModule.getSubModules().empty());
+    EXPECT_EQ(topModule.getSubModules().size(), 2ul);
 }
 
 TEST(DftModuleTest, ModularizationOverlapping) {
@@ -60,14 +64,14 @@ TEST(DftModuleTest, ModularizationOverlapping) {
     auto it = submodules.begin();
     // Submodule F1
     EXPECT_EQ(it->getRepresentative(), 5ul);
-    EXPECT_TRUE(it->getSubModules().empty());
+    EXPECT_EQ(it->getSubModules().size(), 3ul);
     EXPECT_TRUE(it->isStatic());
     EXPECT_TRUE(it->isFullyStatic());
     // Submodule F4
     ++it;
     EXPECT_EQ(it->getRepresentative(), 12ul);
     auto modulesF4 = it->getSubModules();
-    EXPECT_EQ(modulesF4.size(), 1ul);
+    EXPECT_EQ(modulesF4.size(), 2ul);
     EXPECT_FALSE(it->isStatic());
     EXPECT_FALSE(it->isFullyStatic());
     EXPECT_EQ(++it, submodules.end());
@@ -75,17 +79,32 @@ TEST(DftModuleTest, ModularizationOverlapping) {
     it = modulesF4.begin();
     EXPECT_EQ(it->getRepresentative(), 10ul);
     auto modulesF5 = it->getSubModules();
-    EXPECT_EQ(modulesF5.size(), 1ul);
+    EXPECT_EQ(modulesF5.size(), 2ul);
     EXPECT_FALSE(it->isStatic());
     EXPECT_FALSE(it->isFullyStatic());
+    ++it;
+    EXPECT_EQ(it->getRepresentative(), 11ul);
+    EXPECT_TRUE(it->isSingleBE());
     EXPECT_EQ(++it, modulesF4.end());
     // Submodule F6
     it = modulesF5.begin();
     EXPECT_EQ(it->getRepresentative(), 8ul);
-    EXPECT_TRUE(it->getSubModules().empty());
+    auto modulesF6 = it->getSubModules();
+    EXPECT_EQ(modulesF6.size(), 2ul);
     EXPECT_TRUE(it->isStatic());
     EXPECT_TRUE(it->isFullyStatic());
+    ++it;
+    EXPECT_EQ(it->getRepresentative(), 9ul);
+    EXPECT_TRUE(it->isSingleBE());
     EXPECT_EQ(++it, modulesF5.end());
+    // BE submodules of F6
+    it = modulesF6.begin();
+    EXPECT_EQ(it->getRepresentative(), 6ul);
+    EXPECT_TRUE(it->isSingleBE());
+    ++it;
+    EXPECT_EQ(it->getRepresentative(), 7ul);
+    EXPECT_TRUE(it->isSingleBE());
+    EXPECT_EQ(++it, modulesF6.end());
 }
 
 }  // namespace


### PR DESCRIPTION
Fixed an issue with the DFT modularisation pointed out by @AhmadZafarDGB.