### PR TITLE
Fix Formula Parser

### DIFF
--- a/src/storm-parsers/parser/ExpressionParser.cpp
+++ b/src/storm-parsers/parser/ExpressionParser.cpp
@@ -96,10 +96,11 @@ ExpressionParser::ExpressionParser(storm::expressions::ExpressionManager const& 
     roundExpression.name("round expression");
 
     if (allowBacktracking) {
-        minMaxExpression = ((minMaxOperator_[qi::_a = qi::_1] >> qi::lit("(")) >> expression[qi::_val = qi::_1] >>
-                            +(qi::lit(",") >> expression)[qi::_val = phoenix::bind(&ExpressionCreator::createMinimumMaximumExpression,
-                                                                                   phoenix::ref(*expressionCreator), qi::_val, qi::_a, qi::_1, qi::_pass)]) >>
-                           qi::lit(")");
+        minMaxExpression =
+            ((minMaxOperator_[qi::_a = qi::_1] >> qi::lit("(")) >> expression[qi::_val = qi::_1] >>
+             +(qi::lit(",") >> expression)[qi::_b = phoenix::bind(&ExpressionCreator::createMinimumMaximumExpression, phoenix::ref(*expressionCreator),
+                                                                  qi::_val, qi::_a, qi::_1, qi::_pass)][qi::_val = qi::_b]) >>
+            qi::lit(")");
     } else {
         minMaxExpression =
             ((minMaxOperator_[qi::_a = qi::_1] >> qi::lit("(")) > expression[qi::_val = qi::_1] >
@@ -149,8 +150,9 @@ ExpressionParser::ExpressionParser(storm::expressions::ExpressionManager const& 
     if (allowBacktracking) {
         infixPowerModuloExpression =
             unaryExpression[qi::_val = qi::_1] >>
-            -(infixPowerModuloOperator_ >> unaryExpression)[qi::_val = phoenix::bind(&ExpressionCreator::createPowerModuloExpression,
-                                                                                     phoenix::ref(*expressionCreator), qi::_val, qi::_1, qi::_2, qi::_pass)];
+            -(infixPowerModuloOperator_ >>
+              unaryExpression)[qi::_a = phoenix::bind(&ExpressionCreator::createPowerModuloExpression, phoenix::ref(*expressionCreator), qi::_val, qi::_1,
+                                                      qi::_2, qi::_pass)][qi::_val = qi::_a];
     } else {
         infixPowerModuloExpression =
             unaryExpression[qi::_val = qi::_1] >
@@ -163,8 +165,8 @@ ExpressionParser::ExpressionParser(storm::expressions::ExpressionManager const& 
         multiplicationExpression =
             infixPowerModuloExpression[qi::_val = qi::_1] >>
             *(multiplicationOperator_ >>
-              infixPowerModuloExpression)[qi::_val = phoenix::bind(&ExpressionCreator::createMultExpression, phoenix::ref(*expressionCreator), qi::_val, qi::_1,
-                                                                   qi::_2, qi::_pass)];
+              infixPowerModuloExpression)[qi::_a = phoenix::bind(&ExpressionCreator::createMultExpression, phoenix::ref(*expressionCreator), qi::_val, qi::_1,
+                                                                 qi::_2, qi::_pass)][qi::_val = qi::_a];
     } else {
         multiplicationExpression =
             infixPowerModuloExpression[qi::_val = qi::_1] >
@@ -177,8 +179,8 @@ ExpressionParser::ExpressionParser(storm::expressions::ExpressionManager const& 
     if (allowBacktracking) {
         plusExpression =
             multiplicationExpression[qi::_val = qi::_1] >>
-            *(plusOperator_ >> multiplicationExpression)[qi::_val = phoenix::bind(&ExpressionCreator::createPlusExpression, phoenix::ref(*expressionCreator),
-                                                                                  qi::_val, qi::_1, qi::_2, qi::_pass)];
+            *(plusOperator_ >> multiplicationExpression)[qi::_a = phoenix::bind(&ExpressionCreator::createPlusExpression, phoenix::ref(*expressionCreator),
+                                                                                qi::_val, qi::_1, qi::_2, qi::_pass)][qi::_val = qi::_a];
     } else {
         plusExpression =
             multiplicationExpression[qi::_val = qi::_1] >
@@ -190,8 +192,8 @@ ExpressionParser::ExpressionParser(storm::expressions::ExpressionManager const& 
     if (allowBacktracking) {
         relativeExpression =
             plusExpression[qi::_val = qi::_1] >>
-            -(relationalOperator_ >> plusExpression)[qi::_val = phoenix::bind(&ExpressionCreator::createRelationalExpression, phoenix::ref(*expressionCreator),
-                                                                              qi::_val, qi::_1, qi::_2, qi::_pass)];
+            -(relationalOperator_ >> plusExpression)[qi::_a = phoenix::bind(&ExpressionCreator::createRelationalExpression, phoenix::ref(*expressionCreator),
+                                                                            qi::_val, qi::_1, qi::_2, qi::_pass)][qi::_val = qi::_a];
     } else {
         relativeExpression =
             plusExpression[qi::_val = qi::_1] >
@@ -203,8 +205,8 @@ ExpressionParser::ExpressionParser(storm::expressions::ExpressionManager const& 
     if (allowBacktracking) {
         equalityExpression =
             relativeExpression[qi::_val = qi::_1] >>
-            *(equalityOperator_ >> relativeExpression)[qi::_val = phoenix::bind(&ExpressionCreator::createEqualsExpression, phoenix::ref(*expressionCreator),
-                                                                                qi::_val, qi::_1, qi::_2, qi::_pass)];
+            *(equalityOperator_ >> relativeExpression)[qi::_a = phoenix::bind(&ExpressionCreator::createEqualsExpression, phoenix::ref(*expressionCreator),
+                                                                              qi::_val, qi::_1, qi::_2, qi::_pass)][qi::_val = qi::_a];
     } else {
         equalityExpression =
             relativeExpression[qi::_val = qi::_1] >>
@@ -215,8 +217,8 @@ ExpressionParser::ExpressionParser(storm::expressions::ExpressionManager const& 
 
     if (allowBacktracking) {
         andExpression = equalityExpression[qi::_val = qi::_1] >>
-                        *(andOperator_ >> equalityExpression)[qi::_val = phoenix::bind(&ExpressionCreator::createAndExpression,
-                                                                                       phoenix::ref(*expressionCreator), qi::_val, qi::_1, qi::_2, qi::_pass)];
+                        *(andOperator_ >> equalityExpression)[qi::_a = phoenix::bind(&ExpressionCreator::createAndExpression, phoenix::ref(*expressionCreator),
+                                                                                     qi::_val, qi::_1, qi::_2, qi::_pass)][qi::_val = qi::_a];
     } else {
         andExpression = equalityExpression[qi::_val = qi::_1] >>
                         *(andOperator_ > equalityExpression)[qi::_val = phoenix::bind(&ExpressionCreator::createAndExpression, phoenix::ref(*expressionCreator),
@@ -226,8 +228,8 @@ ExpressionParser::ExpressionParser(storm::expressions::ExpressionManager const& 
 
     if (allowBacktracking) {
         orExpression = andExpression[qi::_val = qi::_1] >>
-                       *(orOperator_ >> andExpression)[qi::_val = phoenix::bind(&ExpressionCreator::createOrExpression, phoenix::ref(*expressionCreator),
-                                                                                qi::_val, qi::_1, qi::_2, qi::_pass)];
+                       *(orOperator_ >> andExpression)[qi::_a = phoenix::bind(&ExpressionCreator::createOrExpression, phoenix::ref(*expressionCreator),
+                                                                              qi::_val, qi::_1, qi::_2, qi::_pass)][qi::_val = qi::_a];
     } else {
         orExpression = andExpression[qi::_val = qi::_1] >
                        *(orOperator_ > andExpression)[qi::_val = phoenix::bind(&ExpressionCreator::createOrExpression, phoenix::ref(*expressionCreator),
@@ -238,8 +240,8 @@ ExpressionParser::ExpressionParser(storm::expressions::ExpressionManager const& 
     if (allowBacktracking) {
         iteExpression = orExpression[qi::_val = qi::_1] >>
                         -(qi::lit("?") >> iteExpression >> qi::lit(":") >>
-                          iteExpression)[qi::_val = phoenix::bind(&ExpressionCreator::createIteExpression, phoenix::ref(*expressionCreator), qi::_val, qi::_1,
-                                                                  qi::_2, qi::_pass)];
+                          iteExpression)[qi::_a = phoenix::bind(&ExpressionCreator::createIteExpression, phoenix::ref(*expressionCreator), qi::_val, qi::_1,
+                                                                qi::_2, qi::_pass)][qi::_val = qi::_a];
     } else {
         iteExpression =
             orExpression[qi::_val = qi::_1] > -(qi::lit("?") > iteExpression > qi::lit(":") >

--- a/src/storm-parsers/parser/ExpressionParser.h
+++ b/src/storm-parsers/parser/ExpressionParser.h
@@ -213,20 +213,21 @@ class ExpressionParser : public qi::grammar<Iterator, storm::expressions::Expres
 
     // Rules for parsing a composed expression.
     qi::rule<Iterator, storm::expressions::Expression(), Skipper> expression;
-    qi::rule<Iterator, storm::expressions::Expression(), Skipper> iteExpression;
-    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<bool>, Skipper> orExpression;
-    qi::rule<Iterator, storm::expressions::Expression(), Skipper> andExpression;
-    qi::rule<Iterator, storm::expressions::Expression(), Skipper> relativeExpression;
-    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<bool>, Skipper> equalityExpression;
-    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<bool>, Skipper> plusExpression;
-    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<bool>, Skipper> multiplicationExpression;
+    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<storm::expressions::Expression>, Skipper> iteExpression;
+    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<storm::expressions::Expression>, Skipper> orExpression;
+    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<storm::expressions::Expression>, Skipper> andExpression;
+    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<storm::expressions::Expression>, Skipper> relativeExpression;
+    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<storm::expressions::Expression>, Skipper> equalityExpression;
+    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<storm::expressions::Expression>, Skipper> plusExpression;
+    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<storm::expressions::Expression>, Skipper> multiplicationExpression;
     qi::rule<Iterator, storm::expressions::Expression(), qi::locals<bool>, Skipper> prefixPowerModuloExpression;
-    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<bool>, Skipper> infixPowerModuloExpression;
+    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<storm::expressions::Expression>, Skipper> infixPowerModuloExpression;
     qi::rule<Iterator, storm::expressions::Expression(), Skipper> unaryExpression;
     qi::rule<Iterator, storm::expressions::Expression(), Skipper> atomicExpression;
     qi::rule<Iterator, storm::expressions::Expression(), Skipper> literalExpression;
     qi::rule<Iterator, storm::expressions::Expression(), Skipper> identifierExpression;
-    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<storm::expressions::OperatorType>, Skipper> minMaxExpression;
+    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<storm::expressions::OperatorType, storm::expressions::Expression>, Skipper>
+        minMaxExpression;
     qi::rule<Iterator, storm::expressions::Expression(), qi::locals<storm::expressions::OperatorType>, Skipper> floorCeilExpression;
     qi::rule<Iterator, storm::expressions::Expression(), Skipper> roundExpression;
     qi::rule<Iterator, storm::expressions::Expression(), Skipper> predicateExpression;

--- a/src/storm-parsers/parser/FormulaParserGrammar.h
+++ b/src/storm-parsers/parser/FormulaParserGrammar.h
@@ -144,8 +144,6 @@ class FormulaParserGrammar : public qi::grammar<Iterator, std::vector<storm::jan
     // Atomic propositions
     qi::rule<Iterator, std::shared_ptr<storm::logic::Formula const>(), Skipper> labelFormula;
     qi::rule<Iterator, std::shared_ptr<storm::logic::Formula const>(), Skipper> expressionFormula;
-    qi::rule<Iterator, std::shared_ptr<storm::logic::Formula const>(), qi::locals<bool>, Skipper> booleanLiteralFormula;
-    qi::rule<Iterator, std::shared_ptr<storm::logic::Formula const>(), Skipper> atomicPropositionFormula;
 
     // Propositional logic operators
     qi::rule<Iterator, std::shared_ptr<storm::logic::Formula const>(FormulaKind, storm::logic::FormulaContext), Skipper> basicPropositionalFormula;

--- a/src/storm/storage/expressions/Expression.cpp
+++ b/src/storm/storage/expressions/Expression.cpp
@@ -315,17 +315,7 @@ Expression operator&&(Expression const& first, Expression const& second) {
     } else if (!second.isInitialized()) {
         return first;
     }
-
     assertSameManager(first.getBaseExpression(), second.getBaseExpression());
-    if (first.isTrue()) {
-        STORM_LOG_THROW(second.hasBooleanType(), storm::exceptions::InvalidTypeException, "Operator requires boolean operands.");
-        return second;
-    }
-    if (second.isTrue()) {
-        STORM_LOG_THROW(first.hasBooleanType(), storm::exceptions::InvalidTypeException, "Operator requires boolean operands.");
-        return first;
-    }
-
     return Expression(std::shared_ptr<BaseExpression>(new BinaryBooleanFunctionExpression(
         first.getBaseExpression().getManager(), first.getType().logicalConnective(second.getType()), first.getBaseExpressionPointer(),
         second.getBaseExpressionPointer(), BinaryBooleanFunctionExpression::OperatorType::And)));

--- a/src/test/storm/parser/FormulaParserTest.cpp
+++ b/src/test/storm/parser/FormulaParserTest.cpp
@@ -43,6 +43,28 @@ TEST(FormulaParserTest, ExpressionTest) {
     EXPECT_TRUE(formula->isAtomicExpressionFormula());
 }
 
+TEST(FormulaParserTest, ExpressionTest2) {
+    std::shared_ptr<storm::expressions::ExpressionManager> manager(new storm::expressions::ExpressionManager());
+
+    storm::parser::FormulaParser formulaParser(manager);
+
+    std::string input = "(false)=false";
+    std::shared_ptr<storm::logic::Formula const> formula(nullptr);
+    ASSERT_NO_THROW(formula = formulaParser.parseSingleFormulaFromString(input));
+
+    EXPECT_TRUE(formula->isInFragment(storm::logic::propositional()));
+    EXPECT_TRUE(formula->isAtomicExpressionFormula());
+}
+
+TEST(FormulaParserTest, ExpressionTest3) {
+    std::shared_ptr<storm::expressions::ExpressionManager> manager(new storm::expressions::ExpressionManager());
+
+    storm::parser::FormulaParser formulaParser(manager);
+
+    std::string input = "1 & false";
+    STORM_SILENT_ASSERT_THROW(formulaParser.parseSingleFormulaFromString(input), storm::exceptions::WrongFormatException);
+}
+
 TEST(FormulaParserTest, LabelAndExpressionTest) {
     std::shared_ptr<storm::expressions::ExpressionManager> manager(new storm::expressions::ExpressionManager());
     manager->declareBooleanVariable("x");
@@ -71,6 +93,19 @@ TEST(FormulaParserTest, ProbabilityOperatorTest) {
     EXPECT_TRUE(formula->isProbabilityOperatorFormula());
     EXPECT_TRUE(formula->asProbabilityOperatorFormula().hasBound());
     EXPECT_FALSE(formula->asProbabilityOperatorFormula().hasOptimalityType());
+}
+
+TEST(FormulaParserTest, ProbabilityOperatorTest2) {
+    storm::parser::FormulaParser formulaParser;
+
+    std::string input = "1 = 1 & 2 = 2 & true & P<0.9 [\"a\" U \"b\"]";
+    std::shared_ptr<storm::logic::Formula const> formula(nullptr);
+    ASSERT_NO_THROW(formula = formulaParser.parseSingleFormulaFromString(input));
+
+    ASSERT_TRUE(formula->isBinaryBooleanStateFormula());
+    EXPECT_TRUE(formula->asBinaryBooleanStateFormula().isAnd());
+    EXPECT_TRUE(formula->asBinaryBooleanStateFormula().getLeftSubformula().isAtomicExpressionFormula());
+    EXPECT_TRUE(formula->asBinaryBooleanStateFormula().getRightSubformula().isProbabilityOperatorFormula());
 }
 
 TEST(FormulaParserTest, UntilOperatorTest) {
@@ -400,7 +435,7 @@ TEST(FormulaParserTest, HOAPathFormulaTest) {
     EXPECT_EQ(4ul, da2->getNumberOfEdgesPerState());
 
     std::map<std::string, std::shared_ptr<storm::logic::Formula const>> apFormulaMap2 = nested2.asHOAPathFormula().getAPMapping();
-    EXPECT_TRUE(apFormulaMap2["p0"]->isBinaryBooleanStateFormula());
+    EXPECT_TRUE(apFormulaMap2["p0"]->isAtomicExpressionFormula());
     EXPECT_TRUE(apFormulaMap2["p1"]->isAtomicExpressionFormula());
 
     // Wrong format: p1 -> path formula


### PR DESCRIPTION
## Fixed parsing expression formulas (fixes #195)

The issue was that if we see an opening bracket `(` we expected that there is a *formula* inside the brackets. This is not the case for formulas like `(1)=2` as 1 is not a formula.


## Fixed backtracking mode in expression parser

With backtracking enabled, the expression parser is not supposed to throw an exception  on a formula like `1 & true`.
However, when such an error is encountered the expression parser currently overwrites the result parsed so far with a dummy expression which results in a BAD_ACCESS signal. This commit fixes the issue.