### PR TITLE
JANI to JSON export: Fixed unary minus.

### DIFF
--- a/src/storm/storage/jani/visitor/JSONExporter.cpp
+++ b/src/storm/storage/jani/visitor/JSONExporter.cpp
@@ -713,7 +713,12 @@ boost::any ExpressionToJson::visit(storm::expressions::UnaryBooleanFunctionExpre
 boost::any ExpressionToJson::visit(storm::expressions::UnaryNumericalFunctionExpression const& expression, boost::any const& data) {
     ExportJsonType opDecl;
     opDecl["op"] = operatorTypeToJaniString(expression.getOperator());
-    opDecl["exp"] = anyToJson(expression.getOperand()->accept(*this, data));
+    if (expression.getOperator() == storm::expressions::OperatorType::Minus) {
+        opDecl["left"] = 0;
+        opDecl["right"] = anyToJson(expression.getOperand()->accept(*this, data));
+    } else {
+        opDecl["exp"] = anyToJson(expression.getOperand()->accept(*this, data));
+    }
     return opDecl;
 }
 


### PR DESCRIPTION
The jani-to-json export produced unary minus expressions, which are not part of the [jani-spec](https://docs.google.com/document/d/1BDQIzPBtscxJFFlDUEPIo8ivKHgXT8_X6hz5quq7jK0/).
This PR changes the exports of expressions like `-x` to

```json
{ "left": 0, "op": "-",  "right": "x" }
```