### PR TITLE
Fixed JANI reward expressions with constants

### DIFF
--- a/src/storm/logic/RewardAccumulation.h
+++ b/src/storm/logic/RewardAccumulation.h
@@ -8,6 +8,9 @@ class RewardAccumulation {
    public:
     RewardAccumulation(bool steps, bool time, bool exit);
     RewardAccumulation(RewardAccumulation const& other) = default;
+    RewardAccumulation(RewardAccumulation&& other) = default;
+    RewardAccumulation& operator=(RewardAccumulation const& other) = default;
+    RewardAccumulation& operator=(RewardAccumulation&& other) = default;
 
     bool isStepsSet() const;  // If set, choice rewards and transition rewards are accumulated upon taking the transition
     bool isTimeSet() const;   // If set, state rewards are accumulated over time (assuming 0 time passes in discrete-time model states)


### PR DESCRIPTION
Fixed handling the case where a reward expression in a JANI property contains constants.

I also piggy-backed a fix to this warning:

```console
storm/logic/RewardAccumulation.h:10:5: warning: definition of implicit copy assignment operator for 'RewardAccumulation' is deprecated because it has a user-declared copy constructor [-Wdeprecated-copy]
    RewardAccumulation(RewardAccumulation const& other) = default;
```