### PR TITLE
SparseMatrix: ranges for RowGroupIndices and no uint_fast64_t

### DIFF
--- a/src/storm/storage/SparseMatrix.cpp
+++ b/src/storm/storage/SparseMatrix.cpp
@@ -773,6 +773,17 @@ std::vector<typename SparseMatrix<ValueType>::index_type> const& SparseMatrix<Va
 }
 
 template<typename ValueType>
+boost::integer_range<typename SparseMatrix<ValueType>::index_type> SparseMatrix<ValueType>::getRowGroupIndices(index_type group) const {
+    STORM_LOG_ASSERT(group < this->getRowGroupCount(),
+                     "Invalid row group index:" << group << ". Only " << this->getRowGroupCount() << " row groups available.");
+    if (this->rowGroupIndices) {
+        return boost::irange(rowGroupIndices.get()[group], rowGroupIndices.get()[group + 1]);
+    } else {
+        return boost::irange(group, group + 1);
+    }
+}
+
+template<typename ValueType>
 std::vector<typename SparseMatrix<ValueType>::index_type> SparseMatrix<ValueType>::swapRowGroupIndices(std::vector<index_type>&& newRowGrouping) {
     std::vector<index_type> result;
     if (this->rowGroupIndices) {

--- a/src/storm/storage/SparseMatrix.cpp
+++ b/src/storm/storage/SparseMatrix.cpp
@@ -671,11 +671,11 @@ typename SparseMatrix<ValueType>::index_type SparseMatrix<ValueType>::getEntryCo
     return entryCount;
 }
 
-template<typename T>
-uint_fast64_t SparseMatrix<T>::getRowGroupEntryCount(uint_fast64_t const group) const {
-    uint_fast64_t result = 0;
+template<typename ValueType>
+typename SparseMatrix<ValueType>::index_type SparseMatrix<ValueType>::getRowGroupEntryCount(index_type const group) const {
+    index_type result = 0;
     if (!this->hasTrivialRowGrouping()) {
-        for (uint_fast64_t row = this->getRowGroupIndices()[group]; row < this->getRowGroupIndices()[group + 1]; ++row) {
+        for (auto row : this->getRowGroupIndices(group)) {
             result += (this->rowIndications[row + 1] - this->rowIndications[row]);
         }
     } else {
@@ -820,8 +820,7 @@ template<typename ValueType>
 storm::storage::BitVector SparseMatrix<ValueType>::getRowFilter(storm::storage::BitVector const& groupConstraint) const {
     storm::storage::BitVector res(this->getRowCount(), false);
     for (auto group : groupConstraint) {
-        uint_fast64_t const endOfGroup = this->getRowGroupIndices()[group + 1];
-        for (uint_fast64_t row = this->getRowGroupIndices()[group]; row < endOfGroup; ++row) {
+        for (auto row : this->getRowGroupIndices(group)) {
             res.set(row, true);
         }
     }
@@ -833,8 +832,7 @@ storm::storage::BitVector SparseMatrix<ValueType>::getRowFilter(storm::storage::
                                                                 storm::storage::BitVector const& columnConstraint) const {
     storm::storage::BitVector result(this->getRowCount(), false);
     for (auto group : groupConstraint) {
-        uint_fast64_t const endOfGroup = this->getRowGroupIndices()[group + 1];
-        for (uint_fast64_t row = this->getRowGroupIndices()[group]; row < endOfGroup; ++row) {
+        for (auto row : this->getRowGroupIndices(group)) {
             bool choiceSatisfiesColumnConstraint = true;
             for (auto const& entry : this->getRow(row)) {
                 if (!columnConstraint.get(entry.getColumn())) {
@@ -1137,13 +1135,13 @@ SparseMatrix<ValueType> SparseMatrix<ValueType>::getSubmatrix(bool useGroups, st
         // Create a new row grouping that reflects the new sizes of the row groups if the current matrix has a
         // non trivial row-grouping.
         if (!this->hasTrivialRowGrouping()) {
-            std::vector<uint_fast64_t> newRowGroupIndices;
+            std::vector<index_type> newRowGroupIndices;
             newRowGroupIndices.push_back(0);
             auto selectedRowIt = rowConstraint.begin();
 
             // For this, we need to count how many rows were preserved in every group.
-            for (uint_fast64_t group = 0; group < this->getRowGroupCount(); ++group) {
-                uint_fast64_t newRowCount = 0;
+            for (index_type group = 0; group < this->getRowGroupCount(); ++group) {
+                index_type newRowCount = 0;
                 while (*selectedRowIt < this->getRowGroupIndices()[group + 1]) {
                     ++selectedRowIt;
                     ++newRowCount;
@@ -1166,7 +1164,7 @@ SparseMatrix<ValueType> SparseMatrix<ValueType>::getSubmatrix(storm::storage::Bi
                                                               storm::storage::BitVector const& columnConstraint, std::vector<index_type> const& rowGroupIndices,
                                                               bool insertDiagonalEntries, storm::storage::BitVector const& makeZeroColumns) const {
     STORM_LOG_THROW(!rowGroupConstraint.empty() && !columnConstraint.empty(), storm::exceptions::InvalidArgumentException, "Cannot build empty submatrix.");
-    uint_fast64_t submatrixColumnCount = columnConstraint.getNumberOfSetBits();
+    index_type submatrixColumnCount = columnConstraint.getNumberOfSetBits();
 
     // Start by creating a temporary vector that stores for each index whose bit is set to true the number of
     // bits that were set before that particular index.
@@ -1246,13 +1244,13 @@ SparseMatrix<ValueType> SparseMatrix<ValueType>::restrictRows(storm::storage::Bi
     STORM_LOG_ASSERT(rowsToKeep.size() == this->getRowCount(), "Dimensions mismatch.");
 
     // Count the number of entries of the resulting matrix
-    uint_fast64_t entryCount = 0;
+    index_type entryCount = 0;
     for (auto row : rowsToKeep) {
         entryCount += this->getRow(row).getNumberOfEntries();
     }
 
     // Get the smallest row group index such that all row groups with at least this index are empty.
-    uint_fast64_t firstTrailingEmptyRowGroup = this->getRowGroupCount();
+    index_type firstTrailingEmptyRowGroup = this->getRowGroupCount();
     for (auto groupIndexIt = this->getRowGroupIndices().rbegin() + 1; groupIndexIt != this->getRowGroupIndices().rend(); ++groupIndexIt) {
         if (rowsToKeep.getNextSetIndex(*groupIndexIt) != rowsToKeep.size()) {
             break;
@@ -1264,12 +1262,12 @@ SparseMatrix<ValueType> SparseMatrix<ValueType>::restrictRows(storm::storage::Bi
 
     // build the matrix. The row grouping will always be considered as nontrivial.
     SparseMatrixBuilder<ValueType> builder(rowsToKeep.getNumberOfSetBits(), this->getColumnCount(), entryCount, true, true, this->getRowGroupCount());
-    uint_fast64_t newRow = 0;
-    for (uint_fast64_t rowGroup = 0; rowGroup < firstTrailingEmptyRowGroup; ++rowGroup) {
+    index_type newRow = 0;
+    for (index_type rowGroup = 0; rowGroup < firstTrailingEmptyRowGroup; ++rowGroup) {
         // Add a new row group
         builder.newRowGroup(newRow);
         bool rowGroupEmpty = true;
-        for (uint_fast64_t row = rowsToKeep.getNextSetIndex(this->getRowGroupIndices()[rowGroup]); row < this->getRowGroupIndices()[rowGroup + 1];
+        for (index_type row = rowsToKeep.getNextSetIndex(this->getRowGroupIndices()[rowGroup]); row < this->getRowGroupIndices()[rowGroup + 1];
              row = rowsToKeep.getNextSetIndex(row + 1)) {
             rowGroupEmpty = false;
             for (auto const& entry : this->getRow(row)) {
@@ -1499,7 +1497,7 @@ SparseMatrix<ValueType> SparseMatrix<ValueType>::transpose(bool joinGroups, bool
 }
 
 template<typename ValueType>
-SparseMatrix<ValueType> SparseMatrix<ValueType>::transposeSelectedRowsFromRowGroups(std::vector<uint_fast64_t> const& rowGroupChoices, bool keepZeros) const {
+SparseMatrix<ValueType> SparseMatrix<ValueType>::transposeSelectedRowsFromRowGroups(std::vector<uint64_t> const& rowGroupChoices, bool keepZeros) const {
     index_type rowCount = this->getColumnCount();
     index_type columnCount = this->getRowGroupCount();
 
@@ -1902,7 +1900,7 @@ void SparseMatrix<Interval>::performWalkerChaeStep(std::vector<Interval> const& 
 template<typename ValueType>
 void SparseMatrix<ValueType>::multiplyAndReduceForward(OptimizationDirection const& dir, std::vector<uint64_t> const& rowGroupIndices,
                                                        std::vector<ValueType> const& vector, std::vector<ValueType> const* summand,
-                                                       std::vector<ValueType>& result, std::vector<uint_fast64_t>* choices) const {
+                                                       std::vector<ValueType>& result, std::vector<uint64_t>* choices) const {
     if (dir == OptimizationDirection::Minimize) {
         multiplyAndReduceForward<storm::utility::ElementLess<ValueType>>(rowGroupIndices, vector, summand, result, choices);
     } else {
@@ -1914,7 +1912,7 @@ template<typename ValueType>
 template<typename Compare>
 void SparseMatrix<ValueType>::multiplyAndReduceForward(std::vector<uint64_t> const& rowGroupIndices, std::vector<ValueType> const& vector,
                                                        std::vector<ValueType> const* summand, std::vector<ValueType>& result,
-                                                       std::vector<uint_fast64_t>* choices) const {
+                                                       std::vector<uint64_t>* choices) const {
     Compare compare;
     auto elementIt = this->begin();
     auto rowGroupIt = rowGroupIndices.begin();
@@ -1923,7 +1921,7 @@ void SparseMatrix<ValueType>::multiplyAndReduceForward(std::vector<uint64_t> con
     if (summand) {
         summandIt = summand->begin();
     }
-    typename std::vector<uint_fast64_t>::iterator choiceIt;
+    typename std::vector<uint64_t>::iterator choiceIt;
     if (choices) {
         choiceIt = choices->begin();
     }
@@ -1992,7 +1990,7 @@ template<>
 void SparseMatrix<storm::RationalFunction>::multiplyAndReduceForward(OptimizationDirection const& dir, std::vector<uint64_t> const& rowGroupIndices,
                                                                      std::vector<storm::RationalFunction> const& vector,
                                                                      std::vector<storm::RationalFunction> const* b,
-                                                                     std::vector<storm::RationalFunction>& result, std::vector<uint_fast64_t>* choices) const {
+                                                                     std::vector<storm::RationalFunction>& result, std::vector<uint64_t>* choices) const {
     STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "This operation is not supported.");
 }
 #endif
@@ -2000,7 +1998,7 @@ void SparseMatrix<storm::RationalFunction>::multiplyAndReduceForward(Optimizatio
 template<typename ValueType>
 void SparseMatrix<ValueType>::multiplyAndReduceBackward(OptimizationDirection const& dir, std::vector<uint64_t> const& rowGroupIndices,
                                                         std::vector<ValueType> const& vector, std::vector<ValueType> const* summand,
-                                                        std::vector<ValueType>& result, std::vector<uint_fast64_t>* choices) const {
+                                                        std::vector<ValueType>& result, std::vector<uint64_t>* choices) const {
     if (dir == storm::OptimizationDirection::Minimize) {
         multiplyAndReduceBackward<storm::utility::ElementLess<ValueType>>(rowGroupIndices, vector, summand, result, choices);
     } else {
@@ -2012,7 +2010,7 @@ template<typename ValueType>
 template<typename Compare>
 void SparseMatrix<ValueType>::multiplyAndReduceBackward(std::vector<uint64_t> const& rowGroupIndices, std::vector<ValueType> const& vector,
                                                         std::vector<ValueType> const* summand, std::vector<ValueType>& result,
-                                                        std::vector<uint_fast64_t>* choices) const {
+                                                        std::vector<uint64_t>* choices) const {
     Compare compare;
     auto elementIt = this->end() - 1;
     auto rowGroupIt = rowGroupIndices.end() - 2;
@@ -2021,7 +2019,7 @@ void SparseMatrix<ValueType>::multiplyAndReduceBackward(std::vector<uint64_t> co
     if (summand) {
         summandIt = summand->end() - 1;
     }
-    typename std::vector<uint_fast64_t>::iterator choiceIt;
+    typename std::vector<uint64_t>::iterator choiceIt;
     if (choices) {
         choiceIt = choices->end() - 1;
     }
@@ -2085,7 +2083,7 @@ template<>
 void SparseMatrix<storm::RationalFunction>::multiplyAndReduceBackward(OptimizationDirection const& dir, std::vector<uint64_t> const& rowGroupIndices,
                                                                       std::vector<storm::RationalFunction> const& vector,
                                                                       std::vector<storm::RationalFunction> const* b,
-                                                                      std::vector<storm::RationalFunction>& result, std::vector<uint_fast64_t>* choices) const {
+                                                                      std::vector<storm::RationalFunction>& result, std::vector<uint64_t>* choices) const {
     STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "This operation is not supported.");
 }
 #endif
@@ -2100,7 +2098,7 @@ class TbbMultAddReduceFunctor {
 
     TbbMultAddReduceFunctor(std::vector<uint64_t> const& rowGroupIndices, std::vector<MatrixEntry<index_type, value_type>> const& columnsAndEntries,
                             std::vector<uint64_t> const& rowIndications, std::vector<ValueType> const& x, std::vector<ValueType>& result,
-                            std::vector<value_type> const* summand, std::vector<uint_fast64_t>* choices)
+                            std::vector<value_type> const* summand, std::vector<uint64_t>* choices)
         : rowGroupIndices(rowGroupIndices),
           columnsAndEntries(columnsAndEntries),
           rowIndications(rowIndications),
@@ -2121,7 +2119,7 @@ class TbbMultAddReduceFunctor {
         if (summand) {
             summandIt = summand->begin() + *groupIt;
         }
-        typename std::vector<uint_fast64_t>::iterator choiceIt;
+        typename std::vector<uint64_t>::iterator choiceIt;
         if (choices) {
             choiceIt = choices->begin() + range.begin();
         }
@@ -2192,13 +2190,13 @@ class TbbMultAddReduceFunctor {
     std::vector<ValueType> const& x;
     std::vector<ValueType>& result;
     std::vector<value_type> const* summand;
-    std::vector<uint_fast64_t>* choices;
+    std::vector<uint64_t>* choices;
 };
 
 template<typename ValueType>
 void SparseMatrix<ValueType>::multiplyAndReduceParallel(OptimizationDirection const& dir, std::vector<uint64_t> const& rowGroupIndices,
                                                         std::vector<ValueType> const& vector, std::vector<ValueType> const* summand,
-                                                        std::vector<ValueType>& result, std::vector<uint_fast64_t>* choices) const {
+                                                        std::vector<ValueType>& result, std::vector<uint64_t>* choices) const {
     if (dir == storm::OptimizationDirection::Minimize) {
         tbb::parallel_for(tbb::blocked_range<index_type>(0, rowGroupIndices.size() - 1, 100),
                           TbbMultAddReduceFunctor<ValueType, storm::utility::ElementLess<ValueType>>(rowGroupIndices, columnsAndValues, rowIndications, vector,
@@ -2215,7 +2213,7 @@ template<>
 void SparseMatrix<storm::RationalFunction>::multiplyAndReduceParallel(OptimizationDirection const& dir, std::vector<uint64_t> const& rowGroupIndices,
                                                                       std::vector<storm::RationalFunction> const& vector,
                                                                       std::vector<storm::RationalFunction> const* summand,
-                                                                      std::vector<storm::RationalFunction>& result, std::vector<uint_fast64_t>* choices) const {
+                                                                      std::vector<storm::RationalFunction>& result, std::vector<uint64_t>* choices) const {
     STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "This operation is not supported.");
 }
 #endif
@@ -2224,7 +2222,7 @@ void SparseMatrix<storm::RationalFunction>::multiplyAndReduceParallel(Optimizati
 template<typename ValueType>
 void SparseMatrix<ValueType>::multiplyAndReduce(OptimizationDirection const& dir, std::vector<uint64_t> const& rowGroupIndices,
                                                 std::vector<ValueType> const& vector, std::vector<ValueType> const* summand, std::vector<ValueType>& result,
-                                                std::vector<uint_fast64_t>* choices) const {
+                                                std::vector<uint64_t>* choices) const {
     // If the vector and the result are aliases, we need and temporary vector.
     std::vector<ValueType>* target;
     std::vector<ValueType> temporary;
@@ -2250,7 +2248,7 @@ void SparseMatrix<ValueType>::multiplyVectorWithMatrix(std::vector<value_type> c
     std::vector<index_type>::const_iterator rowIterator = rowIndications.begin();
     std::vector<index_type>::const_iterator rowIteratorEnd = rowIndications.end();
 
-    uint_fast64_t currentRow = 0;
+    index_type currentRow = 0;
     for (; rowIterator != rowIteratorEnd - 1; ++rowIterator) {
         for (ite = this->begin() + *(rowIterator + 1); it != ite; ++it) {
             result[it->getColumn()] += it->getValue() * vector[currentRow];
@@ -2262,7 +2260,7 @@ void SparseMatrix<ValueType>::multiplyVectorWithMatrix(std::vector<value_type> c
 template<typename ValueType>
 void SparseMatrix<ValueType>::scaleRowsInPlace(std::vector<ValueType> const& factors) {
     STORM_LOG_ASSERT(factors.size() == this->getRowCount(), "Can not scale rows: Number of rows and number of scaling factors do not match.");
-    uint_fast64_t row = 0;
+    index_type row = 0;
     for (auto const& factor : factors) {
         for (auto& entry : getRow(row)) {
             entry.setValue(entry.getValue() * factor);
@@ -2274,7 +2272,7 @@ void SparseMatrix<ValueType>::scaleRowsInPlace(std::vector<ValueType> const& fac
 template<typename ValueType>
 void SparseMatrix<ValueType>::divideRowsInPlace(std::vector<ValueType> const& divisors) {
     STORM_LOG_ASSERT(divisors.size() == this->getRowCount(), "Can not divide rows: Number of rows and number of divisors do not match.");
-    uint_fast64_t row = 0;
+    index_type row = 0;
     for (auto const& divisor : divisors) {
         STORM_LOG_ASSERT(!storm::utility::isZero(divisor), "Can not divide row " << row << " by 0.");
         for (auto& entry : getRow(row)) {
@@ -2644,7 +2642,7 @@ template bool SparseMatrix<int>::isSubmatrixOf(SparseMatrix<storm::storage::spar
 
 #if defined(STORM_HAVE_CLN)
 template class MatrixEntry<typename SparseMatrix<ClnRationalNumber>::index_type, ClnRationalNumber>;
-template std::ostream& operator<<(std::ostream& out, MatrixEntry<uint_fast64_t, ClnRationalNumber> const& entry);
+template std::ostream& operator<<(std::ostream& out, MatrixEntry<typename SparseMatrix<ClnRationalNumber>::index_type, ClnRationalNumber> const& entry);
 template class SparseMatrixBuilder<ClnRationalNumber>;
 template class SparseMatrix<ClnRationalNumber>;
 template std::ostream& operator<<(std::ostream& out, SparseMatrix<ClnRationalNumber> const& matrix);
@@ -2657,7 +2655,7 @@ template bool SparseMatrix<storm::ClnRationalNumber>::isSubmatrixOf(SparseMatrix
 
 #if defined(STORM_HAVE_GMP)
 template class MatrixEntry<typename SparseMatrix<GmpRationalNumber>::index_type, GmpRationalNumber>;
-template std::ostream& operator<<(std::ostream& out, MatrixEntry<uint_fast64_t, GmpRationalNumber> const& entry);
+template std::ostream& operator<<(std::ostream& out, MatrixEntry<typename SparseMatrix<GmpRationalNumber>::index_type, GmpRationalNumber> const& entry);
 template class SparseMatrixBuilder<GmpRationalNumber>;
 template class SparseMatrix<GmpRationalNumber>;
 template std::ostream& operator<<(std::ostream& out, SparseMatrix<GmpRationalNumber> const& matrix);
@@ -2670,7 +2668,7 @@ template bool SparseMatrix<storm::GmpRationalNumber>::isSubmatrixOf(SparseMatrix
 
 // Rational Function
 template class MatrixEntry<typename SparseMatrix<RationalFunction>::index_type, RationalFunction>;
-template std::ostream& operator<<(std::ostream& out, MatrixEntry<uint_fast64_t, RationalFunction> const& entry);
+template std::ostream& operator<<(std::ostream& out, MatrixEntry<typename SparseMatrix<RationalFunction>::index_type, RationalFunction> const& entry);
 template class SparseMatrixBuilder<RationalFunction>;
 template class SparseMatrix<RationalFunction>;
 template std::ostream& operator<<(std::ostream& out, SparseMatrix<RationalFunction> const& matrix);
@@ -2692,7 +2690,7 @@ template bool SparseMatrix<storm::RationalFunction>::isSubmatrixOf(SparseMatrix<
 template std::vector<storm::Interval> SparseMatrix<double>::getPointwiseProductRowSumVector(
     storm::storage::SparseMatrix<storm::Interval> const& otherMatrix) const;
 template class MatrixEntry<typename SparseMatrix<Interval>::index_type, Interval>;
-template std::ostream& operator<<(std::ostream& out, MatrixEntry<uint_fast64_t, Interval> const& entry);
+template std::ostream& operator<<(std::ostream& out, MatrixEntry<typename SparseMatrix<Interval>::index_type, Interval> const& entry);
 template class SparseMatrixBuilder<Interval>;
 template class SparseMatrix<Interval>;
 template std::ostream& operator<<(std::ostream& out, SparseMatrix<Interval> const& matrix);

--- a/src/storm/storage/SparseMatrix.h
+++ b/src/storm/storage/SparseMatrix.h
@@ -8,6 +8,7 @@
 
 #include <boost/functional/hash.hpp>
 #include <boost/optional.hpp>
+#include <boost/range/irange.hpp>
 
 #include "storm/solver/OptimizationDirection.h"
 #include "storm/storage/BitVector.h"
@@ -597,6 +598,11 @@ class SparseMatrix {
      * @return The grouping of rows of this matrix.
      */
     std::vector<index_type> const& getRowGroupIndices() const;
+
+    /*!
+     * Returns the row indices within the given group
+     */
+    boost::integer_range<index_type> getRowGroupIndices(index_type group) const;
 
     /*!
      * Swaps the grouping of rows of this matrix.

--- a/src/storm/storage/SparseMatrix.h
+++ b/src/storm/storage/SparseMatrix.h
@@ -40,7 +40,7 @@ namespace storage {
 template<typename T>
 class SparseMatrix;
 
-typedef uint_fast64_t SparseMatrixIndexType;
+typedef uint64_t SparseMatrixIndexType;
 
 template<typename IndexType, typename ValueType>
 class MatrixEntry {
@@ -539,7 +539,7 @@ class SparseMatrix {
      *
      * @return The number of entries in the given row group of the matrix.
      */
-    uint_fast64_t getRowGroupEntryCount(uint_fast64_t const group) const;
+    index_type getRowGroupEntryCount(index_type const group) const;
 
     /*!
      * Returns the cached number of nonzero entries in the matrix.
@@ -839,7 +839,7 @@ class SparseMatrix {
      * @param keepZeros A flag indicating whether entries with value zero should be kept.
      *
      */
-    SparseMatrix<ValueType> transposeSelectedRowsFromRowGroups(std::vector<uint_fast64_t> const& rowGroupChoices, bool keepZeros = false) const;
+    SparseMatrix<ValueType> transposeSelectedRowsFromRowGroups(std::vector<uint64_t> const& rowGroupChoices, bool keepZeros = false) const;
 
     /*!
      * Transforms the matrix into an equation system. That is, it transforms the matrix A into a matrix (1-A).
@@ -930,28 +930,28 @@ class SparseMatrix {
      * @return The resulting vector the content of the given result vector.
      */
     void multiplyAndReduce(storm::solver::OptimizationDirection const& dir, std::vector<uint64_t> const& rowGroupIndices, std::vector<ValueType> const& vector,
-                           std::vector<ValueType> const* summand, std::vector<ValueType>& result, std::vector<uint_fast64_t>* choices) const;
+                           std::vector<ValueType> const* summand, std::vector<ValueType>& result, std::vector<uint64_t>* choices) const;
 
     void multiplyAndReduceForward(storm::solver::OptimizationDirection const& dir, std::vector<uint64_t> const& rowGroupIndices,
                                   std::vector<ValueType> const& vector, std::vector<ValueType> const* b, std::vector<ValueType>& result,
-                                  std::vector<uint_fast64_t>* choices) const;
+                                  std::vector<uint64_t>* choices) const;
     template<typename Compare>
     void multiplyAndReduceForward(std::vector<uint64_t> const& rowGroupIndices, std::vector<ValueType> const& vector, std::vector<ValueType> const* summand,
-                                  std::vector<ValueType>& result, std::vector<uint_fast64_t>* choices) const;
+                                  std::vector<ValueType>& result, std::vector<uint64_t>* choices) const;
 
     void multiplyAndReduceBackward(storm::solver::OptimizationDirection const& dir, std::vector<uint64_t> const& rowGroupIndices,
                                    std::vector<ValueType> const& vector, std::vector<ValueType> const* b, std::vector<ValueType>& result,
-                                   std::vector<uint_fast64_t>* choices) const;
+                                   std::vector<uint64_t>* choices) const;
     template<typename Compare>
     void multiplyAndReduceBackward(std::vector<uint64_t> const& rowGroupIndices, std::vector<ValueType> const& vector, std::vector<ValueType> const* b,
-                                   std::vector<ValueType>& result, std::vector<uint_fast64_t>* choices) const;
+                                   std::vector<ValueType>& result, std::vector<uint64_t>* choices) const;
 #ifdef STORM_HAVE_INTELTBB
     void multiplyAndReduceParallel(storm::solver::OptimizationDirection const& dir, std::vector<uint64_t> const& rowGroupIndices,
                                    std::vector<ValueType> const& vector, std::vector<ValueType> const* b, std::vector<ValueType>& result,
-                                   std::vector<uint_fast64_t>* choices) const;
+                                   std::vector<uint64_t>* choices) const;
     template<typename Compare>
     void multiplyAndReduceParallel(std::vector<uint64_t> const& rowGroupIndices, std::vector<ValueType> const& vector, std::vector<ValueType> const* b,
-                                   std::vector<ValueType>& result, std::vector<uint_fast64_t>* choices) const;
+                                   std::vector<ValueType>& result, std::vector<uint64_t>* choices) const;
 #endif
 
     /*!

--- a/src/test/storm/storage/SparseMatrixTest.cpp
+++ b/src/test/storm/storage/SparseMatrixTest.cpp
@@ -336,6 +336,43 @@ TEST(SparseMatrix, MakeRowGroupAbsorbing) {
     ASSERT_TRUE(matrix == matrix2);
 }
 
+TEST(SparseMatrix, rowGroupIndices) {
+    storm::storage::SparseMatrixBuilder<double> matrixBuilder(5, 4, 9, true, true, 4);
+    ASSERT_NO_THROW(matrixBuilder.newRowGroup(0));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(0, 1, 1.0));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(0, 2, 1.2));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(1, 0, 0.5));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(1, 1, 0.7));
+    ASSERT_NO_THROW(matrixBuilder.newRowGroup(2));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(2, 0, 0.5));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(3, 2, 1.1));
+    ASSERT_NO_THROW(matrixBuilder.newRowGroup(4));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(4, 0, 0.1));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(4, 1, 0.2));
+    ASSERT_NO_THROW(matrixBuilder.addNextValue(4, 3, 0.3));
+    storm::storage::SparseMatrix<double> matrix;
+    ASSERT_NO_THROW(matrix = matrixBuilder.build());
+
+    EXPECT_EQ(4, matrix.getRowGroupCount());
+    std::vector<storm::storage::SparseMatrixIndexType> expected, actual;
+    expected.assign({0, 1});
+    auto indices = matrix.getRowGroupIndices(0);
+    actual.assign(indices.begin(), indices.end());
+    EXPECT_EQ(expected, actual);
+    expected.assign({2, 3});
+    indices = matrix.getRowGroupIndices(1);
+    actual.assign(indices.begin(), indices.end());
+    EXPECT_EQ(expected, actual);
+    expected.assign({4});
+    indices = matrix.getRowGroupIndices(2);
+    actual.assign(indices.begin(), indices.end());
+    EXPECT_EQ(expected, actual);
+    expected.assign({});
+    indices = matrix.getRowGroupIndices(3);
+    actual.assign(indices.begin(), indices.end());
+    EXPECT_EQ(expected, actual);
+}
+
 TEST(SparseMatrix, ConstrainedRowSumVector) {
     storm::storage::SparseMatrixBuilder<double> matrixBuilder(5, 4, 9);
     ASSERT_NO_THROW(matrixBuilder.addNextValue(0, 1, 1.0));


### PR DESCRIPTION
This PR adds an overload of `SparseMatrix<T>::getRowGroupIndices` that returns an index range for a given row group.

Instead of

```c++
for (auto rowIndex = matrix.getRowGroupIndices()[group]; rowIndex < matrix.getRowGroupIndices()[group + 1]; ++rowIndex) {
    // stuff
}
```

we can now do this

```c++
for (auto rowIndex : matrix.getRowGroupIndices(group)) {
    // stuff
}
```

The PR also avoids using `uint_fast64_t` in the SparseMatrix file (see #259).

