### PR TITLE
Direct elimination of zero entries in SparseMatrix transformations

### DIFF
--- a/src/storm/storage/SparseMatrix.h
+++ b/src/storm/storage/SparseMatrix.h
@@ -659,15 +659,19 @@ class SparseMatrix {
      * This function makes the given rows absorbing.
      *
      * @param rows A bit vector indicating which rows are to be made absorbing.
+     * @param dropZeroEntries if true, zero entries resulting from the transformation are dropped from the matrix after the transformation.
+     * Dropping zero entries takes time linear in the number of matrix entries.
      */
-    void makeRowsAbsorbing(storm::storage::BitVector const& rows);
+    void makeRowsAbsorbing(storm::storage::BitVector const& rows, bool dropZeroEntries = false);
 
     /*!
      * This function makes the groups of rows given by the bit vector absorbing.
      *
      * @param rowGroupConstraint A bit vector indicating which row groups to make absorbing.
+     * @param dropZeroEntries if true, zero entries resulting from the transformation are dropped from the matrix after the transformation.
+     * Dropping zero entries takes time linear in the number of matrix entries.
      */
-    void makeRowGroupsAbsorbing(storm::storage::BitVector const& rowGroupConstraint);
+    void makeRowGroupsAbsorbing(storm::storage::BitVector const& rowGroupConstraint, bool dropZeroEntries = false);
 
     /*!
      * This function makes the given row Dirac. This means that all entries will be set to 0 except the one
@@ -675,8 +679,10 @@ class SparseMatrix {
      *
      * @param row The row to be made Dirac.
      * @param column The index of the column whose value is to be set to 1.
+     * @param dropZeroEntries if true, zero entries resulting from the transformation are dropped from the matrix after the transformation.
+     * Dropping zero entries takes time linear in the number of matrix entries.
      */
-    void makeRowDirac(index_type row, index_type column);
+    void makeRowDirac(index_type row, index_type column, bool dropZeroEntries = false);
 
     /*
      * Sums the entries in all rows.
@@ -847,8 +853,10 @@ class SparseMatrix {
 
     /*!
      * Sets all diagonal elements to zero.
+     * @param dropZeroEntries if true, zero entries resulting from the transformation are dropped from the matrix after the transformation.
+     * Dropping zero entries takes time linear in the number of matrix entries.
      */
-    void deleteDiagonalEntries();
+    void deleteDiagonalEntries(bool dropZeroEntries = false);
 
     /*!
      * Calculates the Jacobi decomposition of this sparse matrix. For this operation, the matrix must be square.

--- a/src/test/storm/storage/SparseMatrixTest.cpp
+++ b/src/test/storm/storage/SparseMatrixTest.cpp
@@ -792,3 +792,108 @@ TEST(SparseMatrix, Permute) {
     EXPECT_EQ(matrix.getRowSum(3), matrixperm.getRowSum(3));
     EXPECT_EQ(matrix.getRowSum(2), matrixperm.getRowSum(4));
 }
+
+TEST(SparseMatrix, DropZeroEntries) {
+    storm::storage::SparseMatrixBuilder<double> matrixBuilder(4, 3, 8, true, true);
+    ASSERT_NO_THROW(matrixBuilder.newRowGroup(0));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(0, 1, 1.0));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(0, 2, 1.2));
+    ASSERT_NO_THROW(matrixBuilder.newRowGroup(1));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(1, 0, 0.5));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(1, 1, 1.1));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(1, 2, 0.5));
+    ASSERT_NO_THROW(matrixBuilder.newRowGroup(2));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(2, 0, 0.1));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(3, 1, 0.2));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(3, 2, 0.3));
+    storm::storage::SparseMatrix<double> matrix;
+    ASSERT_NO_THROW(matrix = matrixBuilder.build());
+
+    storm::storage::BitVector absorbingRows(3);
+    absorbingRows.set(0);
+
+    ASSERT_NO_THROW(matrix.makeRowsAbsorbing(absorbingRows, true));
+
+    storm::storage::SparseMatrixBuilder<double> matrixBuilderX(4, 3, 8, true, true);
+    ASSERT_NO_THROW(matrixBuilderX.newRowGroup(0));
+    ASSERT_NO_THROW(matrixBuilderX.addNextValue(0, 1, 1.0));
+    ASSERT_NO_THROW(matrixBuilderX.addNextValue(0, 2, 1.2));
+    ASSERT_NO_THROW(matrixBuilderX.newRowGroup(1));
+    ASSERT_NO_THROW(matrixBuilderX.addNextValue(1, 0, 0.5));
+    ASSERT_NO_THROW(matrixBuilderX.addNextValue(1, 1, 1.1));
+    ASSERT_NO_THROW(matrixBuilderX.addNextValue(1, 2, 0.5));
+    ASSERT_NO_THROW(matrixBuilderX.newRowGroup(2));
+    ASSERT_NO_THROW(matrixBuilderX.addNextValue(2, 0, 0.1));
+    ASSERT_NO_THROW(matrixBuilderX.addNextValue(3, 1, 0.2));
+    ASSERT_NO_THROW(matrixBuilderX.addNextValue(3, 2, 0.3));
+    storm::storage::SparseMatrix<double> matrixX;
+    ASSERT_NO_THROW(matrixX = matrixBuilderX.build());
+
+    ASSERT_NO_THROW(matrixX.makeRowsAbsorbing(absorbingRows, false));
+
+    storm::storage::SparseMatrixBuilder<double> matrixBuilder2(4, 3, 7, true, true);
+    ASSERT_NO_THROW(matrixBuilder2.newRowGroup(0));
+    ASSERT_NO_THROW(matrixBuilder2.addNextValue(0, 0, 1.0));
+    ASSERT_NO_THROW(matrixBuilder2.newRowGroup(1));
+    ASSERT_NO_THROW(matrixBuilder2.addNextValue(1, 0, 0.5));
+    ASSERT_NO_THROW(matrixBuilder2.addNextValue(1, 1, 1.1));
+    ASSERT_NO_THROW(matrixBuilder2.addNextValue(1, 2, 0.5));
+    ASSERT_NO_THROW(matrixBuilder2.newRowGroup(2));
+    ASSERT_NO_THROW(matrixBuilder2.addNextValue(2, 0, 0.1));
+    ASSERT_NO_THROW(matrixBuilder2.addNextValue(3, 1, 0.2));
+    ASSERT_NO_THROW(matrixBuilder2.addNextValue(3, 2, 0.3));
+    storm::storage::SparseMatrix<double> matrix2;
+    ASSERT_NO_THROW(matrix2 = matrixBuilder2.build());
+
+    ASSERT_TRUE(matrix == matrix2);
+    ASSERT_TRUE(matrix.getEntryCount() == matrix2.getEntryCount());
+
+    ASSERT_TRUE(matrixX == matrix2);
+    ASSERT_FALSE(matrixX.getEntryCount() == matrix2.getEntryCount());
+
+    ASSERT_NO_THROW(matrix.makeRowDirac(1, 1, true));
+    ASSERT_NO_THROW(matrixX.dropZeroEntries());
+    ASSERT_NO_THROW(matrixX.makeRowDirac(1, 1, false));
+
+    storm::storage::SparseMatrixBuilder<double> matrixBuilder3(4, 3, 5, true, true);
+    ASSERT_NO_THROW(matrixBuilder3.newRowGroup(0));
+    ASSERT_NO_THROW(matrixBuilder3.addNextValue(0, 0, 1.0));
+    ASSERT_NO_THROW(matrixBuilder3.newRowGroup(1));
+    ASSERT_NO_THROW(matrixBuilder3.addNextValue(1, 1, 1.0));
+    ASSERT_NO_THROW(matrixBuilder3.newRowGroup(2));
+    ASSERT_NO_THROW(matrixBuilder3.addNextValue(2, 0, 0.1));
+    ASSERT_NO_THROW(matrixBuilder3.addNextValue(3, 1, 0.2));
+    ASSERT_NO_THROW(matrixBuilder3.addNextValue(3, 2, 0.3));
+    storm::storage::SparseMatrix<double> matrix3;
+    ASSERT_NO_THROW(matrix3 = matrixBuilder3.build());
+
+    ASSERT_TRUE(matrix == matrix3);
+    ASSERT_TRUE(matrix.getEntryCount() == matrix3.getEntryCount());
+
+    ASSERT_TRUE(matrixX == matrix3);
+    ASSERT_FALSE(matrixX.getEntryCount() == matrix3.getEntryCount());
+
+    storm::storage::BitVector absorbingRowGroups(3);
+    absorbingRowGroups.set(2);
+
+    ASSERT_NO_THROW(matrix.makeRowGroupsAbsorbing(absorbingRowGroups, true));
+    ASSERT_NO_THROW(matrixX.dropZeroEntries());
+    ASSERT_NO_THROW(matrixX.makeRowGroupsAbsorbing(absorbingRowGroups, false));
+
+    storm::storage::SparseMatrixBuilder<double> matrixBuilder4(4, 3, 4, true, true);
+    ASSERT_NO_THROW(matrixBuilder4.newRowGroup(0));
+    ASSERT_NO_THROW(matrixBuilder4.addNextValue(0, 0, 1.0));
+    ASSERT_NO_THROW(matrixBuilder4.newRowGroup(1));
+    ASSERT_NO_THROW(matrixBuilder4.addNextValue(1, 1, 1.0));
+    ASSERT_NO_THROW(matrixBuilder4.newRowGroup(2));
+    ASSERT_NO_THROW(matrixBuilder4.addNextValue(2, 2, 1.0));
+    ASSERT_NO_THROW(matrixBuilder4.addNextValue(3, 2, 1.0));
+    storm::storage::SparseMatrix<double> matrix4;
+    ASSERT_NO_THROW(matrix4 = matrixBuilder4.build());
+
+    ASSERT_TRUE(matrix == matrix4);
+    ASSERT_TRUE(matrix.getEntryCount() == matrix4.getEntryCount());
+
+    ASSERT_TRUE(matrixX == matrix4);
+    ASSERT_FALSE(matrixX.getEntryCount() == matrix4.getEntryCount());
+}


### PR DESCRIPTION
This PR adds a Boolean flag to all transformations in SparseMatrix that may lead to zero entries. If the flag is set, entries that are zero are deleted from the sparse matrix representation instead of just being set to zero. As in many cases, the performance impact of this operation is not desirable, the default behavior of not dropping zero entries is preserved.
This also directly exposes the default behavior and helps to prevent implicit expectations about the form of the matrix after the transformation has been applied (see also #309).
This pull request resolves #309.