### PR TITLE
Change `storm::storage::BitVector` to use `std::shared_ptr` for 64-bit buckets

### DIFF
--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -222,7 +222,7 @@ void BitVector::resize(uint_fast64_t newLength, bool init) {
         }
 
         if (newBucketCount > this->bucketCount()) {
-			std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
+			std::shared_ptr<uint64_t> newBuckets(new uint64_t[newBucketCount], std::default_delete<uint64_t[]>());
             std::copy_n(buckets, this->bucketCount(), newBuckets);
             if (init) {
                 if (this->bucketCount() > 0) {

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -77,18 +77,18 @@ BitVector::BitVector(uint_fast64_t length, bool init) : bitCount(length), bucket
 
     // Initialize the storage with the required values.
     if (init) {
-		std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
-		buckets = newBuckets;
+        std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
+        buckets = newBuckets;
         std::fill_n(buckets.get(), bucketCount, -1ull);
         truncateLastBucket();
     } else {
-		std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
-		buckets = newBuckets;
+        std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
+        buckets = newBuckets;
     }
 }
 
 BitVector::~BitVector() {
-	// Intentionally left empty. `buckets` now managed by c++ stl through shared_ptr
+    // Intentionally left empty. `buckets` now managed by c++ stl through shared_ptr
 }
 
 template<typename InputIterator>
@@ -102,14 +102,14 @@ BitVector::BitVector(uint_fast64_t length, std::vector<uint_fast64_t> setEntries
 
 BitVector::BitVector(uint_fast64_t bucketCount, uint_fast64_t bitCount) : bitCount(bitCount), buckets(nullptr) {
     STORM_LOG_ASSERT((bucketCount << 6) == bitCount, "Bit count does not match number of buckets.");
-	std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
-	buckets = newBuckets;
+    std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
+    buckets = newBuckets;
 
 }
 
 BitVector::BitVector(BitVector const& other) : bitCount(other.bitCount), buckets(nullptr) {
-	std::shared_ptr<uint64_t> newBuckets(new uint64_t[other.bucketCount()], std::default_delete<uint64_t[]>());
-	buckets = newBuckets;
+    std::shared_ptr<uint64_t> newBuckets(new uint64_t[other.bucketCount()], std::default_delete<uint64_t[]>());
+    buckets = newBuckets;
 
     std::copy_n(other.buckets.get(), other.bucketCount(), buckets.get());
 }
@@ -119,12 +119,12 @@ BitVector& BitVector::operator=(BitVector const& other) {
     if (this != &other) {
         if (buckets && bucketCount() != other.bucketCount()) {
             // deletion of buckets occurs implicitly due to std::shared_ptr
-			buckets = nullptr;
+            buckets = nullptr;
         }
         bitCount = other.bitCount;
         if (!buckets) {
-			std::shared_ptr<uint64_t> newBuckets(new uint64_t[other.bucketCount()], std::default_delete<uint64_t[]>());
-			buckets = newBuckets;
+            std::shared_ptr<uint64_t> newBuckets(new uint64_t[other.bucketCount()], std::default_delete<uint64_t[]>());
+            buckets = newBuckets;
         }
         std::copy_n(other.buckets.get(), other.bucketCount(), buckets.get());
     }
@@ -163,8 +163,8 @@ BitVector& BitVector::operator=(BitVector&& other) {
         bitCount = other.bitCount;
         other.bitCount = 0;
         // bucket deletion of current BitVector's buckets occurs implicitly
-		// it will not delete if there is another reference to the same buckets though
-		this->buckets = other.buckets;
+        // it will not delete if there is another reference to the same buckets though
+        this->buckets = other.buckets;
         other.buckets = nullptr;
     }
 
@@ -222,7 +222,7 @@ void BitVector::resize(uint_fast64_t newLength, bool init) {
         }
 
         if (newBucketCount > this->bucketCount()) {
-			std::shared_ptr<uint64_t> newBuckets(new uint64_t[newBucketCount], std::default_delete<uint64_t[]>());
+            std::shared_ptr<uint64_t> newBuckets(new uint64_t[newBucketCount], std::default_delete<uint64_t[]>());
             std::copy_n(buckets.get(), this->bucketCount(), newBuckets.get());
             if (init) {
                 if (this->bucketCount() > 0) {
@@ -233,8 +233,8 @@ void BitVector::resize(uint_fast64_t newLength, bool init) {
                 std::fill_n(newBuckets.get() + this->bucketCount(), newBucketCount - this->bucketCount(), 0);
             }
             // old bucket deletion occurs implicitly
-			// will not delete if another bitvector shares old buckets
-			buckets = newBuckets;
+            // will not delete if another bitvector shares old buckets
+            buckets = newBuckets;
             bitCount = newLength;
         } else {
             // If the underlying storage does not need to grow, we have to insert the missing bits.
@@ -253,11 +253,11 @@ void BitVector::resize(uint_fast64_t newLength, bool init) {
         // If the number of buckets needs to be reduced, we resize it now. Otherwise, we can just truncate the
         // last bucket.
         if (newBucketCount < this->bucketCount()) {
-			std::shared_ptr<uint64_t> newBuckets(new uint64_t[newBucketCount], std::default_delete<uint64_t[]>());
+            std::shared_ptr<uint64_t> newBuckets(new uint64_t[newBucketCount], std::default_delete<uint64_t[]>());
             std::copy_n(buckets.get(), newBucketCount, newBuckets.get());
             // old buckets deletion occurs implicitly
-			// will not delete if another bv shared old buckets
-			buckets = newBuckets;
+            // will not delete if another bv shared old buckets
+            buckets = newBuckets;
             bitCount = newLength;
         }
         bitCount = newLength;

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -108,7 +108,7 @@ BitVector::BitVector(uint_fast64_t bucketCount, uint_fast64_t bitCount) : bitCou
 }
 
 BitVector::BitVector(BitVector const& other) : bitCount(other.bitCount), buckets(nullptr) {
-	std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
+	std::shared_ptr<uint64_t> newBuckets(new uint64_t[other.bucketCount()], std::default_delete<uint64_t[]>());
 	buckets = newBuckets;
 
     std::copy_n(other.buckets.get(), other.bucketCount(), buckets.get());
@@ -123,7 +123,7 @@ BitVector& BitVector::operator=(BitVector const& other) {
         }
         bitCount = other.bitCount;
         if (!buckets) {
-			std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
+			std::shared_ptr<uint64_t> newBuckets(new uint64_t[other.bucketCount()], std::default_delete<uint64_t[]>());
 			buckets = newBuckets;
         }
         std::copy_n(other.buckets.get(), other.bucketCount(), buckets.get());

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -79,7 +79,7 @@ BitVector::BitVector(uint_fast64_t length, bool init) : bitCount(length), bucket
     if (init) {
 		std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
 		buckets = newBuckets;
-        std::fill_n(buckets, bucketCount, -1ull);
+        std::fill_n(buckets.get(), bucketCount, -1ull);
         truncateLastBucket();
     } else {
 		std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
@@ -223,7 +223,7 @@ void BitVector::resize(uint_fast64_t newLength, bool init) {
 
         if (newBucketCount > this->bucketCount()) {
 			std::shared_ptr<uint64_t> newBuckets(new uint64_t[newBucketCount], std::default_delete<uint64_t[]>());
-            std::copy_n(buckets, this->bucketCount(), newBuckets);
+            std::copy_n(buckets.get(), this->bucketCount(), newBuckets);
             if (init) {
                 if (this->bucketCount() > 0) {
                     newBuckets.get()[this->bucketCount() - 1] |= ((1ull << (64 - (bitCount & mod64mask))) - 1ull);

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -68,13 +68,6 @@ BitVector::BitVector() : bitCount(0), buckets(nullptr) {
     // Intentionally left empty.
 }
 
-BitVector::BitVector(const BitVector & other) {
-	bitCount = other.bitCount;
-    buckets = new uint64_t[other.bucketCount()];
-    std::copy_n(other.buckets, other.bucketCount(), buckets);
-
-}
-
 BitVector::BitVector(uint_fast64_t length, bool init) : bitCount(length), buckets(nullptr) {
     // Compute the correct number of buckets needed to store the given number of bits.
     uint_fast64_t bucketCount = length >> 6;

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -104,7 +104,6 @@ BitVector::BitVector(uint_fast64_t bucketCount, uint_fast64_t bitCount) : bitCou
     STORM_LOG_ASSERT((bucketCount << 6) == bitCount, "Bit count does not match number of buckets.");
     std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
     buckets = newBuckets;
-
 }
 
 BitVector::BitVector(BitVector const& other) : bitCount(other.bitCount), buckets(nullptr) {

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -68,6 +68,13 @@ BitVector::BitVector() : bitCount(0), buckets(nullptr) {
     // Intentionally left empty.
 }
 
+BitVector::BitVector(const BitVector & other) {
+	bitCount = other.bitCount;
+    buckets = new uint64_t[other.bucketCount()];
+    std::copy_n(other.buckets, other.bucketCount(), buckets);
+
+}
+
 BitVector::BitVector(uint_fast64_t length, bool init) : bitCount(length), buckets(nullptr) {
     // Compute the correct number of buckets needed to store the given number of bits.
     uint_fast64_t bucketCount = length >> 6;

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -223,7 +223,7 @@ void BitVector::resize(uint_fast64_t newLength, bool init) {
 
         if (newBucketCount > this->bucketCount()) {
 			std::shared_ptr<uint64_t> newBuckets(new uint64_t[newBucketCount], std::default_delete<uint64_t[]>());
-            std::copy_n(buckets.get(), this->bucketCount(), newBuckets);
+            std::copy_n(buckets.get(), this->bucketCount(), newBuckets.get());
             if (init) {
                 if (this->bucketCount() > 0) {
                     newBuckets.get()[this->bucketCount() - 1] |= ((1ull << (64 - (bitCount & mod64mask))) - 1ull);
@@ -254,7 +254,7 @@ void BitVector::resize(uint_fast64_t newLength, bool init) {
         // last bucket.
         if (newBucketCount < this->bucketCount()) {
 			std::shared_ptr<uint64_t> newBuckets(new uint64_t[newBucketCount], std::default_delete<uint64_t[]>());
-            std::copy_n(buckets, newBucketCount, newBuckets);
+            std::copy_n(buckets.get(), newBucketCount, newBuckets.get());
             // old buckets deletion occurs implicitly
 			// will not delete if another bv shared old buckets
 			buckets = newBuckets;

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -77,12 +77,12 @@ BitVector::BitVector(uint_fast64_t length, bool init) : bitCount(length), bucket
 
     // Initialize the storage with the required values.
     if (init) {
-		std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>);
+		std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
 		buckets = newBuckets;
         std::fill_n(buckets, bucketCount, -1ull);
         truncateLastBucket();
     } else {
-		std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>);
+		std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
 		buckets = newBuckets;
     }
 }
@@ -102,13 +102,13 @@ BitVector::BitVector(uint_fast64_t length, std::vector<uint_fast64_t> setEntries
 
 BitVector::BitVector(uint_fast64_t bucketCount, uint_fast64_t bitCount) : bitCount(bitCount), buckets(nullptr) {
     STORM_LOG_ASSERT((bucketCount << 6) == bitCount, "Bit count does not match number of buckets.");
-	std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>);
+	std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
 	buckets = newBuckets;
 
 }
 
 BitVector::BitVector(BitVector const& other) : bitCount(other.bitCount), buckets(nullptr) {
-	std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>);
+	std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
 	buckets = newBuckets;
 
     std::copy_n(other.buckets.get(), other.bucketCount(), buckets.get());
@@ -123,7 +123,7 @@ BitVector& BitVector::operator=(BitVector const& other) {
         }
         bitCount = other.bitCount;
         if (!buckets) {
-			std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>);
+			std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
 			buckets = newBuckets;
         }
         std::copy_n(other.buckets.get(), other.bucketCount(), buckets.get());
@@ -138,9 +138,9 @@ bool BitVector::operator<(BitVector const& other) const {
         return false;
     }
 
-    uint64_t* first1 = this->buckets;
-    uint64_t* last1 = this->buckets + this->bucketCount();
-    uint64_t* first2 = other.buckets;
+    uint64_t* first1 = this->buckets.get();
+    uint64_t* last1 = this->buckets.get() + this->bucketCount();
+    uint64_t* first2 = other.buckets.get();
 
     for (; first1 != last1; ++first1, ++first2) {
         if (*first1 < *first2) {
@@ -222,15 +222,15 @@ void BitVector::resize(uint_fast64_t newLength, bool init) {
         }
 
         if (newBucketCount > this->bucketCount()) {
-			std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>);
+			std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>());
             std::copy_n(buckets, this->bucketCount(), newBuckets);
             if (init) {
                 if (this->bucketCount() > 0) {
-                    newbuckets.get()[this->bucketCount() - 1] |= ((1ull << (64 - (bitCount & mod64mask))) - 1ull);
+                    newBuckets.get()[this->bucketCount() - 1] |= ((1ull << (64 - (bitCount & mod64mask))) - 1ull);
                 }
-                std::fill_n(newBuckets + this->bucketCount(), newBucketCount - this->bucketCount(), -1ull);
+                std::fill_n(newBuckets.get() + this->bucketCount(), newBucketCount - this->bucketCount(), -1ull);
             } else {
-                std::fill_n(newBuckets + this->bucketCount(), newBucketCount - this->bucketCount(), 0);
+                std::fill_n(newBuckets.get() + this->bucketCount(), newBucketCount - this->bucketCount(), 0);
             }
             // old bucket deletion occurs implicitly
 			// will not delete if another bitvector shares old buckets
@@ -253,7 +253,7 @@ void BitVector::resize(uint_fast64_t newLength, bool init) {
         // If the number of buckets needs to be reduced, we resize it now. Otherwise, we can just truncate the
         // last bucket.
         if (newBucketCount < this->bucketCount()) {
-			std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketCount], std::default_delete<uint64_t[]>);
+			std::shared_ptr<uint64_t> newBuckets(new uint64_t[newBucketCount], std::default_delete<uint64_t[]>());
             std::copy_n(buckets, newBucketCount, newBuckets);
             // old buckets deletion occurs implicitly
 			// will not delete if another bv shared old buckets

--- a/src/storm/storage/BitVector.h
+++ b/src/storm/storage/BitVector.h
@@ -7,6 +7,7 @@
 #include <iterator>
 #include <ostream>
 #include <vector>
+#include <memory>
 
 namespace storm {
 namespace storage {

--- a/src/storm/storage/BitVector.h
+++ b/src/storm/storage/BitVector.h
@@ -179,8 +179,6 @@ class BitVector {
      * deep copy.
      */
     BitVector& operator=(BitVector const& other);
-	// Copy constructor which does the same thing
-	BitVector(BitVector const& other);
     /*!
      * Move assigns the given bit vector to the current bit vector.
      *

--- a/src/storm/storage/BitVector.h
+++ b/src/storm/storage/BitVector.h
@@ -5,9 +5,9 @@
 #include <cstdint>
 #include <functional>
 #include <iterator>
+#include <memory>
 #include <ostream>
 #include <vector>
-#include <memory>
 
 namespace storm {
 namespace storage {

--- a/src/storm/storage/BitVector.h
+++ b/src/storm/storage/BitVector.h
@@ -616,7 +616,7 @@ class BitVector {
     uint_fast64_t bitCount;
 
     // The underlying storage of 64-bit buckets for all bits of this bit vector.
-	std::shared_ptr<uint64_t> buckets;
+    std::shared_ptr<uint64_t> buckets;
 
     // A bit mask that can be used to reduce a modulo 64 operation to a logical "and".
     static const uint_fast64_t mod64mask = (1 << 6) - 1;

--- a/src/storm/storage/BitVector.h
+++ b/src/storm/storage/BitVector.h
@@ -179,7 +179,8 @@ class BitVector {
      * deep copy.
      */
     BitVector& operator=(BitVector const& other);
-
+	// Copy constructor which does the same thing
+	BitVector(BitVector const& other);
     /*!
      * Move assigns the given bit vector to the current bit vector.
      *

--- a/src/storm/storage/BitVector.h
+++ b/src/storm/storage/BitVector.h
@@ -615,7 +615,7 @@ class BitVector {
     uint_fast64_t bitCount;
 
     // The underlying storage of 64-bit buckets for all bits of this bit vector.
-    uint64_t* buckets;
+	std::shared_ptr<uint64_t> buckets;
 
     // A bit mask that can be used to reduce a modulo 64 operation to a logical "and".
     static const uint_fast64_t mod64mask = (1 << 6) - 1;


### PR DESCRIPTION
This PR changes `uint64_t * buckets` in `storm::storage::BitVector` to use a `std::shared_ptr<uint64_t>`, which can be initialized for an array as follows:

```cpp
std::shared_ptr<uint64_t> newBuckets(new uint64_t[bucketSize], std::default_delete<uint64_t>());
buckets = newBuckets;
```
Additionally, pointer arithmetic can be used with the `T * std::shared_ptr<T> get()` function:

```
// Old
buckets + n;
// New
buckets.get() + n
```

The reason I'm proposing this change is because it is possible for two BitVectors to exist, which share the same buckets in memory, and for the destructor of one to get called, invalidating the memory of the other and causing a segmentation fault. To explain why, let me give some background; the `BitVector` has two copy constructors:

1. `BitVector(const BitVector & other)`, which creates a deep copy, i.e., copies the buckets.
2. `BitVector(BitVector && other)`, which creates a shallow copy, i.e., has the new BitVector share the same buckets as the old one.
If creating a copy of a `BitVector` the first copy constructor is invoked, but if creating a copy of a `BitVector &` or a `const BitVector &`, like the `NextStateGenerator`s produce, the second copy constructor is invoked. If the copy outlasts the original (and the original's destructor is called, deleting `buckets`), the copy is left with a pointer to invalid memory. This is not detectable in the program at runtime since the pointer is not nulled, just invalid. Consequently, this often causes a segfault.

This issue was discovered in STAMINA, since STAMINA maintains copies of state values periodically. Since we want both shallow and deep copy to exist, there should be a way if shallow copy is used, to make sure that multiple copies of the same BitVector will never have invalid memory if one of them is destroyed.