### PR TITLE
re-implementation of value iteration-based approaches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Version 1.7.x
 -------------
 
 ## Version 1.7.1
-- Revised implementation of value iteration and its variants
+- Revised implementation of value iteration algorithms and its variants, fixing a bug in the optimistic value iteration heuristic.
 - Experimental support for compiling on Apple Silicon
 - Added SoPlex as a possible LP solver
 - Upgraded shipped version of sylvan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version 1.7.x
 -------------
 
 ## Version 1.7.1
+- Revised implementation of value iteration and its variants
 - Experimental support for compiling on Apple Silicon
 - Added SoPlex as a possible LP solver
 - Upgraded shipped version of sylvan

--- a/src/storm/environment/solver/MinMaxSolverEnvironment.cpp
+++ b/src/storm/environment/solver/MinMaxSolverEnvironment.cpp
@@ -24,7 +24,7 @@ MinMaxSolverEnvironment::MinMaxSolverEnvironment() {
                          minMaxSettings.getConvergenceCriterion() == storm::settings::modules::MinMaxEquationSolverSettings::ConvergenceCriterion::Absolute,
                      "Unknown convergence criterion");
     multiplicationStyle = minMaxSettings.getValueIterationMultiplicationStyle();
-    symmetricUpdates = minMaxSettings.isForceIntervalIterationSymmetricUpdatesSet();
+    forceRequireUnique = minMaxSettings.isForceUniqueSolutionRequirementSet();
 }
 
 MinMaxSolverEnvironment::~MinMaxSolverEnvironment() {
@@ -76,12 +76,12 @@ void MinMaxSolverEnvironment::setMultiplicationStyle(storm::solver::Multiplicati
     multiplicationStyle = value;
 }
 
-bool MinMaxSolverEnvironment::isSymmetricUpdatesSet() const {
-    return symmetricUpdates;
+bool MinMaxSolverEnvironment::isForceRequireUnique() const {
+    return forceRequireUnique;
 }
 
-void MinMaxSolverEnvironment::setSymmetricUpdates(bool value) {
-    symmetricUpdates = value;
+void MinMaxSolverEnvironment::setForceRequireUnique(bool value) {
+    forceRequireUnique = value;
 }
 
 }  // namespace storm

--- a/src/storm/environment/solver/MinMaxSolverEnvironment.h
+++ b/src/storm/environment/solver/MinMaxSolverEnvironment.h
@@ -24,8 +24,8 @@ class MinMaxSolverEnvironment {
     void setRelativeTerminationCriterion(bool value);
     storm::solver::MultiplicationStyle const& getMultiplicationStyle() const;
     void setMultiplicationStyle(storm::solver::MultiplicationStyle value);
-    bool isSymmetricUpdatesSet() const;
-    void setSymmetricUpdates(bool value);
+    bool isForceRequireUnique() const;
+    void setForceRequireUnique(bool value);
 
    private:
     storm::solver::MinMaxMethod minMaxMethod;
@@ -34,6 +34,6 @@ class MinMaxSolverEnvironment {
     storm::RationalNumber precision;
     bool considerRelativeTerminationCriterion;
     storm::solver::MultiplicationStyle multiplicationStyle;
-    bool symmetricUpdates;
+    bool forceRequireUnique;
 };
 }  // namespace storm

--- a/src/storm/environment/solver/OviSolverEnvironment.cpp
+++ b/src/storm/environment/solver/OviSolverEnvironment.cpp
@@ -3,41 +3,18 @@
 #include "storm/settings/SettingsManager.h"
 #include "storm/settings/modules/OviSolverSettings.h"
 #include "storm/utility/constants.h"
-#include "storm/utility/macros.h"
 
 namespace storm {
 
 OviSolverEnvironment::OviSolverEnvironment() {
     auto const& oviSettings = storm::settings::getModule<storm::settings::modules::OviSolverSettings>();
-    precisionUpdateFactor = storm::utility::convertNumber<storm::RationalNumber>(oviSettings.getPrecisionUpdateFactor());
-    maxVerificationIterationFactor = storm::utility::convertNumber<storm::RationalNumber>(oviSettings.getMaxVerificationIterationFactor());
-    upperBoundGuessingFactor = storm::utility::convertNumber<storm::RationalNumber>(oviSettings.getUpperBoundGuessingFactor());
-    upperBoundOnlyIterations = oviSettings.getUpperBoundOnlyIterations();
-    noTerminationGuaranteeMinimumMethod = oviSettings.useNoTerminationGuaranteeMinimumMethod();
+    if (oviSettings.hasUpperBoundGuessingFactorBeenSet()) {
+        upperBoundGuessingFactor = storm::utility::convertNumber<storm::RationalNumber>(oviSettings.getUpperBoundGuessingFactor());
+    }
 }
 
-OviSolverEnvironment::~OviSolverEnvironment() {
-    // Intentionally left empty
-}
-
-storm::RationalNumber OviSolverEnvironment::getPrecisionUpdateFactor() const {
-    return precisionUpdateFactor;
-}
-
-storm::RationalNumber OviSolverEnvironment::getMaxVerificationIterationFactor() const {
-    return maxVerificationIterationFactor;
-}
-
-storm::RationalNumber OviSolverEnvironment::getUpperBoundGuessingFactor() const {
+std::optional<storm::RationalNumber> const& OviSolverEnvironment::getUpperBoundGuessingFactor() const {
     return upperBoundGuessingFactor;
-}
-
-uint64_t OviSolverEnvironment::getUpperBoundOnlyIterations() const {
-    return upperBoundOnlyIterations;
-}
-
-bool OviSolverEnvironment::useNoTerminationGuaranteeMinimumMethod() const {
-    return noTerminationGuaranteeMinimumMethod;
 }
 
 }  // namespace storm

--- a/src/storm/environment/solver/OviSolverEnvironment.h
+++ b/src/storm/environment/solver/OviSolverEnvironment.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include "storm/environment/solver/SolverEnvironment.h"
 
 #include "storm/adapters/RationalNumberAdapter.h"
@@ -9,19 +10,11 @@ namespace storm {
 class OviSolverEnvironment {
    public:
     OviSolverEnvironment();
-    ~OviSolverEnvironment();
+    ~OviSolverEnvironment() = default;
 
-    storm::RationalNumber getPrecisionUpdateFactor() const;
-    storm::RationalNumber getMaxVerificationIterationFactor() const;
-    storm::RationalNumber getUpperBoundGuessingFactor() const;
-    uint64_t getUpperBoundOnlyIterations() const;
-    bool useNoTerminationGuaranteeMinimumMethod() const;
+    std::optional<storm::RationalNumber> const& getUpperBoundGuessingFactor() const;
 
    private:
-    storm::RationalNumber precisionUpdateFactor;
-    storm::RationalNumber maxVerificationIterationFactor;
-    storm::RationalNumber upperBoundGuessingFactor;
-    uint64_t upperBoundOnlyIterations;
-    bool noTerminationGuaranteeMinimumMethod;
+    std::optional<storm::RationalNumber> upperBoundGuessingFactor;
 };
 }  // namespace storm

--- a/src/storm/settings/modules/MinMaxEquationSolverSettings.cpp
+++ b/src/storm/settings/modules/MinMaxEquationSolverSettings.cpp
@@ -12,13 +12,13 @@ namespace settings {
 namespace modules {
 
 const std::string MinMaxEquationSolverSettings::moduleName = "minmax";
-const std::string MinMaxEquationSolverSettings::solvingMethodOptionName = "method";
-const std::string MinMaxEquationSolverSettings::maximalIterationsOptionName = "maxiter";
-const std::string MinMaxEquationSolverSettings::maximalIterationsOptionShortName = "i";
-const std::string MinMaxEquationSolverSettings::precisionOptionName = "precision";
-const std::string MinMaxEquationSolverSettings::absoluteOptionName = "absolute";
-const std::string MinMaxEquationSolverSettings::valueIterationMultiplicationStyleOptionName = "vimult";
-const std::string MinMaxEquationSolverSettings::intervalIterationSymmetricUpdatesOptionName = "symmetricupdates";
+const std::string solvingMethodOptionName = "method";
+const std::string maximalIterationsOptionName = "maxiter";
+const std::string maximalIterationsOptionShortName = "i";
+const std::string precisionOptionName = "precision";
+const std::string absoluteOptionName = "absolute";
+const std::string valueIterationMultiplicationStyleOptionName = "vimult";
+const std::string forceUniqueSolutionRequirementOptionName = "force-require-unique";
 
 MinMaxEquationSolverSettings::MinMaxEquationSolverSettings() : ModuleSettings(moduleName) {
     std::vector<std::string> minMaxSolvingTechniques = {
@@ -64,8 +64,8 @@ MinMaxEquationSolverSettings::MinMaxEquationSolverSettings() : ModuleSettings(mo
                                          .build())
                         .build());
 
-    this->addOption(storm::settings::OptionBuilder(moduleName, intervalIterationSymmetricUpdatesOptionName, false,
-                                                   "If set, interval iteration performs an update on both, lower and upper bound in each iteration")
+    this->addOption(storm::settings::OptionBuilder(moduleName, forceUniqueSolutionRequirementOptionName, false,
+                                                   "If set, a MinMax solver always requires a unique solution for its input.")
                         .setIsAdvanced()
                         .build());
 }
@@ -142,8 +142,8 @@ storm::solver::MultiplicationStyle MinMaxEquationSolverSettings::getValueIterati
     STORM_LOG_THROW(false, storm::exceptions::IllegalArgumentValueException, "Unknown multiplication style '" << multiplicationStyleString << "'.");
 }
 
-bool MinMaxEquationSolverSettings::isForceIntervalIterationSymmetricUpdatesSet() const {
-    return this->getOption(intervalIterationSymmetricUpdatesOptionName).getHasOptionBeenSet();
+bool MinMaxEquationSolverSettings::isForceUniqueSolutionRequirementSet() const {
+    return this->getOption(forceUniqueSolutionRequirementOptionName).getHasOptionBeenSet();
 }
 
 }  // namespace modules

--- a/src/storm/settings/modules/MinMaxEquationSolverSettings.cpp
+++ b/src/storm/settings/modules/MinMaxEquationSolverSettings.cpp
@@ -65,7 +65,8 @@ MinMaxEquationSolverSettings::MinMaxEquationSolverSettings() : ModuleSettings(mo
                         .build());
 
     this->addOption(storm::settings::OptionBuilder(moduleName, forceUniqueSolutionRequirementOptionName, false,
-                                                   "If set, a MinMax solver always requires a unique solution for its input.")
+                                                   "Enforces end component collapsing for MinMax equation systems so that their solution becomes unique. May "
+                                                   "simplify solving but causes some overhead.")
                         .setIsAdvanced()
                         .build());
 }

--- a/src/storm/settings/modules/MinMaxEquationSolverSettings.h
+++ b/src/storm/settings/modules/MinMaxEquationSolverSettings.h
@@ -91,22 +91,12 @@ class MinMaxEquationSolverSettings : public ModuleSettings {
     storm::solver::MultiplicationStyle getValueIterationMultiplicationStyle() const;
 
     /*!
-     * Retrievew whether updates in interval iteration have to be made symmetrically
+     * @return if a MinMax solver should always require a unique solution for its input even if it is not a requirement of the used method.
      */
-    bool isForceIntervalIterationSymmetricUpdatesSet() const;
+    bool isForceUniqueSolutionRequirementSet() const;
 
     // The name of the module.
     static const std::string moduleName;
-
-   private:
-    static const std::string solvingMethodOptionName;
-    static const std::string maximalIterationsOptionName;
-    static const std::string maximalIterationsOptionShortName;
-    static const std::string precisionOptionName;
-    static const std::string absoluteOptionName;
-    static const std::string valueIterationMultiplicationStyleOptionName;
-    static const std::string intervalIterationSymmetricUpdatesOptionName;
-    static const std::string forceBoundsOptionName;
 };
 
 }  // namespace modules

--- a/src/storm/settings/modules/OviSolverSettings.cpp
+++ b/src/storm/settings/modules/OviSolverSettings.cpp
@@ -4,83 +4,29 @@
 #include "storm/settings/Option.h"
 #include "storm/settings/OptionBuilder.h"
 
-#include "storm/exceptions/IllegalArgumentValueException.h"
-#include "storm/utility/macros.h"
-
 namespace storm {
 namespace settings {
 namespace modules {
 
 const std::string OviSolverSettings::moduleName = "ovi";
-const std::string OviSolverSettings::precisionUpdateFactorOptionName = "precision-update-factor";
-const std::string OviSolverSettings::maxVerificationIterationFactorOptionName = "max-verification-iter-factor";
 const std::string OviSolverSettings::upperBoundGuessingFactorOptionName = "upper-bound-factor";
-const std::string OviSolverSettings::upperBoundOnlyIterationsOptionName = "check-upper-only-iter";
-const std::string OviSolverSettings::useNoTerminationGuaranteeMinimumMethodOptionName = "no-termination-guarantee";
 
 OviSolverSettings::OviSolverSettings() : ModuleSettings(moduleName) {
-    this->addOption(storm::settings::OptionBuilder(moduleName, precisionUpdateFactorOptionName, false,
-                                                   "Sets with which factor the precision of the inner value iteration is updated.")
+    this->addOption(storm::settings::OptionBuilder(moduleName, upperBoundGuessingFactorOptionName, false, "Sets how optimistic the upper bound is guessed.")
                         .setIsAdvanced()
                         .addArgument(storm::settings::ArgumentBuilder::createDoubleArgument("factor", "The factor.")
-                                         .setDefaultValueDouble(0.4)
-                                         .addValidatorDouble(ArgumentValidatorFactory::createDoubleRangeValidatorExcluding(0.0, 1.0))
-                                         .build())
-                        .build());
-
-    this->addOption(storm::settings::OptionBuilder(moduleName, maxVerificationIterationFactorOptionName, false,
-                                                   "Controls how many verification iterations are performed before guessing a new upper bound.")
-                        .setIsAdvanced()
-                        .addArgument(storm::settings::ArgumentBuilder::createDoubleArgument("factor", "The factor.")
-                                         .setDefaultValueDouble(1.0)
+                                         .setDefaultValueDouble(1e-6)
                                          .addValidatorDouble(ArgumentValidatorFactory::createDoubleGreaterValidator(0.0))
                                          .build())
                         .build());
-
-    this->addOption(storm::settings::OptionBuilder(moduleName, upperBoundGuessingFactorOptionName, false,
-                                                   "Sets with which factor the precision is multiplied to guess the upper bound.")
-                        .setIsAdvanced()
-                        .addArgument(storm::settings::ArgumentBuilder::createDoubleArgument("factor", "The factor.")
-                                         .setDefaultValueDouble(1.0)
-                                         .addValidatorDouble(ArgumentValidatorFactory::createDoubleGreaterValidator(0.0))
-                                         .build())
-                        .build());
-
-    this->addOption(storm::settings::OptionBuilder(moduleName, upperBoundOnlyIterationsOptionName, false,
-                                                   "Sets the max. iterations OVI will only iterate over the upper bound.")
-                        .setIsAdvanced()
-                        .addArgument(storm::settings::ArgumentBuilder::createIntegerArgument("iter", "The iterations.")
-                                         .setDefaultValueInteger(20000)
-                                         .addValidatorInteger(ArgumentValidatorFactory::createIntegerGreaterValidator(0))
-                                         .build())
-                        .build());
-
-    this->addOption(storm::settings::OptionBuilder(
-                        moduleName, useNoTerminationGuaranteeMinimumMethodOptionName, false,
-                        "If set, we don't take the element-wise minimum for the upper bound, which is often faster but theoretically incomplete.")
-                        .setShortName("ntg")
-                        .setIsAdvanced()
-                        .build());
 }
 
-double OviSolverSettings::getPrecisionUpdateFactor() const {
-    return this->getOption(precisionUpdateFactorOptionName).getArgumentByName("factor").getValueAsDouble();
-}
-
-double OviSolverSettings::getMaxVerificationIterationFactor() const {
-    return this->getOption(maxVerificationIterationFactorOptionName).getArgumentByName("factor").getValueAsDouble();
+bool OviSolverSettings::hasUpperBoundGuessingFactorBeenSet() const {
+    return this->getOption(upperBoundGuessingFactorOptionName).getHasOptionBeenSet();
 }
 
 double OviSolverSettings::getUpperBoundGuessingFactor() const {
     return this->getOption(upperBoundGuessingFactorOptionName).getArgumentByName("factor").getValueAsDouble();
-}
-
-uint64_t OviSolverSettings::getUpperBoundOnlyIterations() const {
-    return this->getOption(upperBoundOnlyIterationsOptionName).getArgumentByName("iter").getValueAsInteger();
-}
-
-bool OviSolverSettings::useNoTerminationGuaranteeMinimumMethod() const {
-    return this->getOption(useNoTerminationGuaranteeMinimumMethodOptionName).getHasOptionBeenSet();
 }
 
 }  // namespace modules

--- a/src/storm/settings/modules/OviSolverSettings.h
+++ b/src/storm/settings/modules/OviSolverSettings.h
@@ -14,25 +14,21 @@ class OviSolverSettings : public ModuleSettings {
    public:
     OviSolverSettings();
 
-    double getPrecisionUpdateFactor() const;
+    /*!
+     * @return true if the parameter controlling how optimistic upper bounds are guessed has been set by the user
+     */
+    bool hasUpperBoundGuessingFactorBeenSet() const;
 
-    double getMaxVerificationIterationFactor() const;
-
+    /*!
+     * @return the parameter controlling how optimistic upper bounds are guessed
+     */
     double getUpperBoundGuessingFactor() const;
-
-    uint64_t getUpperBoundOnlyIterations() const;
-
-    bool useNoTerminationGuaranteeMinimumMethod() const;
 
     // The name of the module.
     static const std::string moduleName;
 
    private:
-    static const std::string precisionUpdateFactorOptionName;
-    static const std::string maxVerificationIterationFactorOptionName;
     static const std::string upperBoundGuessingFactorOptionName;
-    static const std::string upperBoundOnlyIterationsOptionName;
-    static const std::string useNoTerminationGuaranteeMinimumMethodOptionName;
 };
 
 }  // namespace modules

--- a/src/storm/solver/NativeLinearEquationSolver.cpp
+++ b/src/storm/solver/NativeLinearEquationSolver.cpp
@@ -3,21 +3,24 @@
 #include <limits>
 
 #include "storm/environment/solver/NativeSolverEnvironment.h"
+#include "storm/environment/solver/OviSolverEnvironment.h"
 
 #include "storm/exceptions/InvalidEnvironmentException.h"
-#include "storm/exceptions/InvalidStateException.h"
-#include "storm/exceptions/NotSupportedException.h"
-#include "storm/exceptions/PrecisionExceededException.h"
 #include "storm/exceptions/UnmetRequirementException.h"
+#include "storm/solver/helper/IntervalterationHelper.h"
 #include "storm/solver/helper/OptimisticValueIterationHelper.h"
+#include "storm/solver/helper/RationalSearchHelper.h"
 #include "storm/solver/helper/SoundValueIterationHelper.h"
+#include "storm/solver/helper/ValueIterationHelper.h"
 #include "storm/solver/multiplier/Multiplier.h"
 #include "storm/utility/ConstantsComparator.h"
-#include "storm/utility/KwekMehlhorn.h"
 #include "storm/utility/NumberTraits.h"
 #include "storm/utility/SignalHandler.h"
 #include "storm/utility/constants.h"
 #include "storm/utility/vector.h"
+
+#include "storm/settings/SettingsManager.h"
+#include "storm/settings/modules/ModelCheckerSettings.h"
 
 namespace storm {
 namespace solver {
@@ -49,6 +52,14 @@ void NativeLinearEquationSolver<ValueType>::setMatrix(storm::storage::SparseMatr
     localA = std::make_unique<storm::storage::SparseMatrix<ValueType>>(std::move(A));
     this->A = localA.get();
     clearCache();
+}
+
+template<typename ValueType>
+void NativeLinearEquationSolver<ValueType>::setUpViOperator() const {
+    if (!viOperator) {
+        viOperator = std::make_shared<helper::ValueIterationOperator<ValueType, true>>();
+        viOperator->setMatrixBackwards(*this->A);
+    }
 }
 
 template<typename ValueType>
@@ -351,46 +362,38 @@ typename NativeLinearEquationSolver<ValueType>::PowerIterationResult NativeLinea
 template<typename ValueType>
 bool NativeLinearEquationSolver<ValueType>::solveEquationsPower(Environment const& env, std::vector<ValueType>& x, std::vector<ValueType> const& b) const {
     STORM_LOG_INFO("Solving linear equation system (" << x.size() << " rows) with NativeLinearEquationSolver (Power)");
-
     // Prepare the solution vectors.
-    if (!this->cachedRowVector) {
-        this->cachedRowVector = std::make_unique<std::vector<ValueType>>(getMatrixRowCount());
-    }
-    if (!this->multiplier) {
-        this->multiplier = storm::solver::MultiplierFactory<ValueType>().create(env, *A);
-    }
-    std::vector<ValueType>* currentX = &x;
+    setUpViOperator();
+
     SolverGuarantee guarantee = SolverGuarantee::None;
     if (this->hasCustomTerminationCondition()) {
         if (this->getTerminationCondition().requiresGuarantee(SolverGuarantee::LessOrEqual) && this->hasLowerBound()) {
-            this->createLowerBoundsVector(*currentX);
+            this->createLowerBoundsVector(x);
             guarantee = SolverGuarantee::LessOrEqual;
         } else if (this->getTerminationCondition().requiresGuarantee(SolverGuarantee::GreaterOrEqual) && this->hasUpperBound()) {
-            this->createUpperBoundsVector(*currentX);
+            this->createUpperBoundsVector(x);
             guarantee = SolverGuarantee::GreaterOrEqual;
         }
     }
-    std::vector<ValueType>* newX = this->cachedRowVector.get();
 
-    // Forward call to power iteration implementation.
+    storm::solver::helper::ValueIterationHelper<ValueType, true> viHelper(viOperator);
+    uint64_t numIterations{0};
+    auto viCallback = [&](SolverStatus const& current) {
+        this->showProgressIterative(numIterations);
+        return this->updateStatus(current, x, guarantee, numIterations, env.solver().native().getMaximalNumberOfIterations());
+    };
     this->startMeasureProgress();
-    ValueType precision = storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision());
-    PowerIterationResult result =
-        this->performPowerIteration(env, currentX, newX, b, precision, env.solver().native().getRelativeTerminationCriterion(), guarantee, 0,
-                                    env.solver().native().getMaximalNumberOfIterations(), env.solver().native().getPowerMethodMultiplicationStyle());
+    auto status = viHelper.VI(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(),
+                              storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision()), {}, viCallback,
+                              env.solver().native().getPowerMethodMultiplicationStyle());
 
-    // Swap the result in place.
-    if (currentX == this->cachedRowVector.get()) {
-        std::swap(x, *newX);
-    }
+    this->reportStatus(status, numIterations);
 
     if (!this->isCachingEnabled()) {
         clearCache();
     }
 
-    this->logIterations(result.status == SolverStatus::Converged, result.status == SolverStatus::TerminatedEarly, result.iterations);
-
-    return result.status == SolverStatus::Converged || result.status == SolverStatus::TerminatedEarly;
+    return status == SolverStatus::Converged || status == SolverStatus::TerminatedEarly;
 }
 
 template<typename ValueType>
@@ -424,229 +427,75 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsIntervalIteration(Envi
     STORM_LOG_THROW(this->hasLowerBound(), storm::exceptions::UnmetRequirementException, "Solver requires lower bound, but none was given.");
     STORM_LOG_THROW(this->hasUpperBound(), storm::exceptions::UnmetRequirementException, "Solver requires upper bound, but none was given.");
     STORM_LOG_INFO("Solving linear equation system (" << x.size() << " rows) with NativeLinearEquationSolver (IntervalIteration)");
+    setUpViOperator();
+    helper::IntervalIterationHelper<ValueType, true> iiHelper(viOperator);
+    auto prec = storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision());
+    auto lowerBoundsCallback = [&](std::vector<ValueType>& vector) { this->createLowerBoundsVector(vector); };
+    auto upperBoundsCallback = [&](std::vector<ValueType>& vector) { this->createUpperBoundsVector(vector); };
 
-    std::vector<ValueType>* lowerX = &x;
-    this->createLowerBoundsVector(*lowerX);
-    this->createUpperBoundsVector(this->cachedRowVector, this->getMatrixRowCount());
-    std::vector<ValueType>* upperX = this->cachedRowVector.get();
-
-    bool useGaussSeidelMultiplication = env.solver().native().getPowerMethodMultiplicationStyle() == storm::solver::MultiplicationStyle::GaussSeidel;
-    std::vector<ValueType>* tmp;
-    if (!useGaussSeidelMultiplication) {
-        cachedRowVector2 = std::make_unique<std::vector<ValueType>>(x.size());
-        tmp = cachedRowVector2.get();
+    uint64_t numIterations{0};
+    auto iiCallback = [&](helper::IIData<ValueType> const& data) {
+        this->showProgressIterative(numIterations);
+        bool terminateEarly = this->hasCustomTerminationCondition() && this->getTerminationCondition().terminateNow(data.x, SolverGuarantee::LessOrEqual) &&
+                              this->getTerminationCondition().terminateNow(data.y, SolverGuarantee::GreaterOrEqual);
+        return this->updateStatus(data.status, terminateEarly, numIterations, env.solver().native().getMaximalNumberOfIterations());
+    };
+    std::optional<storm::storage::BitVector> optionalRelevantValues;
+    if (this->hasRelevantValues()) {
+        optionalRelevantValues = this->getRelevantValues();
     }
-
-    if (!this->multiplier) {
-        this->multiplier = storm::solver::MultiplierFactory<ValueType>().create(env, *A);
-    }
-
-    SolverStatus status = SolverStatus::InProgress;
-    uint64_t iterations = 0;
-    bool doConvergenceCheck = true;
-    bool useDiffs = this->hasRelevantValues() && !env.solver().native().isSymmetricUpdatesSet();
-    std::vector<ValueType> oldValues;
-    if (useGaussSeidelMultiplication && useDiffs) {
-        oldValues.resize(this->getRelevantValues().getNumberOfSetBits());
-    }
-    ValueType maxLowerDiff = storm::utility::zero<ValueType>();
-    ValueType maxUpperDiff = storm::utility::zero<ValueType>();
-    ValueType precision = storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision());
-    bool relative = env.solver().native().getRelativeTerminationCriterion();
-    if (!relative) {
-        precision *= storm::utility::convertNumber<ValueType>(2.0);
-    }
-    uint64_t maxIter = env.solver().native().getMaximalNumberOfIterations();
     this->startMeasureProgress();
-    while (status == SolverStatus::InProgress && iterations < maxIter) {
-        // Remember in which directions we took steps in this iteration.
-        bool lowerStep = false;
-        bool upperStep = false;
-
-        // In every thousandth iteration or if the differences are the same, we improve both bounds.
-        if (iterations % 1000 == 0 || maxLowerDiff == maxUpperDiff) {
-            lowerStep = true;
-            upperStep = true;
-            if (useGaussSeidelMultiplication) {
-                if (useDiffs) {
-                    preserveOldRelevantValues(*lowerX, this->getRelevantValues(), oldValues);
-                }
-                this->multiplier->multiplyGaussSeidel(env, *lowerX, &b);
-                if (useDiffs) {
-                    maxLowerDiff = computeMaxAbsDiff(*lowerX, this->getRelevantValues(), oldValues);
-                    preserveOldRelevantValues(*upperX, this->getRelevantValues(), oldValues);
-                }
-                this->multiplier->multiplyGaussSeidel(env, *upperX, &b);
-                if (useDiffs) {
-                    maxUpperDiff = computeMaxAbsDiff(*upperX, this->getRelevantValues(), oldValues);
-                }
-            } else {
-                this->multiplier->multiply(env, *lowerX, &b, *tmp);
-                if (useDiffs) {
-                    maxLowerDiff = computeMaxAbsDiff(*lowerX, *tmp, this->getRelevantValues());
-                }
-                std::swap(tmp, lowerX);
-                this->multiplier->multiply(env, *upperX, &b, *tmp);
-                if (useDiffs) {
-                    maxUpperDiff = computeMaxAbsDiff(*upperX, *tmp, this->getRelevantValues());
-                }
-                std::swap(tmp, upperX);
-            }
-        } else {
-            // In the following iterations, we improve the bound with the greatest difference.
-            if (useGaussSeidelMultiplication) {
-                if (maxLowerDiff >= maxUpperDiff) {
-                    if (useDiffs) {
-                        preserveOldRelevantValues(*lowerX, this->getRelevantValues(), oldValues);
-                    }
-                    this->multiplier->multiplyGaussSeidel(env, *lowerX, &b);
-                    if (useDiffs) {
-                        maxLowerDiff = computeMaxAbsDiff(*lowerX, this->getRelevantValues(), oldValues);
-                    }
-                    lowerStep = true;
-                } else {
-                    if (useDiffs) {
-                        preserveOldRelevantValues(*upperX, this->getRelevantValues(), oldValues);
-                    }
-                    this->multiplier->multiplyGaussSeidel(env, *upperX, &b);
-                    if (useDiffs) {
-                        maxUpperDiff = computeMaxAbsDiff(*upperX, this->getRelevantValues(), oldValues);
-                    }
-                    upperStep = true;
-                }
-            } else {
-                if (maxLowerDiff >= maxUpperDiff) {
-                    this->multiplier->multiply(env, *lowerX, &b, *tmp);
-                    if (useDiffs) {
-                        maxLowerDiff = computeMaxAbsDiff(*lowerX, *tmp, this->getRelevantValues());
-                    }
-                    std::swap(tmp, lowerX);
-                    lowerStep = true;
-                } else {
-                    this->multiplier->multiply(env, *upperX, &b, *tmp);
-                    if (useDiffs) {
-                        maxUpperDiff = computeMaxAbsDiff(*upperX, *tmp, this->getRelevantValues());
-                    }
-                    std::swap(tmp, upperX);
-                    upperStep = true;
-                }
-            }
-        }
-        STORM_LOG_ASSERT(maxLowerDiff >= storm::utility::zero<ValueType>(), "Expected non-negative lower diff.");
-        STORM_LOG_ASSERT(maxUpperDiff >= storm::utility::zero<ValueType>(), "Expected non-negative upper diff.");
-        if (iterations % 1000 == 0) {
-            STORM_LOG_TRACE("Iteration " << iterations << ": lower difference: " << maxLowerDiff << ", upper difference: " << maxUpperDiff << ".");
-        }
-
-        if (doConvergenceCheck) {
-            // Now check if the process already converged within our precision. Note that we double the target
-            // precision here. Doing so, we need to take the means of the lower and upper values later to guarantee
-            // the original precision.
-            if (this->hasRelevantValues()) {
-                if (storm::utility::vector::equalModuloPrecision<ValueType>(*lowerX, *upperX, this->getRelevantValues(), precision, relative)) {
-                    status = SolverStatus::Converged;
-                }
-            } else {
-                if (storm::utility::vector::equalModuloPrecision<ValueType>(*lowerX, *upperX, precision, relative)) {
-                    status = SolverStatus::Converged;
-                }
-            }
-            if (lowerStep && this->terminateNow(*lowerX, SolverGuarantee::LessOrEqual)) {
-                status = SolverStatus::TerminatedEarly;
-            }
-            if (upperStep && this->terminateNow(*upperX, SolverGuarantee::GreaterOrEqual)) {
-                status = SolverStatus::TerminatedEarly;
-            }
-        }
-
-        // Potentially show progress.
-        this->showProgressIterative(iterations);
-
-        // Set up next iteration.
-        ++iterations;
-        doConvergenceCheck = !doConvergenceCheck;
-        status = this->updateStatus(status, false, iterations, maxIter);
-    }
-
-    // We take the means of the lower and upper bound so we guarantee the desired precision.
-    storm::utility::vector::applyPointwise(
-        *lowerX, *upperX, *lowerX, [](ValueType const& a, ValueType const& b) -> ValueType { return (a + b) / storm::utility::convertNumber<ValueType>(2.0); });
-
-    // Since we shuffled the pointer around, we need to write the actual results to the input/output vector x.
-    if (&x == tmp) {
-        std::swap(x, *tmp);
-    } else if (&x == this->cachedRowVector.get()) {
-        std::swap(x, *this->cachedRowVector);
-    }
+    auto status = iiHelper.II(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(), prec, lowerBoundsCallback, upperBoundsCallback, {},
+                              iiCallback, optionalRelevantValues);
+    this->reportStatus(status, numIterations);
 
     if (!this->isCachingEnabled()) {
         clearCache();
     }
-    this->reportStatus(status, iterations);
 
-    return status == SolverStatus::Converged;
+    return status == SolverStatus::Converged || status == SolverStatus::TerminatedEarly;
 }
 
 template<typename ValueType>
 bool NativeLinearEquationSolver<ValueType>::solveEquationsSoundValueIteration(Environment const& env, std::vector<ValueType>& x,
                                                                               std::vector<ValueType> const& b) const {
     // Prepare the solution vectors and the helper.
-    assert(x.size() == this->A->getRowCount());
-    if (!this->cachedRowVector) {
-        this->cachedRowVector = std::make_unique<std::vector<ValueType>>();
-    }
-    if (!this->soundValueIterationHelper) {
-        this->soundValueIterationHelper = std::make_unique<storm::solver::helper::SoundValueIterationHelper<ValueType>>(
-            *this->A, x, *this->cachedRowVector, env.solver().native().getRelativeTerminationCriterion(),
-            storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision()));
-    } else {
-        this->soundValueIterationHelper = std::make_unique<storm::solver::helper::SoundValueIterationHelper<ValueType>>(
-            std::move(*this->soundValueIterationHelper), x, *this->cachedRowVector, env.solver().native().getRelativeTerminationCriterion(),
-            storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision()));
-    }
+    assert(x.size() == this->A->getRowGroupCount());
 
-    // Prepare initial bounds for the solution (if given)
+    std::optional<ValueType> lowerBound, upperBound;
     if (this->hasLowerBound()) {
-        this->soundValueIterationHelper->setLowerBound(this->getLowerBound(true));
+        lowerBound = this->getLowerBound(true);
     }
     if (this->hasUpperBound()) {
-        this->soundValueIterationHelper->setUpperBound(this->getUpperBound(true));
+        upperBound = this->getUpperBound(true);
     }
 
-    storm::storage::BitVector const* relevantValuesPtr = nullptr;
+    setUpViOperator();
+
+    auto precision = storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision());
+    uint64_t numIterations{0};
+    auto sviCallback = [&](typename helper::SoundValueIterationHelper<ValueType, true>::SVIData const& current) {
+        this->showProgressIterative(numIterations);
+        return this->updateStatus(current.status,
+                                  this->hasCustomTerminationCondition() && current.checkCustomTerminationCondition(this->getTerminationCondition()),
+                                  numIterations, env.solver().native().getMaximalNumberOfIterations());
+    };
+    std::optional<storm::storage::BitVector> optionalRelevantValues;
     if (this->hasRelevantValues()) {
-        relevantValuesPtr = &this->getRelevantValues();
+        optionalRelevantValues = this->getRelevantValues();
     }
-
-    SolverStatus status = SolverStatus::InProgress;
     this->startMeasureProgress();
-    uint64_t iterations = 0;
+    helper::SoundValueIterationHelper<ValueType, true> sviHelper(viOperator);
+    auto status = sviHelper.SVI(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(), precision, {}, lowerBound, upperBound,
+                                sviCallback, optionalRelevantValues);
 
-    while (status == SolverStatus::InProgress && iterations < env.solver().native().getMaximalNumberOfIterations()) {
-        this->soundValueIterationHelper->performIterationStep(b);
-        if (this->soundValueIterationHelper->checkConvergenceUpdateBounds(relevantValuesPtr)) {
-            status = SolverStatus::Converged;
-        }
-
-        // Update environment variables.
-        ++iterations;
-
-        // Potentially show progress.
-        this->showProgressIterative(iterations);
-
-        status = this->updateStatus(
-            status, this->hasCustomTerminationCondition() && this->soundValueIterationHelper->checkCustomTerminationCondition(this->getTerminationCondition()),
-            iterations, env.solver().native().getMaximalNumberOfIterations());
-    }
-    this->soundValueIterationHelper->setSolutionVector();
-
-    this->reportStatus(status, iterations);
+    this->reportStatus(status, numIterations);
 
     if (!this->isCachingEnabled()) {
         clearCache();
     }
 
-    return status == SolverStatus::Converged;
+    return status == SolverStatus::Converged || status == SolverStatus::TerminatedEarly;
 }
 
 template<typename ValueType>
@@ -658,330 +507,72 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsOptimisticValueIterati
         return true;
     }
 
-    if (!this->cachedRowVector) {
-        this->cachedRowVector = std::make_unique<std::vector<ValueType>>(this->A->getRowCount());
-    }
-    if (!optimisticValueIterationHelper) {
-        optimisticValueIterationHelper = std::make_unique<storm::solver::helper::OptimisticValueIterationHelper<ValueType>>(*this->A);
-    }
+    setUpViOperator();
 
-    // x has to start with a lower bound.
+    helper::OptimisticValueIterationHelper<ValueType, true> oviHelper(viOperator);
+    auto prec = storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision());
+    std::optional<ValueType> lowerBound, upperBound;
+    if (this->hasLowerBound()) {
+        lowerBound = this->getLowerBound(true);
+    }
+    if (this->hasUpperBound()) {
+        upperBound = this->getUpperBound(true);
+    }
+    uint64_t numIterations{0};
+    auto oviCallback = [&](SolverStatus const& current, std::vector<ValueType> const& v) {
+        this->showProgressIterative(numIterations);
+        return this->updateStatus(current, v, SolverGuarantee::LessOrEqual, numIterations, env.solver().native().getMaximalNumberOfIterations());
+    };
     this->createLowerBoundsVector(x);
-
-    std::vector<ValueType>* lowerX = &x;
-    std::vector<ValueType>* upperX = this->cachedRowVector.get();
-
-    storm::solver::helper::OptimisticValueIterationHelper<ValueType> helper(*this->A);
-    auto statusIters = helper.solveEquations(env, lowerX, upperX, b, env.solver().native().getRelativeTerminationCriterion(),
-                                             storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision()),
-                                             env.solver().native().getMaximalNumberOfIterations(),
-                                             boost::none,  // No optimization dir
-                                             this->getOptionalRelevantValues());
-    auto two = storm::utility::convertNumber<ValueType>(2.0);
-    storm::utility::vector::applyPointwise<ValueType, ValueType, ValueType>(
-        *lowerX, *upperX, x, [&two](ValueType const& a, ValueType const& b) -> ValueType { return (a + b) / two; });
-    this->logIterations(statusIters.first == SolverStatus::Converged, statusIters.first == SolverStatus::TerminatedEarly, statusIters.second);
+    std::optional<ValueType> guessingFactor;
+    if (env.solver().ovi().getUpperBoundGuessingFactor()) {
+        guessingFactor = storm::utility::convertNumber<ValueType>(*env.solver().ovi().getUpperBoundGuessingFactor());
+    }
+    this->startMeasureProgress();
+    auto status = oviHelper.OVI(x, b, env.solver().native().getRelativeTerminationCriterion(), prec, {}, guessingFactor, lowerBound, upperBound, oviCallback);
+    this->reportStatus(status, numIterations);
 
     if (!this->isCachingEnabled()) {
         clearCache();
     }
-    return statusIters.first == SolverStatus::Converged || statusIters.first == SolverStatus::TerminatedEarly;
-}
-
-template<typename ValueType>
-bool NativeLinearEquationSolver<ValueType>::solveEquationsRationalSearch(Environment const& env, std::vector<ValueType>& x,
-                                                                         std::vector<ValueType> const& b) const {
-    return solveEquationsRationalSearchHelper<double>(env, x, b);
-}
-
-template<typename RationalType, typename ImpreciseType>
-struct TemporaryHelper {
-    static std::vector<RationalType>* getTemporary(std::vector<RationalType>& rationalX, std::vector<ImpreciseType>*& currentX,
-                                                   std::vector<ImpreciseType>*& newX) {
-        return &rationalX;
-    }
-
-    static void swapSolutions(std::vector<RationalType>& rationalX, std::vector<RationalType>*& rationalSolution, std::vector<ImpreciseType>& x,
-                              std::vector<ImpreciseType>*& currentX, std::vector<ImpreciseType>*& newX) {
-        // Nothing to do.
-    }
-};
-
-template<typename RationalType>
-struct TemporaryHelper<RationalType, RationalType> {
-    static std::vector<RationalType>* getTemporary(std::vector<RationalType>& rationalX, std::vector<RationalType>*& currentX,
-                                                   std::vector<RationalType>*& newX) {
-        return newX;
-    }
-
-    static void swapSolutions(std::vector<RationalType>& rationalX, std::vector<RationalType>*& rationalSolution, std::vector<RationalType>& x,
-                              std::vector<RationalType>*& currentX, std::vector<RationalType>*& newX) {
-        if (&rationalX == rationalSolution) {
-            // In this case, the rational solution is in place.
-
-            // However, since the rational solution is no alias to current x, the imprecise solution is stored
-            // in current x and and rational x is not an alias to x, we can swap the contents of currentX to x.
-            std::swap(x, *currentX);
-        } else {
-            // Still, we may assume that the rational solution is not current x and is therefore new x.
-            std::swap(rationalX, *rationalSolution);
-            std::swap(x, *currentX);
-        }
-    }
-};
-
-template<typename ValueType>
-template<typename RationalType, typename ImpreciseType>
-bool NativeLinearEquationSolver<ValueType>::solveEquationsRationalSearchHelper(
-    Environment const& env, NativeLinearEquationSolver<ImpreciseType> const& impreciseSolver, storm::storage::SparseMatrix<RationalType> const& rationalA,
-    std::vector<RationalType>& rationalX, std::vector<RationalType> const& rationalB, storm::storage::SparseMatrix<ImpreciseType> const& A,
-    std::vector<ImpreciseType>& x, std::vector<ImpreciseType> const& b, std::vector<ImpreciseType>& tmpX) const {
-    ValueType precision = storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision());
-    uint64_t maxIter = env.solver().native().getMaximalNumberOfIterations();
-    bool relative = env.solver().native().getRelativeTerminationCriterion();
-    auto multiplicationStyle = env.solver().native().getPowerMethodMultiplicationStyle();
-
-    std::vector<ImpreciseType> const* originalX = &x;
-
-    std::vector<ImpreciseType>* currentX = &x;
-    std::vector<ImpreciseType>* newX = &tmpX;
-
-    SolverStatus status = SolverStatus::InProgress;
-    uint64_t overallIterations = 0;
-    uint64_t valueIterationInvocations = 0;
-    impreciseSolver.startMeasureProgress();
-    while (status == SolverStatus::InProgress && overallIterations < maxIter) {
-        // Perform value iteration with the current precision.
-        typename NativeLinearEquationSolver<ImpreciseType>::PowerIterationResult result =
-            impreciseSolver.performPowerIteration(env, currentX, newX, b, storm::utility::convertNumber<ImpreciseType, ValueType>(precision), relative,
-                                                  SolverGuarantee::LessOrEqual, overallIterations, maxIter, multiplicationStyle);
-
-        // At this point, the result of the imprecise value iteration is stored in the (imprecise) current x.
-
-        ++valueIterationInvocations;
-        STORM_LOG_TRACE("Completed " << valueIterationInvocations << " power iteration invocations, the last one with precision " << precision
-                                     << " completed in " << result.iterations << " iterations.");
-
-        // Count the iterations.
-        overallIterations += result.iterations;
-
-        // Compute maximal precision until which to sharpen.
-        uint64_t p =
-            storm::utility::convertNumber<uint64_t>(storm::utility::ceil(storm::utility::log10<ValueType>(storm::utility::one<ValueType>() / precision)));
-
-        // Make sure that currentX and rationalX are not aliased.
-        std::vector<RationalType>* temporaryRational = TemporaryHelper<RationalType, ImpreciseType>::getTemporary(rationalX, currentX, newX);
-
-        // Sharpen solution and place it in the temporary rational.
-        bool foundSolution = sharpen(p, rationalA, *currentX, rationalB, *temporaryRational);
-
-        // After sharpen, if a solution was found, it is contained in the free rational.
-
-        if (foundSolution) {
-            status = SolverStatus::Converged;
-
-            TemporaryHelper<RationalType, ImpreciseType>::swapSolutions(rationalX, temporaryRational, x, currentX, newX);
-        } else {
-            // Increase the precision.
-            precision = precision / 10;
-        }
-        if (storm::utility::resources::isTerminate()) {
-            status = SolverStatus::Aborted;
-        }
-    }
-
-    // Swap the two vectors if the current result is not in the original x.
-    if (currentX != originalX) {
-        std::swap(x, tmpX);
-    }
-
-    if (status == SolverStatus::InProgress && overallIterations == maxIter) {
-        status = SolverStatus::MaximalIterationsExceeded;
-    }
-
-    this->logIterations(status == SolverStatus::Converged, status == SolverStatus::TerminatedEarly, overallIterations);
 
     return status == SolverStatus::Converged || status == SolverStatus::TerminatedEarly;
 }
 
 template<typename ValueType>
-template<typename ImpreciseType>
-typename std::enable_if<std::is_same<ValueType, ImpreciseType>::value && !NumberTraits<ValueType>::IsExact, bool>::type
-NativeLinearEquationSolver<ValueType>::solveEquationsRationalSearchHelper(Environment const& env, std::vector<ValueType>& x,
-                                                                          std::vector<ValueType> const& b) const {
-    // Version for when the overall value type is imprecise.
+bool NativeLinearEquationSolver<ValueType>::solveEquationsRationalSearch(Environment const& env, std::vector<ValueType>& x,
+                                                                         std::vector<ValueType> const& b) const {
+    // Set up two value iteration operators. One for exact and one for imprecise computations
+    setUpViOperator();
+    std::shared_ptr<helper::ValueIterationOperator<storm::RationalNumber, true>> exactOp;
+    std::shared_ptr<helper::ValueIterationOperator<double, true>> impreciseOp;
 
-    // Create a rational representation of the input so we can check for a proper solution later.
-    storm::storage::SparseMatrix<storm::RationalNumber> rationalA = this->A->template toValueType<storm::RationalNumber>();
-    std::vector<storm::RationalNumber> rationalX(x.size());
-    std::vector<storm::RationalNumber> rationalB = storm::utility::vector::convertNumericVector<storm::RationalNumber>(b);
-
-    if (!this->cachedRowVector) {
-        this->cachedRowVector = std::make_unique<std::vector<ValueType>>(this->A->getRowCount());
-    }
-    if (!this->multiplier) {
-        this->multiplier = storm::solver::MultiplierFactory<ValueType>().create(env, *A);
-    }
-
-    // Forward the call to the core rational search routine.
-    bool converged = solveEquationsRationalSearchHelper<storm::RationalNumber, ImpreciseType>(env, *this, rationalA, rationalX, rationalB, *this->A, x, b,
-                                                                                              *this->cachedRowVector);
-
-    // Translate back rational result to imprecise result.
-    auto targetIt = x.begin();
-    for (auto it = rationalX.begin(), ite = rationalX.end(); it != ite; ++it, ++targetIt) {
-        *targetIt = storm::utility::convertNumber<ValueType>(*it);
-    }
-
-    if (!this->isCachingEnabled()) {
-        this->clearCache();
-    }
-
-    return converged;
-}
-
-template<typename ValueType>
-template<typename ImpreciseType>
-typename std::enable_if<std::is_same<ValueType, ImpreciseType>::value && NumberTraits<ValueType>::IsExact, bool>::type
-NativeLinearEquationSolver<ValueType>::solveEquationsRationalSearchHelper(Environment const& env, std::vector<ValueType>& x,
-                                                                          std::vector<ValueType> const& b) const {
-    // Version for when the overall value type is exact and the same type is to be used for the imprecise part.
-
-    if (!this->cachedRowVector) {
-        this->cachedRowVector = std::make_unique<std::vector<ValueType>>(this->A->getRowCount());
-    }
-    if (!this->multiplier) {
-        this->multiplier = storm::solver::MultiplierFactory<ValueType>().create(env, *A);
-    }
-
-    // Forward the call to the core rational search routine.
-    bool converged = solveEquationsRationalSearchHelper<ValueType, ImpreciseType>(env, *this, *this->A, x, b, *this->A, *this->cachedRowVector, b, x);
-
-    if (!this->isCachingEnabled()) {
-        this->clearCache();
-    }
-
-    return converged;
-}
-
-template<typename ValueType>
-template<typename ImpreciseType>
-typename std::enable_if<!std::is_same<ValueType, ImpreciseType>::value, bool>::type NativeLinearEquationSolver<ValueType>::solveEquationsRationalSearchHelper(
-    Environment const& env, std::vector<ValueType>& x, std::vector<ValueType> const& b) const {
-    // Version for when the overall value type is exact and the imprecise one is not. We first try to solve the
-    // problem using the imprecise data type and fall back to the exact type as needed.
-
-    // Translate A to its imprecise version.
-    storm::storage::SparseMatrix<ImpreciseType> impreciseA = this->A->template toValueType<ImpreciseType>();
-
-    // Translate x to its imprecise version.
-    std::vector<ImpreciseType> impreciseX(x.size());
-    {
-        std::vector<ValueType> tmp(x.size());
-        this->createLowerBoundsVector(tmp);
-        auto targetIt = impreciseX.begin();
-        for (auto sourceIt = tmp.begin(); targetIt != impreciseX.end(); ++targetIt, ++sourceIt) {
-            *targetIt = storm::utility::convertNumber<ImpreciseType, ValueType>(*sourceIt);
-        }
-    }
-
-    // Create temporary storage for an imprecise x.
-    std::vector<ImpreciseType> impreciseTmpX(x.size());
-
-    // Translate b to its imprecise version.
-    std::vector<ImpreciseType> impreciseB(b.size());
-    auto targetIt = impreciseB.begin();
-    for (auto sourceIt = b.begin(); targetIt != impreciseB.end(); ++targetIt, ++sourceIt) {
-        *targetIt = storm::utility::convertNumber<ImpreciseType, ValueType>(*sourceIt);
-    }
-
-    // Create imprecise solver from the imprecise data.
-    NativeLinearEquationSolver<ImpreciseType> impreciseSolver;
-    impreciseSolver.setMatrix(impreciseA);
-    impreciseSolver.setCachingEnabled(true);
-    impreciseSolver.multiplier = storm::solver::MultiplierFactory<ImpreciseType>().create(env, impreciseA);
-
-    bool converged = false;
-    try {
-        // Forward the call to the core rational search routine.
-        converged = solveEquationsRationalSearchHelper<ValueType, ImpreciseType>(env, impreciseSolver, *this->A, x, b, impreciseA, impreciseX, impreciseB,
-                                                                                 impreciseTmpX);
-        impreciseSolver.clearCache();
-    } catch (storm::exceptions::PrecisionExceededException const& e) {
-        STORM_LOG_WARN("Precision of value type was exceeded, trying to recover by switching to rational arithmetic.");
-
-        if (!this->cachedRowVector) {
-            this->cachedRowVector = std::make_unique<std::vector<ValueType>>(this->A->getRowGroupCount());
-        }
-        if (!this->multiplier) {
-            this->multiplier = storm::solver::MultiplierFactory<ValueType>().create(env, *A);
-        }
-        // Translate the imprecise value iteration result to the one we are going to use from now on.
-        auto targetIt = this->cachedRowVector->begin();
-        for (auto it = impreciseX.begin(), ite = impreciseX.end(); it != ite; ++it, ++targetIt) {
-            *targetIt = storm::utility::convertNumber<ValueType>(*it);
-        }
-
-        // Get rid of the superfluous data structures.
-        impreciseX = std::vector<ImpreciseType>();
-        impreciseTmpX = std::vector<ImpreciseType>();
-        impreciseB = std::vector<ImpreciseType>();
-        impreciseA = storm::storage::SparseMatrix<ImpreciseType>();
-
-        // Forward the call to the core rational search routine, but now with our value type as the imprecise value type.
-        converged = solveEquationsRationalSearchHelper<ValueType, ValueType>(env, *this, *this->A, x, b, *this->A, *this->cachedRowVector, b, x);
-    }
-
-    if (!this->isCachingEnabled()) {
-        this->clearCache();
-    }
-
-    return converged;
-}
-
-template<typename ValueType>
-template<typename RationalType, typename ImpreciseType>
-bool NativeLinearEquationSolver<ValueType>::sharpen(uint64_t precision, storm::storage::SparseMatrix<RationalType> const& A,
-                                                    std::vector<ImpreciseType> const& x, std::vector<RationalType> const& b, std::vector<RationalType>& tmp) {
-    for (uint64_t p = 1; p <= precision; ++p) {
-        storm::utility::kwek_mehlhorn::sharpen(p, x, tmp);
-
-        if (NativeLinearEquationSolver<RationalType>::isSolution(A, tmp, b)) {
-            return true;
-        }
-    }
-    return false;
-}
-
-template<typename ValueType>
-bool NativeLinearEquationSolver<ValueType>::isSolution(storm::storage::SparseMatrix<ValueType> const& matrix, std::vector<ValueType> const& values,
-                                                       std::vector<ValueType> const& b) {
-    storm::utility::ConstantsComparator<ValueType> comparator;
-
-    auto valueIt = values.begin();
-    auto bIt = b.begin();
-    for (uint64_t row = 0; row < matrix.getRowCount(); ++row, ++valueIt, ++bIt) {
-        ValueType rowValue = *bIt + matrix.multiplyRowWithVector(row, values);
-
-        // If the value does not match the one in the values vector, the given vector is not a solution.
-        if (!comparator.isEqual(rowValue, *valueIt)) {
-            return false;
-        }
-    }
-
-    // Checked all values at this point.
-    return true;
-}
-
-template<typename ValueType>
-void NativeLinearEquationSolver<ValueType>::logIterations(bool converged, bool terminate, uint64_t iterations) const {
-    if (converged) {
-        STORM_LOG_INFO("Iterative solver converged in " << iterations << " iterations.");
-    } else if (terminate) {
-        STORM_LOG_INFO("Iterative solver terminated after " << iterations << " iterations.");
+    if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) {
+        exactOp = viOperator;
+        impreciseOp = std::make_shared<helper::ValueIterationOperator<double, true>>();
+        impreciseOp->setMatrixBackwards(this->A->template toValueType<double>());
     } else {
-        STORM_LOG_WARN("Iterative solver did not converge in " << iterations << " iterations.");
+        impreciseOp = viOperator;
+        exactOp = std::make_shared<helper::ValueIterationOperator<storm::RationalNumber, true>>();
+        exactOp->setMatrixBackwards(this->A->template toValueType<storm::RationalNumber>());
     }
+
+    storm::solver::helper::RationalSearchHelper<ValueType, storm::RationalNumber, double, true> rsHelper(exactOp, impreciseOp);
+    uint64_t numIterations{0};
+    auto rsCallback = [&](SolverStatus const& current) {
+        this->showProgressIterative(numIterations);
+        return this->updateStatus(current, x, SolverGuarantee::None, numIterations, env.solver().native().getMaximalNumberOfIterations());
+    };
+    this->startMeasureProgress();
+    auto status = rsHelper.RS(x, b, numIterations, storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision()), {}, rsCallback);
+
+    this->reportStatus(status, numIterations);
+
+    if (!this->isCachingEnabled()) {
+        clearCache();
+    }
+
+    return status == SolverStatus::Converged || status == SolverStatus::TerminatedEarly;
 }
 
 template<typename ValueType>
@@ -1068,11 +659,9 @@ LinearEquationSolverRequirements NativeLinearEquationSolver<ValueType>::getRequi
 template<typename ValueType>
 void NativeLinearEquationSolver<ValueType>::clearCache() const {
     jacobiDecomposition.reset();
-    cachedRowVector2.reset();
     walkerChaeData.reset();
     multiplier.reset();
-    soundValueIterationHelper.reset();
-    optimisticValueIterationHelper.reset();
+    viOperator.reset();
     LinearEquationSolver<ValueType>::clearCache();
 }
 
@@ -1087,7 +676,7 @@ uint64_t NativeLinearEquationSolver<ValueType>::getMatrixColumnCount() const {
 }
 
 template<typename ValueType>
-std::unique_ptr<storm::solver::LinearEquationSolver<ValueType>> NativeLinearEquationSolverFactory<ValueType>::create(Environment const& env) const {
+std::unique_ptr<storm::solver::LinearEquationSolver<ValueType>> NativeLinearEquationSolverFactory<ValueType>::create(Environment const&) const {
     return std::make_unique<storm::solver::NativeLinearEquationSolver<ValueType>>();
 }
 

--- a/src/storm/solver/OptimizationDirection.cpp
+++ b/src/storm/solver/OptimizationDirection.cpp
@@ -9,14 +9,6 @@ bool isSet(OptimizationDirectionSetting s) {
     return s != OptimizationDirectionSetting::Unset;
 }
 
-bool minimize(OptimizationDirection d) {
-    return d == OptimizationDirection::Minimize;
-}
-
-bool maximize(OptimizationDirection d) {
-    return d == OptimizationDirection::Maximize;
-}
-
 OptimizationDirection convert(OptimizationDirectionSetting s) {
     STORM_LOG_ASSERT(isSet(s), "Setting is not set.");
     return static_cast<OptimizationDirection>(s);
@@ -24,10 +16,6 @@ OptimizationDirection convert(OptimizationDirectionSetting s) {
 
 OptimizationDirectionSetting convert(OptimizationDirection d) {
     return static_cast<OptimizationDirectionSetting>(d);
-}
-
-OptimizationDirection invert(OptimizationDirection d) {
-    return d == OptimizationDirection::Minimize ? OptimizationDirection::Maximize : OptimizationDirection::Minimize;
 }
 
 std::ostream& operator<<(std::ostream& out, OptimizationDirection d) {

--- a/src/storm/solver/OptimizationDirection.h
+++ b/src/storm/solver/OptimizationDirection.h
@@ -6,21 +6,25 @@
 namespace storm {
 namespace solver {
 enum class OptimizationDirection { Minimize = 0, Maximize = 1 };
+
+bool constexpr minimize(OptimizationDirection d) {
+    return d == OptimizationDirection::Minimize;
+}
+
+bool constexpr maximize(OptimizationDirection d) {
+    return d == OptimizationDirection::Maximize;
+}
+
+OptimizationDirection constexpr invert(OptimizationDirection d) {
+    return d == OptimizationDirection::Minimize ? OptimizationDirection::Maximize : OptimizationDirection::Minimize;
+}
+std::ostream& operator<<(std::ostream& out, OptimizationDirection d);
+
 enum class OptimizationDirectionSetting { Minimize = 0, Maximize = 1, Unset };
-
 bool isSet(OptimizationDirectionSetting s);
-
-bool minimize(OptimizationDirection d);
-
-bool maximize(OptimizationDirection d);
-
 OptimizationDirection convert(OptimizationDirectionSetting s);
-
 OptimizationDirectionSetting convert(OptimizationDirection d);
 
-OptimizationDirection invert(OptimizationDirection d);
-
-std::ostream& operator<<(std::ostream& out, OptimizationDirection d);
 }  // namespace solver
 
 using OptimizationDirection = solver::OptimizationDirection;

--- a/src/storm/solver/TopologicalLinearEquationSolver.cpp
+++ b/src/storm/solver/TopologicalLinearEquationSolver.cpp
@@ -89,7 +89,12 @@ bool TopologicalLinearEquationSolver<ValueType>::internalSolveEquations(Environm
     // Handle the case where there is just one large SCC
     bool returnValue = true;
     if (this->sortedSccDecomposition->size() == 1) {
-        returnValue = solveFullyConnectedEquationSystem(sccSolverEnvironment, x, b);
+        if (auto const& scc = *this->sortedSccDecomposition->begin(); scc.size() == 1) {
+            // Catch the trivial case where the whole system is just a single state.
+            returnValue = solveTrivialScc(*scc.begin(), x, b);
+        } else {
+            returnValue = solveFullyConnectedEquationSystem(sccSolverEnvironment, x, b);
+        }
     } else {
         // Solve each SCC individually
         storm::storage::BitVector sccAsBitVector(x.size(), false);

--- a/src/storm/solver/helper/IntervalterationHelper.cpp
+++ b/src/storm/solver/helper/IntervalterationHelper.cpp
@@ -1,0 +1,171 @@
+#include "storm/solver/helper/IntervalterationHelper.h"
+
+#include <type_traits>
+
+#include "storm/adapters/RationalNumberAdapter.h"
+#include "storm/solver/helper/ValueIterationOperator.h"
+#include "storm/utility/Extremum.h"
+#include "storm/utility/constants.h"
+#include "storm/utility/vector.h"
+
+namespace storm::solver::helper {
+
+template<typename ValueType, bool TrivialRowGrouping>
+IntervalIterationHelper<ValueType, TrivialRowGrouping>::IntervalIterationHelper(
+    std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator)
+    : viOperator(viOperator) {
+    // Intentionally left empty.
+}
+
+template<typename ValueType, OptimizationDirection Dir>
+class IIBackend {
+   public:
+    void startNewIteration() {}
+
+    void firstRow(std::pair<ValueType, ValueType>&& value, [[maybe_unused]] uint64_t rowGroup, [[maybe_unused]] uint64_t row) {
+        xBest = std::move(value.first);
+        yBest = std::move(value.second);
+    }
+
+    void nextRow(std::pair<ValueType, ValueType>&& value, [[maybe_unused]] uint64_t rowGroup, [[maybe_unused]] uint64_t row) {
+        xBest &= std::move(value.first);
+        yBest &= std::move(value.second);
+    }
+
+    void applyUpdate(ValueType& xCurr, ValueType& yCurr, [[maybe_unused]] uint64_t rowGroup) {
+        xCurr = std::max(xCurr, *xBest);
+        yCurr = std::min(yCurr, *yBest);
+    }
+
+    void endOfIteration() const {
+        // intentionally left empty.
+    }
+
+    bool constexpr converged() const {
+        return false;
+    }
+
+    bool constexpr abort() const {
+        return false;
+    }
+
+   private:
+    storm::utility::Extremum<Dir, ValueType> xBest, yBest;
+};
+
+template<typename ValueType>
+bool checkConvergence(std::pair<std::vector<ValueType>, std::vector<ValueType>> const& xy, uint64_t& convergenceCheckState,
+                      std::function<void()> const& getNextConvergenceCheckState, bool relative, ValueType const& precision) {
+    if (relative) {
+        for (; convergenceCheckState < xy.first.size(); getNextConvergenceCheckState()) {
+            ValueType const& l = xy.first[convergenceCheckState];
+            ValueType const& u = xy.second[convergenceCheckState];
+            if (l > storm::utility::zero<ValueType>()) {
+                if ((u - l) > l * precision) {
+                    return false;
+                }
+            } else if (u < storm::utility::zero<ValueType>()) {
+                if ((l - u) < u * precision) {
+                    return false;
+                }
+            } else {  //  l <= 0 <= u
+                if (l != u) {
+                    return false;
+                }
+            }
+        }
+    } else {
+        for (; convergenceCheckState < xy.first.size(); getNextConvergenceCheckState()) {
+            if (xy.second[convergenceCheckState] - xy.first[convergenceCheckState] > precision) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+template<OptimizationDirection Dir>
+SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(std::pair<std::vector<ValueType>, std::vector<ValueType>>& xy,
+                                                                        std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative,
+                                                                        ValueType const& precision,
+                                                                        std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback,
+                                                                        std::optional<storm::storage::BitVector> const& relevantValues) const {
+    SolverStatus status{SolverStatus::InProgress};
+    IIBackend<ValueType, Dir> backend;
+    uint64_t convergenceCheckState = 0;
+    std::function<void()> getNextConvergenceCheckState;
+    if (relevantValues) {
+        convergenceCheckState = relevantValues->getNextSetIndex(0);
+        getNextConvergenceCheckState = [&convergenceCheckState, &relevantValues]() {
+            convergenceCheckState = relevantValues->getNextSetIndex(++convergenceCheckState);
+        };
+    } else {
+        getNextConvergenceCheckState = [&convergenceCheckState]() { ++convergenceCheckState; };
+    }
+    while (status == SolverStatus::InProgress) {
+        ++numIterations;
+        viOperator->template applyInPlace(xy, offsets, backend);
+        if (checkConvergence(xy, convergenceCheckState, getNextConvergenceCheckState, relative, precision)) {
+            status = SolverStatus::Converged;
+        } else if (iterationCallback) {
+            status = iterationCallback(IIData<ValueType>({xy.first, xy.second, status}));
+        }
+    }
+    return status;
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets,
+                                                                        uint64_t& numIterations, bool relative, ValueType const& precision,
+                                                                        std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds,
+                                                                        std::function<void(std::vector<ValueType>&)> const& prepareUpperBounds,
+                                                                        std::optional<storm::OptimizationDirection> const& dir,
+                                                                        std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback,
+                                                                        std::optional<storm::storage::BitVector> const& relevantValues) const {
+    // Create two vectors x and y using the given operand plus an auxiliary vector.
+    std::pair<std::vector<ValueType>, std::vector<ValueType>> xy;
+    auto& auxVector = viOperator->allocateAuxiliaryVector(operand.size());
+    xy.first.swap(operand);
+    xy.second.swap(auxVector);
+    prepareLowerBounds(xy.first);
+    prepareUpperBounds(xy.second);
+    auto doublePrec = precision + precision;
+    if constexpr (std::is_same_v<ValueType, double>) {
+        doublePrec -= precision * 1e-6;  // be slightly more precise to avoid a good chunk of floating point issues
+    }
+    SolverStatus status;
+    if (!dir.has_value() || maximize(*dir)) {
+        status = II<OptimizationDirection::Maximize>(xy, offsets, numIterations, relative, precision, iterationCallback, relevantValues);
+    } else {
+        status = II<OptimizationDirection::Minimize>(xy, offsets, numIterations, relative, precision, iterationCallback, relevantValues);
+    }
+    auto two = storm::utility::convertNumber<ValueType>(2.0);
+    // get the average of lower- and upper result
+    storm::utility::vector::applyPointwise<ValueType, ValueType, ValueType>(
+        xy.first, xy.second, xy.first, [&two](ValueType const& a, ValueType const& b) -> ValueType { return (a + b) / two; });
+    // Swap operand and aux vector back to original positions.
+    xy.first.swap(operand);
+    xy.second.swap(auxVector);
+    viOperator->freeAuxiliaryVector();
+    return status;
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative,
+                                                                        ValueType const& precision,
+                                                                        std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds,
+                                                                        std::function<void(std::vector<ValueType>&)> const& prepareUpperBounds,
+                                                                        std::optional<storm::OptimizationDirection> const& dir,
+                                                                        std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback,
+                                                                        std::optional<storm::storage::BitVector> const& relevantValues) const {
+    uint64_t numIterations = 0;
+    return II(operand, offsets, numIterations, relative, precision, prepareLowerBounds, prepareUpperBounds, dir, iterationCallback, relevantValues);
+}
+
+template class IntervalIterationHelper<double, true>;
+template class IntervalIterationHelper<double, false>;
+template class IntervalIterationHelper<storm::RationalNumber, true>;
+template class IntervalIterationHelper<storm::RationalNumber, false>;
+
+}  // namespace storm::solver::helper

--- a/src/storm/solver/helper/IntervalterationHelper.h
+++ b/src/storm/solver/helper/IntervalterationHelper.h
@@ -1,0 +1,52 @@
+#include <functional>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "storm/solver/OptimizationDirection.h"
+#include "storm/solver/SolverStatus.h"
+#include "storm/storage/BitVector.h"
+
+namespace storm::solver::helper {
+
+template<typename ValueType, bool TrivialRowGrouping>
+class ValueIterationOperator;
+
+template<typename ValueType>
+struct IIData {
+    std::vector<ValueType> const& x;
+    std::vector<ValueType> const& y;
+    SolverStatus const status;
+};
+
+/*!
+ * Implements interval iteration
+ * @see https://doi.org/10.1007/978-3-319-63387-9_8
+ */
+template<typename ValueType, bool TrivialRowGrouping>
+class IntervalIterationHelper {
+   public:
+    IntervalIterationHelper(std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator);
+
+    template<OptimizationDirection Dir>
+    SolverStatus II(std::pair<std::vector<ValueType>, std::vector<ValueType>>& xy, std::vector<ValueType> const& offsets, uint64_t& numIterations,
+                    bool relative, ValueType const& precision, std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback = {},
+                    std::optional<storm::storage::BitVector> const& relevantValues = {}) const;
+
+    SolverStatus II(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
+                    std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds,
+                    std::function<void(std::vector<ValueType>&)> const& prepareUpperBounds, std::optional<storm::OptimizationDirection> const& dir = {},
+                    std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback = {},
+                    std::optional<storm::storage::BitVector> const& relevantValues = {}) const;
+
+    SolverStatus II(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
+                    std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds,
+                    std::function<void(std::vector<ValueType>&)> const& prepareUpperBounds, std::optional<storm::OptimizationDirection> const& dir = {},
+                    std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback = {},
+                    std::optional<storm::storage::BitVector> const& relevantValues = {}) const;
+
+   private:
+    std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator;
+};
+
+}  // namespace storm::solver::helper

--- a/src/storm/solver/helper/OptimisticValueIterationHelper.h
+++ b/src/storm/solver/helper/OptimisticValueIterationHelper.h
@@ -1,105 +1,54 @@
 #pragma once
 
-#include <boost/optional.hpp>
+#include <functional>
+#include <memory>
+#include <optional>
 #include <vector>
-
-#include "storm/storage/SparseMatrix.h"
 
 #include "storm/solver/OptimizationDirection.h"
 #include "storm/solver/SolverStatus.h"
-#include "storm/storage/BitVector.h"
 
-namespace storm {
-class Environment;
+namespace storm::solver::helper {
 
-namespace solver {
-namespace helper {
-namespace oviinternal {
-
-template<typename ValueType>
-class IterationHelper {
-   public:
-    typedef uint32_t IndexType;
-    IterationHelper(storm::storage::SparseMatrix<ValueType> const& matrix);
-    enum class IterateResult { AlwaysHigherOrEqual, AlwaysLowerOrEqual, Equal, Incomparable };
-
-    /// performs a single iteration and returns the maximal difference between the iterations as well as the index where this difference happened
-    ValueType singleIterationWithDiff(std::vector<ValueType>& x, std::vector<ValueType> const& b, bool computeRelativeDiff,
-                                      boost::optional<storage::BitVector> const& schedulerFixedForRowgroup = boost::none,
-                                      boost::optional<std::vector<uint_fast64_t>> const& scheduler = boost::none);
-    ValueType singleIterationWithDiff(storm::solver::OptimizationDirection const& dir, std::vector<ValueType>& x, std::vector<ValueType> const& b,
-                                      bool computeRelativeDiff, boost::optional<storage::BitVector> const& schedulerFixedForRowgroup = boost::none,
-                                      boost::optional<std::vector<uint_fast64_t>> const& scheduler = boost::none);
-
-    /// returns the number of performed iterations
-    uint64_t repeatedIterate(std::vector<ValueType>& x, std::vector<ValueType> const& b, ValueType precision, bool relative,
-                             boost::optional<storage::BitVector> const& schedulerFixedForRowgroup = boost::none,
-                             boost::optional<std::vector<uint_fast64_t>> const& scheduler = boost::none);
-    uint64_t repeatedIterate(storm::solver::OptimizationDirection const& dir, std::vector<ValueType>& x, std::vector<ValueType> const& b, ValueType precision,
-                             bool relative, boost::optional<storage::BitVector> const& schedulerFixedForRowgroup = boost::none,
-                             boost::optional<std::vector<uint_fast64_t>> const& scheduler = boost::none);
-
-    /// Performs a single iteration for the upper bound
-    IterateResult iterateUpper(std::vector<ValueType>& x, std::vector<ValueType> const& b, bool takeMinOfOldAndNew,
-                               boost::optional<storage::BitVector> const& schedulerFixedForRowgroup = boost::none,
-                               boost::optional<std::vector<uint_fast64_t>> const& scheduler = boost::none);
-    IterateResult iterateUpper(storm::solver::OptimizationDirection const& dir, std::vector<ValueType>& x, std::vector<ValueType> const& b,
-                               bool takeMinOfOldAndNew, boost::optional<storage::BitVector> const& schedulerFixedForRowgroup = boost::none,
-                               boost::optional<std::vector<uint_fast64_t>> const& scheduler = boost::none);
-
-   private:
-    template<bool HasRowGroups, storm::solver::OptimizationDirection Dir>
-    ValueType singleIterationWithDiffInternal(std::vector<ValueType>& x, std::vector<ValueType> const& b, bool computeRelativeDiff,
-                                              boost::optional<storage::BitVector> const& schedulerFixedForRowgroup = boost::none,
-                                              boost::optional<std::vector<uint_fast64_t>> const& scheduler = boost::none);
-    template<bool HasRowGroups, storm::solver::OptimizationDirection Dir>
-    uint64_t repeatedIterateInternal(std::vector<ValueType>& x, std::vector<ValueType> const& b, ValueType precision, bool relative,
-                                     boost::optional<storage::BitVector> const& schedulerFixedForRowgroup = boost::none,
-                                     boost::optional<std::vector<uint_fast64_t>> const& scheduler = boost::none);
-    template<bool HasRowGroups, storm::solver::OptimizationDirection Dir>
-    IterateResult iterateUpperInternal(std::vector<ValueType>& x, std::vector<ValueType> const& b, bool takeMinOfOldAndNew,
-                                       boost::optional<storage::BitVector> const& schedulerFixedForRowgroup = boost::none,
-                                       boost::optional<std::vector<uint_fast64_t>> const& scheduler = boost::none);
-    ValueType multiplyRow(IndexType const& rowIndex, ValueType const& bi, std::vector<ValueType> const& x);
-    template<storm::solver::OptimizationDirection Dir>
-    ValueType multiplyRowGroup(IndexType const& rowGroupIndex, std::vector<ValueType> const& b, std::vector<ValueType> const& x);
-
-    std::vector<ValueType> matrixValues;
-    std::vector<IndexType> matrixColumns;
-    std::vector<IndexType> rowIndications;
-    std::vector<uint64_t> const* rowGroupIndices;
-};
-}  // namespace oviinternal
+template<typename ValueType, bool TrivialRowGrouping>
+class ValueIterationOperator;
 
 /*!
- * Performs Optimistic value iteration.
- * @see Hartmanns, Kaminski: Optimistic Value Iteration. https://doi.org/10.1007/978-3-030-53291-8\_26
+ * Implements Optimistic value iteration
+ * @see https://doi.org/10.1007/978-3-030-53291-8_26
  */
-template<typename ValueType>
+template<typename ValueType, bool TrivialRowGrouping>
 class OptimisticValueIterationHelper {
    public:
-    OptimisticValueIterationHelper(storm::storage::SparseMatrix<ValueType> const& matrix);
+    OptimisticValueIterationHelper(std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator);
 
-    /*!
-     * @param env
-     * @param lowerX Needs to be some arbitrary lower bound on the actual values initially
-     * @param upperX Does not need to be an upper bound initially
-     * @param b the values added to each matrix row (the b in A*x+b)
-     * @param dir The optimization direction
-     * @param relevantValues If given, we only check the precision at the states with the given indices.
-     * @return The status upon termination as well as the number of iterations Also, the maximum (relative/absolute) difference between lowerX and upperX will
-     * be 2*epsilon with the provided precision parameters.
-     */
-    std::pair<SolverStatus, uint64_t> solveEquations(Environment const& env, std::vector<ValueType>* lowerX, std::vector<ValueType>* upperX,
-                                                     std::vector<ValueType> const& b, bool relative, ValueType precision, uint64_t maxOverallIterations,
-                                                     boost::optional<storm::solver::OptimizationDirection> dir,
-                                                     boost::optional<storm::storage::BitVector> const& relevantValues,
-                                                     boost::optional<storage::BitVector> const& schedulerFixedForRowgroup = boost::none,
-                                                     boost::optional<std::vector<uint_fast64_t>> const& scheduler = boost::none);
+    template<OptimizationDirection Dir, bool Relative>
+    SolverStatus OVI(std::pair<std::vector<ValueType>, std::vector<ValueType>>& vu, std::vector<ValueType> const& offsets, uint64_t& numIterations,
+                     ValueType const& precision, ValueType const& guessValue, std::optional<ValueType> const& lowerBound = {},
+                     std::optional<ValueType> const& upperBound = {},
+                     std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {}) const;
+
+    SolverStatus OVI(std::pair<std::vector<ValueType>, std::vector<ValueType>>& vu, std::vector<ValueType> const& offsets, uint64_t& numIterations,
+                     bool relative, ValueType const& precision, std::optional<storm::OptimizationDirection> const& dir, ValueType const& guessValue,
+                     std::optional<ValueType> const& lowerBound = {}, std::optional<ValueType> const& upperBound = {},
+                     std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {}) const;
+
+    SolverStatus OVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
+                     std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& guessValue = {},
+                     std::optional<ValueType> const& lowerBound = {}, std::optional<ValueType> const& upperBound = {},
+                     std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {}) const;
+
+    SolverStatus OVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
+                     std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& guessValue = {},
+                     std::optional<ValueType> const& lowerBound = {}, std::optional<ValueType> const& upperBound = {},
+                     std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {}) const;
 
    private:
-    oviinternal::IterationHelper<ValueType> iterationHelper;
+    template<storm::OptimizationDirection Dir, bool Relative>
+    SolverStatus GSVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, ValueType const& precision,
+                      std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {}) const;
+
+    std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator;
 };
-}  // namespace helper
-}  // namespace solver
-}  // namespace storm
+
+}  // namespace storm::solver::helper

--- a/src/storm/solver/helper/RationalSearchHelper.cpp
+++ b/src/storm/solver/helper/RationalSearchHelper.cpp
@@ -1,0 +1,192 @@
+#include "storm/solver/helper/RationalSearchHelper.h"
+
+#include "storm/adapters/RationalNumberAdapter.h"
+#include "storm/solver/helper/ValueIterationHelper.h"
+#include "storm/solver/helper/ValueIterationOperator.h"
+#include "storm/utility/Extremum.h"
+#include "storm/utility/KwekMehlhorn.h"
+
+namespace storm::solver::helper {
+
+template<typename TargetValueType, typename ExactValueType, typename ImpreciseValueType, bool TrivialRowGrouping>
+RationalSearchHelper<TargetValueType, ExactValueType, ImpreciseValueType, TrivialRowGrouping>::RationalSearchHelper(
+    std::shared_ptr<ValueIterationOperator<ExactValueType, TrivialRowGrouping>> exactViOperator,
+    std::shared_ptr<ValueIterationOperator<ImpreciseValueType, TrivialRowGrouping>> impreciseViOperator)
+    : exactOperator(exactViOperator), impreciseOperator(impreciseViOperator) {
+    // Intentionally left empty
+}
+
+template<typename ValueType, typename ExactValueType, storm::OptimizationDirection Dir>
+class RSBackend {
+   public:
+    void startNewIteration() {
+        allEqual = true;
+    }
+
+    void firstRow(ExactValueType&& value, [[maybe_unused]] uint64_t rowGroup, [[maybe_unused]] uint64_t row) {
+        best = std::move(value);
+    }
+
+    void nextRow(ExactValueType&& value, [[maybe_unused]] uint64_t rowGroup, [[maybe_unused]] uint64_t row) {
+        best &= value;
+    }
+
+    void applyUpdate(ExactValueType& currValue, [[maybe_unused]] uint64_t rowGroup) {
+        if (currValue != *best) {
+            allEqual = false;
+        }
+    }
+
+    void endOfIteration() const {
+        // intentionally left empty.
+    }
+
+    bool converged() const {
+        return allEqual;
+    }
+
+    bool constexpr abort() const {
+        return !allEqual;
+    }
+
+   private:
+    storm::utility::Extremum<Dir, ExactValueType> best;
+    bool allEqual{true};
+};
+
+template<typename TargetValueType, typename ExactValueType, typename ImpreciseValueType, bool TrivialRowGrouping>
+template<typename ValueType, storm::OptimizationDirection Dir>
+RSResult RationalSearchHelper<TargetValueType, ExactValueType, ImpreciseValueType, TrivialRowGrouping>::sharpen(uint64_t precision,
+                                                                                                                std::vector<ValueType> const& operand,
+                                                                                                                std::vector<ExactValueType> const& exactOffsets,
+                                                                                                                std::vector<TargetValueType>& target) const {
+    RSBackend<ValueType, ExactValueType, Dir> backend;
+    auto& sharpOperand = exactOperator->allocateAuxiliaryVector(operand.size());
+
+    for (uint64_t p = 0; p <= precision; ++p) {
+        // If we need an exact computation but are currently using imprecise values, we might need to consider switching to precise values
+        if (std::is_same_v<ExactValueType, TargetValueType> && std::is_same_v<ValueType, ImpreciseValueType> &&
+            p > std::numeric_limits<ImpreciseValueType>::max_digits10) {
+            exactOperator->freeAuxiliaryVector();
+            return RSResult::PrecisionExceeded;
+        }
+        storm::utility::kwek_mehlhorn::sharpen(p, operand, sharpOperand);
+
+        if (exactOperator->applyInPlace(sharpOperand, exactOffsets, backend)) {
+            // Put the solution into the target vector
+            if constexpr (std::is_same_v<ExactValueType, TargetValueType>) {
+                target.swap(sharpOperand);
+            } else {
+                target.resize(sharpOperand.size());
+                storm::utility::vector::convertNumericVector(sharpOperand, target);
+            }
+            exactOperator->freeAuxiliaryVector();
+            return RSResult::Converged;
+        }
+    }
+    exactOperator->freeAuxiliaryVector();
+    return RSResult::InProgress;
+}
+
+template<typename TargetValueType, typename ExactValueType, typename ImpreciseValueType, bool TrivialRowGrouping>
+template<typename ValueType>
+std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> const&
+RationalSearchHelper<TargetValueType, ExactValueType, ImpreciseValueType, TrivialRowGrouping>::getOperator() const {
+    if constexpr (std::is_same_v<ValueType, ExactValueType>) {
+        return exactOperator;
+    } else {
+        return impreciseOperator;
+    }
+}
+
+template<typename TargetValueType, typename ExactValueType, typename ImpreciseValueType, bool TrivialRowGrouping>
+template<typename ValueType, storm::OptimizationDirection Dir>
+std::pair<RSResult, SolverStatus> RationalSearchHelper<TargetValueType, ExactValueType, ImpreciseValueType, TrivialRowGrouping>::RS(
+    std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, ExactValueType precision,
+    std::vector<ExactValueType> const& exactOffsets, std::vector<TargetValueType>& target,
+    std::function<SolverStatus(SolverStatus const&)> const& iterationCallback) const {
+    ValueIterationHelper<ValueType, TrivialRowGrouping> viHelper(getOperator<ValueType>());
+    SolverStatus status{SolverStatus::InProgress};
+    RSResult result{RSResult::InProgress};
+    while (status == SolverStatus::InProgress) {
+        auto viStatus = viHelper.VI(operand, offsets, numIterations, false, storm::utility::convertNumber<ValueType>(precision), Dir, iterationCallback);
+
+        // Compute maximal precision until which to sharpen.
+        auto p = storm::utility::convertNumber<uint64_t>(
+            storm::utility::ceil(storm::utility::log10<ExactValueType>(storm::utility::one<ExactValueType>() / precision)));
+
+        // check if the sharpened vector is the desired solution.
+        result = sharpen<ValueType, Dir>(p, operand, exactOffsets, target);
+        switch (result) {
+            case RSResult::Converged:
+                status = SolverStatus::Converged;
+                break;
+            case RSResult::InProgress:
+                if (viStatus != SolverStatus::Converged) {
+                    status = viStatus;
+                } else {
+                    // Increase the precision.
+                    precision /= storm::utility::convertNumber<ExactValueType>(static_cast<uint64_t>(10));
+                }
+                break;
+            case RSResult::PrecisionExceeded:
+                status = SolverStatus::Aborted;
+                break;
+        }
+    }
+    return std::pair(result, status);
+}
+
+template<typename TargetValueType, typename ExactValueType, typename ImpreciseValueType, bool TrivialRowGrouping>
+template<storm::OptimizationDirection Dir>
+SolverStatus RationalSearchHelper<TargetValueType, ExactValueType, ImpreciseValueType, TrivialRowGrouping>::RS(
+    std::vector<TargetValueType>& operand, std::vector<TargetValueType> const& offsets, uint64_t& numIterations, TargetValueType const& precision,
+    std::function<SolverStatus(SolverStatus const&)> const& iterationCallback) const {
+    if constexpr (std::is_same_v<TargetValueType, ExactValueType>) {
+        // We need an exact solution
+        // We first try to solve the problem using imprecise values and fall back to exact values if needed.
+        auto& impreciseOperand = impreciseOperator->allocateAuxiliaryVector(operand.size());
+        storm::utility::vector::convertNumericVector(operand, impreciseOperand);
+        auto impreciseOffsets = storm::utility::vector::convertNumericVector<ImpreciseValueType>(offsets);
+        auto [result, status] = RS<ImpreciseValueType, Dir>(impreciseOperand, impreciseOffsets, numIterations, precision, offsets, operand, iterationCallback);
+        if (result != RSResult::PrecisionExceeded) {
+            return status;
+        }
+        STORM_LOG_WARN("Precision of value type was exceeded, trying to recover by switching to rational arithmetic.");
+        storm::utility::vector::convertNumericVector(impreciseOperand, operand);
+        return RS<TargetValueType, Dir>(operand, offsets, numIterations, precision, offsets, operand, iterationCallback).second;
+    } else {
+        // We only try with the inexact type
+        auto exactOffsets = storm::utility::vector::convertNumericVector<ExactValueType>(offsets);
+        return RS<TargetValueType, Dir>(operand, offsets, numIterations, storm::utility::convertNumber<ExactValueType>(precision), exactOffsets, operand,
+                                        iterationCallback)
+            .second;
+    }
+}
+
+template<typename TargetValueType, typename ExactValueType, typename ImpreciseValueType, bool TrivialRowGrouping>
+SolverStatus RationalSearchHelper<TargetValueType, ExactValueType, ImpreciseValueType, TrivialRowGrouping>::RS(
+    std::vector<TargetValueType>& operand, std::vector<TargetValueType> const& offsets, uint64_t& numIterations, TargetValueType const& precision,
+    std::optional<storm::OptimizationDirection> const& dir, std::function<SolverStatus(SolverStatus const&)> const& iterationCallback) const {
+    STORM_LOG_ASSERT(TrivialRowGrouping || dir.has_value(), "no optimization direction given!");
+    if (!dir.has_value() || maximize(*dir)) {
+        return RS<storm::OptimizationDirection::Maximize>(operand, offsets, numIterations, precision, iterationCallback);
+    } else {
+        return RS<storm::OptimizationDirection::Minimize>(operand, offsets, numIterations, precision, iterationCallback);
+    }
+}
+
+template<typename TargetValueType, typename ExactValueType, typename ImpreciseValueType, bool TrivialRowGrouping>
+SolverStatus RationalSearchHelper<TargetValueType, ExactValueType, ImpreciseValueType, TrivialRowGrouping>::RS(
+    std::vector<TargetValueType>& operand, std::vector<TargetValueType> const& offsets, TargetValueType const& precision,
+    std::optional<storm::OptimizationDirection> const& dir, std::function<SolverStatus(SolverStatus const&)> const& iterationCallback) const {
+    uint64_t numIterations = 0;
+    return RS(operand, offsets, numIterations, precision, dir, iterationCallback);
+}
+
+template class RationalSearchHelper<double, storm::RationalNumber, double, true>;
+template class RationalSearchHelper<double, storm::RationalNumber, double, false>;
+template class RationalSearchHelper<storm::RationalNumber, storm::RationalNumber, double, true>;
+template class RationalSearchHelper<storm::RationalNumber, storm::RationalNumber, double, false>;
+
+}  // namespace storm::solver::helper

--- a/src/storm/solver/helper/RationalSearchHelper.h
+++ b/src/storm/solver/helper/RationalSearchHelper.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <vector>
+
+#include "storm/solver/OptimizationDirection.h"
+#include "storm/solver/SolverStatus.h"
+
+namespace storm::solver::helper {
+
+template<typename ValueType, bool TrivialRowGrouping>
+class ValueIterationOperator;
+
+enum class RSResult { InProgress, Converged, PrecisionExceeded };
+
+/*!
+ * Implements rational search
+ * @see https://doi.org/10.1007/s10703-020-00348-y
+ * @tparam TargetValueType The value type in which we want the result to be in
+ * @tparam ExactValueType Value type used for exact computations
+ * @tparam ImpreciseValueType value type used for fast, but inexact computatioins
+ */
+template<typename TargetValueType, typename ExactValueType, typename ImpreciseValueType, bool TrivialRowGrouping>
+class RationalSearchHelper {
+   public:
+    static const bool IsTargetExact = std::is_same_v<TargetValueType, ExactValueType>;
+
+    RationalSearchHelper(std::shared_ptr<ValueIterationOperator<ExactValueType, TrivialRowGrouping>> exactViOperator,
+                         std::shared_ptr<ValueIterationOperator<ImpreciseValueType, TrivialRowGrouping>> impreciseViOperator);
+
+    template<storm::OptimizationDirection Dir>
+    SolverStatus RS(std::vector<TargetValueType>& operand, std::vector<TargetValueType> const& offsets, uint64_t& numIterations,
+                    TargetValueType const& precision, std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {}) const;
+
+    SolverStatus RS(std::vector<TargetValueType>& operand, std::vector<TargetValueType> const& offsets, uint64_t& numIterations,
+                    TargetValueType const& precision, std::optional<storm::OptimizationDirection> const& dir = {},
+                    std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {}) const;
+
+    SolverStatus RS(std::vector<TargetValueType>& operand, std::vector<TargetValueType> const& offsets, TargetValueType const& precision,
+                    std::optional<storm::OptimizationDirection> const& dir = {},
+                    std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {}) const;
+
+   private:
+    template<typename ValueType, storm::OptimizationDirection Dir>
+    std::pair<RSResult, SolverStatus> RS(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations,
+                                         ExactValueType precision, std::vector<ExactValueType> const& exactOffsets, std::vector<TargetValueType>& target,
+                                         std::function<SolverStatus(SolverStatus const&)> const& iterationCallback) const;
+
+    template<typename ValueType>
+    std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> const& getOperator() const;
+
+    template<typename ValueType, storm::OptimizationDirection Dir>
+    RSResult sharpen(uint64_t precision, std::vector<ValueType> const& operand, std::vector<ExactValueType> const& exactOffsets,
+                     std::vector<TargetValueType>& target) const;
+
+    std::shared_ptr<ValueIterationOperator<ExactValueType, TrivialRowGrouping>> exactOperator;
+    std::shared_ptr<ValueIterationOperator<ImpreciseValueType, TrivialRowGrouping>> impreciseOperator;
+};
+
+}  // namespace storm::solver::helper

--- a/src/storm/solver/helper/SchedulerTrackingHelper.cpp
+++ b/src/storm/solver/helper/SchedulerTrackingHelper.cpp
@@ -1,0 +1,101 @@
+#include "storm/solver/helper/SchedulerTrackingHelper.h"
+
+#include "storm/adapters/RationalNumberAdapter.h"
+#include "storm/solver/helper/ValueIterationOperator.h"
+#include "storm/utility/Extremum.h"
+
+namespace storm::solver::helper {
+
+template<typename ValueType, storm::OptimizationDirection Dir>
+class SchedulerTrackingBackend {
+   public:
+    SchedulerTrackingBackend(std::vector<uint64_t>& schedulerStorage,
+                             std::vector<typename ValueIterationOperator<ValueType, false>::IndexType> const& rowGroupIndices, bool applyUpdates)
+        : schedulerStorage(schedulerStorage), applyUpdates(applyUpdates), rowGroupIndices(rowGroupIndices) {
+        // intentionally empty
+    }
+    void startNewIteration() {
+        isConverged = true;
+    }
+
+    void firstRow(ValueType&& value, uint64_t rowGroup, uint64_t row) {
+        currChoice = row - rowGroupIndices[rowGroup];
+        best = std::move(value);
+    }
+
+    void nextRow(ValueType&& value, uint64_t rowGroup, uint64_t row) {
+        if (best &= value) {
+            currChoice = row - rowGroupIndices[rowGroup];
+        } else if (*best == value) {
+            // For rows that are equally good, we prefer the previously selected one.
+            // This is necessary, e.g., for policy iteration correctness.
+            if (uint64_t rowChoice = row - rowGroupIndices[rowGroup]; rowChoice == schedulerStorage[rowGroup]) {
+                currChoice = rowChoice;
+            }
+        }
+    }
+
+    void applyUpdate(ValueType& currValue, uint64_t rowGroup) {
+        if (applyUpdates) {
+            currValue = std::move(*best);
+        }
+        auto& choice = schedulerStorage[rowGroup];
+        if (isConverged) {
+            isConverged = choice == currChoice;
+        }
+        choice = currChoice;
+    }
+
+    void endOfIteration() const {}
+
+    bool converged() const {
+        return isConverged;
+    }
+
+    bool constexpr abort() const {
+        return false;
+    }
+
+   private:
+    std::vector<uint64_t>& schedulerStorage;
+    bool const applyUpdates;
+    std::vector<typename ValueIterationOperator<ValueType, false>::IndexType> const& rowGroupIndices;
+
+    bool isConverged;
+    storm::utility::Extremum<Dir, ValueType> best;
+    uint64_t currChoice;
+};
+
+template<typename ValueType>
+SchedulerTrackingHelper<ValueType>::SchedulerTrackingHelper(std::shared_ptr<ValueIterationOperator<ValueType, false>> viOperator) : viOperator(viOperator) {
+    // Intentionally left empty
+}
+
+template<typename ValueType>
+template<storm::OptimizationDirection Dir>
+bool SchedulerTrackingHelper<ValueType>::computeScheduler(std::vector<ValueType>& operandIn, std::vector<ValueType> const& offsets,
+                                                          std::vector<uint64_t>& schedulerStorage, std::vector<ValueType>* operandOut) const {
+    bool const applyUpdates = operandOut != nullptr;
+    SchedulerTrackingBackend<ValueType, Dir> backend(schedulerStorage, viOperator->getRowGroupIndices(), applyUpdates);
+    if (applyUpdates) {
+        return viOperator->template apply(*operandOut, operandIn, offsets, backend);
+    } else {
+        return viOperator->template applyInPlace(operandIn, offsets, backend);
+    }
+}
+
+template<typename ValueType>
+bool SchedulerTrackingHelper<ValueType>::computeScheduler(std::vector<ValueType>& operandIn, std::vector<ValueType> const& offsets,
+                                                          storm::OptimizationDirection const& dir, std::vector<uint64_t>& schedulerStorage,
+                                                          std::vector<ValueType>* operandOut) const {
+    if (maximize(dir)) {
+        return computeScheduler<storm::OptimizationDirection::Maximize>(operandIn, offsets, schedulerStorage, operandOut);
+    } else {
+        return computeScheduler<storm::OptimizationDirection::Minimize>(operandIn, offsets, schedulerStorage, operandOut);
+    }
+}
+
+template class SchedulerTrackingHelper<double>;
+template class SchedulerTrackingHelper<storm::RationalNumber>;
+
+}  // namespace storm::solver::helper

--- a/src/storm/solver/helper/SchedulerTrackingHelper.h
+++ b/src/storm/solver/helper/SchedulerTrackingHelper.h
@@ -1,0 +1,51 @@
+#pragma once
+#include <memory>
+#include <vector>
+
+#include "storm/solver/OptimizationDirection.h"
+
+namespace storm::solver::helper {
+
+template<typename ValueType, bool TrivialRowGrouping>
+class ValueIterationOperator;
+
+/*!
+ * Helper class to extract optimal scheduler choices from a MinMax equation system solution
+ */
+template<typename ValueType>
+class SchedulerTrackingHelper {
+   public:
+    /*!
+     * Initializes this helper with the given value iteration operator
+     */
+    SchedulerTrackingHelper(std::shared_ptr<ValueIterationOperator<ValueType, false>> viOperator);
+
+    /*!
+     * Computes the optimal choices from the given solution.
+     * Essentially, this applies one iteration of value iteration and stores the optimal choice for each state.
+     * @param operandIn Operand for the value iteration step. Should hold the solution values of the MinMax equation system
+     * @param offsets Offsets that are added to each choice result.
+     * @param dir Optimization direction to consider.
+     * @param schedulerStorage where the scheduler choices will be stored. Should have the same size as the operand(s).
+     * @param operandOut if given, the result values of the performed value iteration step will be stored in this vector. Can be the same as operandIn.
+     * @return True if the scheduler coincides with the provided scheduler encoded in schedulerStorage
+     *
+     * @note: schedulers are encoded using row indices that are local to their row group, i.e. schedulerStorage[i]==j means that we choose the j'th row of row
+     * group i
+     */
+    bool computeScheduler(std::vector<ValueType>& operandIn, std::vector<ValueType> const& offsets, storm::OptimizationDirection const& dir,
+                          std::vector<uint64_t>& schedulerStorage, std::vector<ValueType>* operandOut = nullptr) const;
+
+   private:
+    /*!
+     * Internal variant of computeScheduler
+     */
+    template<storm::OptimizationDirection Dir>
+    bool computeScheduler(std::vector<ValueType>& operandIn, std::vector<ValueType> const& offsets, std::vector<uint64_t>& schedulerStorage,
+                          std::vector<ValueType>* operandOut) const;
+
+   private:
+    std::shared_ptr<ValueIterationOperator<ValueType, false>> viOperator;
+};
+
+}  // namespace storm::solver::helper

--- a/src/storm/solver/helper/SoundValueIterationHelper.h
+++ b/src/storm/solver/helper/SoundValueIterationHelper.h
@@ -1,153 +1,71 @@
 #pragma once
 
-#include <boost/optional.hpp>
+#include <functional>
+#include <memory>
+#include <optional>
 #include <vector>
 
 #include "storm/solver/OptimizationDirection.h"
+#include "storm/solver/SolverStatus.h"
 #include "storm/solver/TerminationCondition.h"
 
-namespace storm {
+namespace storm::solver::helper {
 
-namespace storage {
-template<typename ValueType>
-class SparseMatrix;
+template<typename ValueType, bool TrivialRowGrouping>
+class ValueIterationOperator;
 
-class BitVector;
-}  // namespace storage
-
-namespace solver {
-namespace helper {
-
-template<typename ValueType>
+/*!
+ * Implements sound value iteration
+ * @see https://doi.org/10.1007/978-3-319-96145-3_37
+ */
+template<typename ValueType, bool TrivialRowGrouping>
 class SoundValueIterationHelper {
    public:
-    typedef uint32_t IndexType;
+    SoundValueIterationHelper(std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator);
 
-    /*!
-     * Creates a new helper from the given data
-     */
-    SoundValueIterationHelper(storm::storage::SparseMatrix<ValueType> const& matrix, std::vector<ValueType>& x, std::vector<ValueType>& y, bool relative,
-                              ValueType const& precision);
+    struct SVIData {
+        SolverStatus status;
+        std::pair<std::vector<ValueType>, std::vector<ValueType>> const& xy;
+        std::optional<ValueType> const a, b;
 
-    /*!
-     * Creates a helper from the given data, considering the same matrix as the given old helper
-     */
-    SoundValueIterationHelper(SoundValueIterationHelper<ValueType>&& oldHelper, std::vector<ValueType>& x, std::vector<ValueType>& y, bool relative,
-                              ValueType const& precision);
+        void trySetAverage(std::vector<ValueType>& out) const;
+        void trySetLowerUpper(std::vector<ValueType>& lowerOut, std::vector<ValueType>& upperOut) const;
+        bool checkCustomTerminationCondition(storm::solver::TerminationCondition<ValueType> const& condition) const;
 
-    /*!
-     * Sets the currently known lower / upper bound
-     */
-    void setLowerBound(ValueType const& value);
-    void setUpperBound(ValueType const& value);
+        bool checkConvergence(uint64_t& convergenceCheckState, std::function<void()> const& getNextConvergenceCheckState, bool relative,
+                              ValueType const& precision) const;
+    };
 
-    void setSolutionVector();
+    template<typename BackendType>
+    SVIData SVI(std::pair<std::vector<ValueType>, std::vector<ValueType>>& xy, std::pair<std::vector<ValueType> const*, ValueType> const& offsets,
+                uint64_t& numIterations, bool relative, ValueType const& precision, BackendType&& backend,
+                std::function<SolverStatus(SVIData const&)> const& iterationCallback, std::optional<storm::storage::BitVector> const& relevantValues,
+                uint64_t convergenceCheckState = 0) const;
 
-    /*!
-     * Performs one iteration step with respect to the given optimization direction.
-     */
-    void performIterationStep(OptimizationDirection const& dir, std::vector<ValueType> const& b,
-                              boost::optional<storage::BitVector> const& schedulerFixedForRowgroup = boost::none,
-                              boost::optional<std::vector<uint_fast64_t>> const& scheduler = boost::none);
+    template<storm::OptimizationDirection Dir>
+    SVIData SVI(std::pair<std::vector<ValueType>, std::vector<ValueType>>& xy, std::pair<std::vector<ValueType> const*, ValueType> const& offsets,
+                uint64_t& numIterations, bool relative, ValueType const& precision, std::optional<ValueType> const& a, std::optional<ValueType> const& b,
+                std::function<SolverStatus(SVIData const&)> const& iterationCallback = {},
+                std::optional<storm::storage::BitVector> const& relevantValues = {}) const;
 
-    /*!
-     * Performs one iteration step, assuming that the row grouping of the initial matrix is trivial.
-     */
-    void performIterationStep(std::vector<ValueType> const& b);
+    SVIData SVI(std::pair<std::vector<ValueType>, std::vector<ValueType>>& xy, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative,
+                ValueType const& precision, std::optional<storm::OptimizationDirection> const& dir, std::optional<ValueType> const& lowerBound,
+                std::optional<ValueType> const& upperBound, std::function<SolverStatus(SVIData const&)> const& iterationCallback,
+                std::optional<storm::storage::BitVector> const& relevantValues = {}) const;
 
-    /*!
-     * Checks for convergence and updates the known lower/upper bounds.
-     */
-    bool checkConvergenceUpdateBounds(OptimizationDirection const& dir, storm::storage::BitVector const* relevantValues = nullptr);
+    SolverStatus SVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
+                     std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& lowerBound = {},
+                     std::optional<ValueType> const& upperBound = {}, std::function<SolverStatus(SVIData const&)> const& iterationCallback = {},
+                     std::optional<storm::storage::BitVector> const& relevantValues = {}) const;
 
-    /*!
-     * Checks for convergence and updates the known lower/upper bounds, assuming that the row grouping of the initial matrix is trivial.
-     */
-    bool checkConvergenceUpdateBounds(storm::storage::BitVector const* relevantValues = nullptr);
-
-    /*!
-     * Checks whether the provided termination condition triggers termination
-     */
-    bool checkCustomTerminationCondition(storm::solver::TerminationCondition<ValueType> const& condition);
+    SolverStatus SVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
+                     std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& lowerBound = {},
+                     std::optional<ValueType> const& upperBound = {}, std::function<SolverStatus(SVIData const&)> const& iterationCallback = {},
+                     std::optional<storm::storage::BitVector> const& relevantValues = {}) const;
 
    private:
-    enum class InternalOptimizationDirection { None, Minimize, Maximize };
-
-    template<InternalOptimizationDirection dir>
-    void performIterationStep(std::vector<ValueType> const& b, boost::optional<storm::storage::BitVector> const& schedulerFixedForRowgroup = boost::none,
-                              boost::optional<std::vector<uint_fast64_t>> const& scheduler = boost::none);
-
-    template<InternalOptimizationDirection dir>
-    void performIterationStepUpdateDecisionValue(std::vector<ValueType> const& b,
-                                                 boost::optional<storm::storage::BitVector> const& schedulerFixedForRowgroup = boost::none,
-                                                 boost::optional<std::vector<uint_fast64_t>> const& scheduler = boost::none);
-
-    void multiplyRow(IndexType const& rowIndex, ValueType const& bi, ValueType& xi, ValueType& yi);
-
-    template<InternalOptimizationDirection dir>
-    bool checkConvergenceUpdateBounds(storm::storage::BitVector const* relevantValues = nullptr);
-
-    bool checkConvergencePhase1();
-    bool checkConvergencePhase2(storm::storage::BitVector const* relevantValues = nullptr);
-
-    bool isPreciseEnough(ValueType const& xi, ValueType const& yi, ValueType const& lb, ValueType const& ub);
-
-    template<InternalOptimizationDirection dir>
-    bool preliminaryConvergenceCheck(ValueType& lowerBoundCandidate, ValueType& upperBoundCandidate);
-
-    template<InternalOptimizationDirection dir>
-    void updateLowerUpperBound(ValueType& lowerBoundCandidate, ValueType& upperBoundCandidate);
-
-    template<InternalOptimizationDirection dir>
-    void checkIfDecisionValueBlocks();
-
-    // Auxiliary helper functions to avoid case distinctions due to different optimization directions
-    template<InternalOptimizationDirection dir>
-    inline bool better(ValueType const& val1, ValueType const& val2) {
-        return (dir == InternalOptimizationDirection::Maximize) ? val1 > val2 : val1 < val2;
-    }
-    template<InternalOptimizationDirection dir>
-    inline ValueType& getPrimaryBound() {
-        return (dir == InternalOptimizationDirection::Maximize) ? upperBound : lowerBound;
-    }
-    template<InternalOptimizationDirection dir>
-    inline bool& hasPrimaryBound() {
-        return (dir == InternalOptimizationDirection::Maximize) ? hasUpperBound : hasLowerBound;
-    }
-    template<InternalOptimizationDirection dir>
-    inline ValueType& getSecondaryBound() {
-        return (dir == InternalOptimizationDirection::Maximize) ? lowerBound : upperBound;
-    }
-    template<InternalOptimizationDirection dir>
-    inline uint64_t& getPrimaryIndex() {
-        return (dir == InternalOptimizationDirection::Maximize) ? maxIndex : minIndex;
-    }
-    template<InternalOptimizationDirection dir>
-    inline uint64_t& getSecondaryIndex() {
-        return (dir == InternalOptimizationDirection::Maximize) ? minIndex : maxIndex;
-    }
-
-    std::vector<ValueType>& x;
-    std::vector<ValueType>& y;
-    std::vector<ValueType> xTmp, yTmp;
-
-    ValueType lowerBound, upperBound, decisionValue;
-    bool hasLowerBound, hasUpperBound, hasDecisionValue;
-    bool convergencePhase1;
-    bool decisionValueBlocks;
-    uint64_t firstIndexViolatingConvergence;
-    uint64_t minIndex, maxIndex;
-
-    bool relative;
-    ValueType precision;
-
-    IndexType numRows;
-    std::vector<ValueType> matrixValues;
-    std::vector<IndexType> matrixColumns;
-    std::vector<IndexType> rowIndications;
-    std::vector<uint_fast64_t> const* rowGroupIndices;
+    std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator;
+    uint64_t sizeOfLargestRowGroup;
 };
 
-}  // namespace helper
-}  // namespace solver
-}  // namespace storm
+}  // namespace storm::solver::helper

--- a/src/storm/solver/helper/ValueIterationHelper.cpp
+++ b/src/storm/solver/helper/ValueIterationHelper.cpp
@@ -1,0 +1,135 @@
+#include "storm/solver/helper/ValueIterationHelper.h"
+
+#include "storm/adapters/RationalNumberAdapter.h"
+#include "storm/solver/helper/ValueIterationOperator.h"
+#include "storm/utility/Extremum.h"
+
+namespace storm::solver::helper {
+
+template<typename ValueType, storm::OptimizationDirection Dir, bool Relative>
+class VIOperatorBackend {
+   public:
+    VIOperatorBackend(ValueType const& precision) : precision{precision} {
+        // intentionally empty
+    }
+
+    void startNewIteration() {
+        isConverged = true;
+    }
+
+    void firstRow(ValueType&& value, [[maybe_unused]] uint64_t rowGroup, [[maybe_unused]] uint64_t row) {
+        best = std::move(value);
+    }
+
+    void nextRow(ValueType&& value, [[maybe_unused]] uint64_t rowGroup, [[maybe_unused]] uint64_t row) {
+        best &= value;
+    }
+
+    void applyUpdate(ValueType& currValue, [[maybe_unused]] uint64_t rowGroup) {
+        if (isConverged) {
+            if constexpr (Relative) {
+                isConverged = storm::utility::abs<ValueType>(currValue - *best) <= storm::utility::abs<ValueType>(precision * currValue);
+            } else {
+                isConverged = storm::utility::abs<ValueType>(currValue - *best) <= precision;
+            }
+        }
+        currValue = std::move(*best);
+    }
+
+    void endOfIteration() const {
+        // intentionally left empty.
+    }
+
+    bool converged() const {
+        return isConverged;
+    }
+
+    bool constexpr abort() const {
+        return false;
+    }
+
+   private:
+    storm::utility::Extremum<Dir, ValueType> best;
+    ValueType const precision;
+    bool isConverged{true};
+};
+
+template<typename ValueType, bool TrivialRowGrouping>
+ValueIterationHelper<ValueType, TrivialRowGrouping>::ValueIterationHelper(std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator)
+    : viOperator(viOperator) {
+    // Intentionally left empty
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+template<storm::OptimizationDirection Dir, bool Relative>
+SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping>::VI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets,
+                                                                     uint64_t& numIterations, ValueType const& precision,
+                                                                     std::function<SolverStatus(SolverStatus const&)> const& iterationCallback,
+                                                                     MultiplicationStyle mult) const {
+    VIOperatorBackend<ValueType, Dir, Relative> backend{precision};
+    std::vector<ValueType>* operand1{&operand};
+    std::vector<ValueType>* operand2{&operand};
+    if (mult == MultiplicationStyle::Regular) {
+        operand2 = &viOperator->allocateAuxiliaryVector(operand.size());
+    }
+    bool resultInAuxVector{false};
+    SolverStatus status{SolverStatus::InProgress};
+    while (status == SolverStatus::InProgress) {
+        ++numIterations;
+        if (viOperator->template apply(*operand1, *operand2, offsets, backend)) {
+            status = SolverStatus::Converged;
+        } else if (iterationCallback) {
+            status = iterationCallback(status);
+        }
+        if (mult == MultiplicationStyle::Regular) {
+            std::swap(operand1, operand2);
+            resultInAuxVector = !resultInAuxVector;
+        }
+    }
+    if (mult == MultiplicationStyle::Regular) {
+        if (resultInAuxVector) {
+            STORM_LOG_ASSERT(&operand == operand2, "Unexpected operand address");
+            std::swap(*operand1, *operand2);
+        }
+        viOperator->freeAuxiliaryVector();
+    }
+    return status;
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping>::VI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets,
+                                                                     uint64_t& numIterations, bool relative, ValueType const& precision,
+                                                                     std::optional<storm::OptimizationDirection> const& dir,
+                                                                     std::function<SolverStatus(SolverStatus const&)> const& iterationCallback,
+                                                                     MultiplicationStyle mult) const {
+    STORM_LOG_ASSERT(TrivialRowGrouping || dir.has_value(), "no optimization direction given!");
+    if (!dir.has_value() || maximize(*dir)) {
+        if (relative) {
+            return VI<storm::OptimizationDirection::Maximize, true>(operand, offsets, numIterations, precision, iterationCallback, mult);
+        } else {
+            return VI<storm::OptimizationDirection::Maximize, false>(operand, offsets, numIterations, precision, iterationCallback, mult);
+        }
+    } else {
+        if (relative) {
+            return VI<storm::OptimizationDirection::Minimize, true>(operand, offsets, numIterations, precision, iterationCallback, mult);
+        } else {
+            return VI<storm::OptimizationDirection::Minimize, false>(operand, offsets, numIterations, precision, iterationCallback, mult);
+        }
+    }
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping>::VI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative,
+                                                                     ValueType const& precision, std::optional<storm::OptimizationDirection> const& dir,
+                                                                     std::function<SolverStatus(SolverStatus const&)> const& iterationCallback,
+                                                                     MultiplicationStyle mult) const {
+    uint64_t numIterations = 0;
+    return VI(operand, offsets, numIterations, relative, precision, dir, iterationCallback, mult);
+}
+
+template class ValueIterationHelper<double, true>;
+template class ValueIterationHelper<double, false>;
+template class ValueIterationHelper<storm::RationalNumber, true>;
+template class ValueIterationHelper<storm::RationalNumber, false>;
+
+}  // namespace storm::solver::helper

--- a/src/storm/solver/helper/ValueIterationHelper.h
+++ b/src/storm/solver/helper/ValueIterationHelper.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "storm/solver/MultiplicationStyle.h"
+#include "storm/solver/OptimizationDirection.h"
+#include "storm/solver/SolverStatus.h"
+
+namespace storm::solver::helper {
+
+template<typename ValueType, bool TrivialRowGrouping>
+class ValueIterationOperator;
+
+template<typename ValueType, bool TrivialRowGrouping>
+class ValueIterationHelper {
+   public:
+    explicit ValueIterationHelper(std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator);
+
+    template<storm::OptimizationDirection Dir, bool Relative>
+    SolverStatus VI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, ValueType const& precision,
+                    std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {},
+                    MultiplicationStyle mult = MultiplicationStyle::GaussSeidel) const;
+
+    SolverStatus VI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
+                    std::optional<storm::OptimizationDirection> const& dir = {}, std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {},
+                    MultiplicationStyle mult = MultiplicationStyle::GaussSeidel) const;
+
+    SolverStatus VI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
+                    std::optional<storm::OptimizationDirection> const& dir = {}, std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {},
+                    MultiplicationStyle mult = MultiplicationStyle::GaussSeidel) const;
+
+   private:
+    std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator;
+};
+
+}  // namespace storm::solver::helper

--- a/src/storm/solver/helper/ValueIterationOperator.cpp
+++ b/src/storm/solver/helper/ValueIterationOperator.cpp
@@ -1,0 +1,180 @@
+#include "storm/solver/helper/ValueIterationOperator.h"
+
+#include <optional>
+
+#include "storm/adapters/RationalNumberAdapter.h"
+#include "storm/storage/SparseMatrix.h"
+
+namespace storm::solver::helper {
+
+template<typename ValueType, bool TrivialRowGrouping>
+template<bool Backward>
+void ValueIterationOperator<ValueType, TrivialRowGrouping>::setMatrix(storm::storage::SparseMatrix<ValueType> const& matrix,
+                                                                      std::vector<IndexType> const* rowGroupIndices) {
+    if constexpr (TrivialRowGrouping) {
+        STORM_LOG_ASSERT(matrix.hasTrivialRowGrouping(), "Expected a matrix with trivial row grouping");
+        STORM_LOG_ASSERT(rowGroupIndices == nullptr, "Row groups given, but grouping is supposed to be trivial.");
+        this->rowGroupIndices = nullptr;
+    } else {
+        if (rowGroupIndices) {
+            this->rowGroupIndices = rowGroupIndices;
+        } else {
+            this->rowGroupIndices = &matrix.getRowGroupIndices();
+        }
+    }
+    this->backwards = Backward;
+    this->hasSkippedRows = false;
+    auto const numRows = matrix.getRowCount();
+    matrixValues.clear();
+    matrixColumns.clear();
+    matrixValues.reserve(matrix.getNonzeroEntryCount());
+    matrixColumns.reserve(matrix.getNonzeroEntryCount() + numRows + 1);  // matrixColumns also contain indications for when a row(group) starts
+    if constexpr (!TrivialRowGrouping) {
+        matrixColumns.push_back(StartOfRowGroupIndicator);  // indicate start of first row(group)
+        for (auto groupIndex : indexRange<Backward>(0, this->rowGroupIndices->size() - 1)) {
+            STORM_LOG_ASSERT(this->rowGroupIndices->at(groupIndex) != this->rowGroupIndices->at(groupIndex + 1),
+                             "There is an empty row group. This is not expected.");
+            for (auto rowIndex : indexRange<false>((*this->rowGroupIndices)[groupIndex], (*this->rowGroupIndices)[groupIndex + 1])) {
+                for (auto const& entry : matrix.getRow(rowIndex)) {
+                    matrixValues.push_back(entry.getValue());
+                    matrixColumns.push_back(entry.getColumn());
+                }
+                matrixColumns.push_back(StartOfRowIndicator);  // Indicate start of next row
+            }
+            matrixColumns.back() = StartOfRowGroupIndicator;  // This is the start of the next row group
+        }
+    } else {
+        matrixColumns.push_back(StartOfRowIndicator);  // Indicate start of first row
+        for (auto rowIndex : indexRange<Backward>(0, numRows)) {
+            for (auto const& entry : matrix.getRow(rowIndex)) {
+                matrixValues.push_back(entry.getValue());
+                matrixColumns.push_back(entry.getColumn());
+            }
+            matrixColumns.push_back(StartOfRowIndicator);  // Indicate start of next row
+        }
+    }
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+void ValueIterationOperator<ValueType, TrivialRowGrouping>::setMatrixForwards(storm::storage::SparseMatrix<ValueType> const& matrix,
+                                                                              std::vector<IndexType> const* rowGroupIndices) {
+    setMatrix<false>(matrix, rowGroupIndices);
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+void ValueIterationOperator<ValueType, TrivialRowGrouping>::setMatrixBackwards(storm::storage::SparseMatrix<ValueType> const& matrix,
+                                                                               std::vector<IndexType> const* rowGroupIndices) {
+    setMatrix<true>(matrix, rowGroupIndices);
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+void ValueIterationOperator<ValueType, TrivialRowGrouping>::unsetIgnoredRows() {
+    for (auto& c : matrixColumns) {
+        if (c >= StartOfRowIndicator) {
+            c &= StartOfRowGroupIndicator;
+        }
+    }
+    hasSkippedRows = false;
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+template<bool Backward>
+void ValueIterationOperator<ValueType, TrivialRowGrouping>::setIgnoredRows(bool useLocalRowIndices, std::function<bool(IndexType, IndexType)> const& ignore) {
+    STORM_LOG_ASSERT(!TrivialRowGrouping, "Tried to ignroe rows but the row grouping is trivial.");
+    auto colIt = matrixColumns.begin();
+    for (auto groupIndex : indexRange<Backward>(0, this->rowGroupIndices->size() - 1)) {
+        STORM_LOG_ASSERT(colIt != matrixColumns.end(), "VI Operator in invalid state.");
+        STORM_LOG_ASSERT(*colIt >= StartOfRowGroupIndicator, "VI Operator in invalid state.");
+        auto const rowIndexRange = useLocalRowIndices ? indexRange<false>(0ull, (*this->rowGroupIndices)[groupIndex + 1] - (*this->rowGroupIndices)[groupIndex])
+                                                      : indexRange<false>((*this->rowGroupIndices)[groupIndex], (*this->rowGroupIndices)[groupIndex + 1]);
+        for (auto const rowIndex : rowIndexRange) {
+            if (!ignore(groupIndex, rowIndex)) {
+                *colIt &= StartOfRowGroupIndicator;  // Clear number of skipped entries
+                moveToEndOfRow(colIt);
+            } else if ((*colIt & SkipNumEntriesMask) == 0) {  // i.e. should ignore but is not already ignored
+                auto currColIt = colIt;
+                moveToEndOfRow(colIt);
+                *currColIt += std::distance(currColIt, colIt);  // set number of skipped entries
+            }
+            STORM_LOG_ASSERT(
+                !std::all_of(rowIndexRange.begin(), rowIndexRange.end(), [&ignore, &groupIndex](IndexType rowIndex) { return ignore(groupIndex, rowIndex); }),
+                "All rows in row group " << groupIndex << " are ignored.");
+            STORM_LOG_ASSERT(colIt != matrixColumns.end(), "VI Operator in invalid state.");
+            STORM_LOG_ASSERT(*colIt >= StartOfRowIndicator, "VI Operator in invalid state.");
+        }
+        STORM_LOG_ASSERT(*colIt == StartOfRowGroupIndicator, "VI Operator in invalid state.");
+    }
+    hasSkippedRows = true;
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+void ValueIterationOperator<ValueType, TrivialRowGrouping>::setIgnoredRows(bool useLocalRowIndices, std::function<bool(IndexType, IndexType)> const& ignore) {
+    if (backwards) {
+        setIgnoredRows<true>(useLocalRowIndices, ignore);
+    } else {
+        setIgnoredRows<false>(useLocalRowIndices, ignore);
+    }
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+std::vector<typename ValueIterationOperator<ValueType, TrivialRowGrouping>::IndexType> const&
+ValueIterationOperator<ValueType, TrivialRowGrouping>::getRowGroupIndices() const {
+    STORM_LOG_ASSERT(!TrivialRowGrouping, "Tried to get row group indices for trivial row grouping");
+    return *rowGroupIndices;
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+std::vector<ValueType>& ValueIterationOperator<ValueType, TrivialRowGrouping>::allocateAuxiliaryVector(uint64_t size,
+                                                                                                       std::optional<ValueType> const& initialValue) {
+    STORM_LOG_ASSERT(!auxiliaryVectorUsedExternally, "Auxiliary vector already in use.");
+    if (initialValue) {
+        auxiliaryVector.assign(size, *initialValue);
+    } else {
+        auxiliaryVector.resize(size);
+    }
+    auxiliaryVectorUsedExternally = true;
+    return auxiliaryVector;
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+void ValueIterationOperator<ValueType, TrivialRowGrouping>::freeAuxiliaryVector() {
+    auxiliaryVectorUsedExternally = false;
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+void ValueIterationOperator<ValueType, TrivialRowGrouping>::moveToEndOfRow(std::vector<IndexType>::iterator& matrixColumnIt) const {
+    do {
+        ++matrixColumnIt;
+    } while (*matrixColumnIt < StartOfRowIndicator);
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+bool ValueIterationOperator<ValueType, TrivialRowGrouping>::skipIgnoredRow(std::vector<IndexType>::const_iterator& matrixColumnIt,
+                                                                           typename std::vector<ValueType>::const_iterator& matrixValueIt) const {
+    if (IndexType entriesToSkip = (*matrixColumnIt & SkipNumEntriesMask)) {
+        matrixColumnIt += entriesToSkip;
+        matrixValueIt += entriesToSkip - 1;
+        return true;
+    }
+    return false;
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+uint64_t ValueIterationOperator<ValueType, TrivialRowGrouping>::skipMultipleIgnoredRows(std::vector<IndexType>::const_iterator& matrixColumnIt,
+                                                                                        typename std::vector<ValueType>::const_iterator& matrixValueIt) const {
+    IndexType result{0ull};
+    while (skipIgnoredRow(matrixColumnIt, matrixValueIt)) {
+        ++result;
+        STORM_LOG_ASSERT(*matrixColumnIt >= StartOfRowIndicator, "Undexpected state of VI operator");
+        // We (currently) don't use this past the end of a row group, so we may have this additional sanity check:
+        STORM_LOG_ASSERT(*matrixColumnIt < StartOfRowGroupIndicator, "Undexpected state of VI operator");
+    }
+    return result;
+}
+
+template class ValueIterationOperator<double, true>;
+template class ValueIterationOperator<double, false>;
+template class ValueIterationOperator<storm::RationalNumber, true>;
+template class ValueIterationOperator<storm::RationalNumber, false>;
+
+}  // namespace storm::solver::helper

--- a/src/storm/solver/helper/ValueIterationOperator.h
+++ b/src/storm/solver/helper/ValueIterationOperator.h
@@ -1,0 +1,334 @@
+#pragma once
+#include <functional>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include <boost/range/adaptor/reversed.hpp>
+#include <boost/range/irange.hpp>
+
+#include "storm/storage/sparse/StateType.h"
+#include "storm/utility/macros.h"
+#include "storm/utility/vector.h"  // TODO
+
+namespace storm {
+class Environment;
+
+namespace storage {
+template<typename T>
+class SparseMatrix;
+}
+
+namespace solver::helper {
+
+/*!
+ * This class represents the Value Iteration Operator (also known as Bellman operator).
+ * It is tailored for efficiency, in particular when applied multiple times.
+ * The application of the operator is heavily templated so that many different flavours of value iteration and related algorithms can be implemented using this.
+ * @tparam ValueType The type of the matrix entries
+ * @tparam TrivialRowGrouping True iff the underlying model is deterministic
+ */
+template<typename ValueType, bool TrivialRowGrouping>
+class ValueIterationOperator {
+   public:
+    using IndexType = storm::storage::sparse::state_type;
+
+    /*!
+     * Initializes this operator with the given data
+     * @tparam backwards if true, we iterate backwards starting with the largest rowgroup. This often makes in place (Gauss-Seidel) iterations more efficient
+     * @param matrix the transition matrix
+     * @param rowGroupIndices if given, overwrites the rowGroupIndices of the matrix. Must be nullptr if TrivialRowGrouping is true
+     * @note The reference to the row group indices (either of the matrix or the given pointer) must not be invalidated as long as this operator is used.
+     */
+    template<bool Backward = true>
+    void setMatrix(storm::storage::SparseMatrix<ValueType> const& matrix, std::vector<IndexType> const* rowGroupIndices = nullptr);
+
+    /*!
+     * Initializes this operator with the given data for forward iterations (starting with the smallest row group
+     * @param matrix the transition matrix
+     * @param rowGroupIndices if given, overwrites the rowGroupIndices of the matrix. Must be nullptr if TrivialRowGrouping is true
+     * @note The reference to the row group indices (either of the matrix or the given pointer) must not be invalidated as long as this operator is used.
+     */
+    void setMatrixForwards(storm::storage::SparseMatrix<ValueType> const& matrix, std::vector<IndexType> const* rowGroupIndices = nullptr);
+
+    /*!
+     * Initializes this operator with the given data for backward iterations (starting with the largest row group)
+     * @param matrix the transition matrix
+     * @param rowGroupIndices if given, overwrites the rowGroupIndices of the matrix. Must be nullptr if TrivialRowGrouping is true
+     * @note The reference to the row group indices (either of the matrix or the given pointer) must not be invalidated as long as this operator is used.
+     */
+    void setMatrixBackwards(storm::storage::SparseMatrix<ValueType> const& matrix, std::vector<IndexType> const* rowGroupIndices = nullptr);
+
+    /*!
+     * Applies the operator with the given operands, offsets, and backend.
+     * More specifically, for each row group and for each row in a row group,
+     * this multiplies the matrix row with the given input operand vector and adds the offset row entry.
+     * The backend is invoked with row results and---once all rows in a group are processed---assigns the new row group value to the output operand.
+     * The following backend methods are invoked:
+     * * backend.startNewIteration(); at the beginning of each call to `apply`
+     * * backend.firstRow(rowResult, rowGroupIndex, rowIndex); once the first row of a row group is processed
+     * * backend.nextRow(rowResult, rowGroupIndex, rowIndex); for the subsequent rows of a row group (not invoked if TrivialRowGrouping)
+     * * backend.applyUpdate(operandOutReference, rowGroupIndex); once all rows of a group are processed. Here, the backend can set the result value for
+     *   the row group to the first argument
+     * * backend.abort(); invoked after a group is processed. If this returns true, the method is aborted, even if some groups have not been processed yet
+     * * backend.endOfIteration(); invoked when all groups are processed
+     * * backend.converged(); invoked when abort() returns true or all groups are processed. Determines the return value of this method
+     *
+     * @tparam OperandType The type of input and output operand. Can be a value vector or a pair of two value vectors with one entry per group.
+     *                      In the latter case, the rowResult for backend.firstRow and backend.nextRow is a pair of values and
+     *                      applyUpdate gets two operandOutReference's to write the group result to.
+     * @tparam OffsetType The type of row offsets. Can be a single value vector (one entry per row) or a pair of a (pointer to a) value vector and a value.
+     *                      The latter case is only valid if OperandType is a pair of two value vectors.
+     * @tparam BackendType The type of backend, shall implement the methods above
+     * @param operandIn Input operand
+     * @param operandOut Output operand
+     * @param offsets Row offsets which are added to each row result
+     * @param backend the backend
+     * @return whatever backend.converged() returns
+     *
+     * @note This and other apply methods are intentionally implemented in the header file as there are potentially many different BackendTypes
+     */
+    template<typename OperandType, typename OffsetType, typename BackendType>
+    bool apply(OperandType const& operandIn, OperandType& operandOut, OffsetType const& offsets, BackendType& backend) const {
+        if (hasSkippedRows) {
+            if (backwards) {
+                return apply<OperandType, OffsetType, BackendType, true, true>(operandOut, operandIn, offsets, backend);
+            } else {
+                return apply<OperandType, OffsetType, BackendType, false, true>(operandOut, operandIn, offsets, backend);
+            }
+        } else {
+            if (backwards) {
+                return apply<OperandType, OffsetType, BackendType, true, false>(operandOut, operandIn, offsets, backend);
+            } else {
+                return apply<OperandType, OffsetType, BackendType, false, false>(operandOut, operandIn, offsets, backend);
+            }
+        }
+    }
+
+    /*!
+     * Same as `apply` but with operandOut==operandIn
+     */
+    template<typename OperandType, typename OffsetType, typename BackendType>
+    bool applyInPlace(OperandType& operand, OffsetType const& offsets, BackendType& backend) const {
+        return apply(operand, operand, offsets, backend);
+    }
+
+    /*!
+     * Sets rows that will be skipped when applying the operator.
+     * @note each row group shall have at least one row that is not ignored
+     * @param useLocalRowIndices if true, the row indices are considered to be local to the group, i.e. row i is the i'th row in the given group
+     *                           if false, row indices are global, i.e. row i refers to the i'th row of the entire matrix
+     * @param ignore function object that takes a row group index and a row index and returns true, iff the corresponding row shall be skipped
+     */
+    void setIgnoredRows(bool useLocalRowIndices, std::function<bool(IndexType, IndexType)> const& ignore);
+
+    /*!
+     * Clears all ignored rows
+     */
+    void unsetIgnoredRows();
+
+    /*!
+     * @return The considered row group indices
+     */
+    std::vector<IndexType> const& getRowGroupIndices() const;
+
+    /*!
+     * Allocates additional storage that can be used e.g. when applying the operand
+     * @param size the size of the auxiliary vector
+     * @param initialValue optional initial value
+     * @return a reference to the auxiliary vector
+     */
+    std::vector<ValueType>& allocateAuxiliaryVector(uint64_t size, std::optional<ValueType> const& initialValue = {});
+
+    /*!
+     * Clears the auxiliary vector, invalidating any references to it
+     */
+    void freeAuxiliaryVector();
+
+   private:
+    /*!
+     * Internal variant of `apply`
+     * @note This and other apply methods are intentionally implemented in the header file as there are potentially many different BackendTypes
+     */
+    template<typename OperandType, typename OffsetType, typename BackendType, bool Backward, bool SkipIgnoredRows>
+    bool apply(OperandType& operandOut, OperandType const& operandIn, OffsetType const& offsets, BackendType& backend) const {
+        STORM_LOG_ASSERT(getSize(operandIn) == getSize(operandOut), "Input and Output Operands have different sizes.");
+        auto const operandSize = getSize(operandIn);
+        STORM_LOG_ASSERT(TrivialRowGrouping || rowGroupIndices->size() == operandSize + 1, "Dimension mismatch");
+        backend.startNewIteration();
+        auto matrixValueIt = matrixValues.cbegin();
+        auto matrixColumnIt = matrixColumns.cbegin();
+        for (auto groupIndex : indexRange<Backward>(0, operandSize)) {
+            STORM_LOG_ASSERT(matrixColumnIt != matrixColumns.end(), "VI Operator in invalid state.");
+            STORM_LOG_ASSERT(*matrixColumnIt >= StartOfRowIndicator, "VI Operator in invalid state.");
+            //            STORM_LOG_ASSERT(matrixValueIt != matrixValues.end(), "VI Operator in invalid state.");
+            if constexpr (TrivialRowGrouping) {
+                backend.firstRow(applyRow(matrixColumnIt, matrixValueIt, operandIn, offsets, groupIndex), groupIndex, groupIndex);
+            } else {
+                IndexType rowIndex = (*rowGroupIndices)[groupIndex];
+                if constexpr (SkipIgnoredRows) {
+                    rowIndex += skipMultipleIgnoredRows(matrixColumnIt, matrixValueIt);
+                }
+                backend.firstRow(applyRow(matrixColumnIt, matrixValueIt, operandIn, offsets, rowIndex), groupIndex, rowIndex);
+                while (*matrixColumnIt < StartOfRowGroupIndicator) {
+                    ++rowIndex;
+                    if (!SkipIgnoredRows || !skipIgnoredRow(matrixColumnIt, matrixValueIt)) {
+                        backend.nextRow(applyRow(matrixColumnIt, matrixValueIt, operandIn, offsets, rowIndex), groupIndex, rowIndex);
+                    }
+                }
+            }
+            if constexpr (isPair<OperandType>::value) {
+                backend.applyUpdate(operandOut.first[groupIndex], operandOut.second[groupIndex], groupIndex);
+            } else {
+                backend.applyUpdate(operandOut[groupIndex], groupIndex);
+            }
+            if (backend.abort()) {
+                return backend.converged();
+            }
+        }
+        STORM_LOG_ASSERT(matrixColumnIt + 1 == matrixColumns.cend(), "Unexpected position of matrix column iterator.");
+        STORM_LOG_ASSERT(matrixValueIt == matrixValues.cend(), "Unexpected position of matrix column iterator.");
+        backend.endOfIteration();
+        return backend.converged();
+    }
+
+    // Auxiliary methods to deal with various OperandTypes and OffsetTypes
+
+    template<typename OpT, typename OffT>
+    OpT initializeRowRes(std::vector<OpT> const&, std::vector<OffT> const& offsets, uint64_t offsetIndex) const {
+        return offsets[offsetIndex];
+    }
+
+    template<typename OpT1, typename OpT2, typename OffT>
+    std::pair<OpT1, OpT2> initializeRowRes(std::pair<std::vector<OpT1>, std::vector<OpT2>> const&, std::vector<OffT> const& offsets,
+                                           uint64_t offsetIndex) const {
+        return {offsets[offsetIndex], offsets[offsetIndex]};
+    }
+
+    template<typename OpT1, typename OpT2, typename OffT1, typename OffT2>
+    std::pair<OpT1, OpT2> initializeRowRes(std::pair<std::vector<OpT1>, std::vector<OpT2>> const&, std::pair<std::vector<OffT1> const*, OffT2> const& offsets,
+                                           uint64_t offsetIndex) const {
+        return {(*offsets.first)[offsetIndex], offsets.second};
+    }
+
+    /*!
+     * Computes the result for a single row and advances the given iterators to the end of the row
+     */
+    template<typename OperandType, typename OffsetType>
+    auto applyRow(std::vector<IndexType>::const_iterator& matrixColumnIt, typename std::vector<ValueType>::const_iterator& matrixValueIt,
+                  OperandType const& operand, OffsetType const& offsets, uint64_t offsetIndex) const {
+        STORM_LOG_ASSERT(*matrixColumnIt >= StartOfRowIndicator, "VI Operator in invalid state.");
+        auto result{initializeRowRes(operand, offsets, offsetIndex)};
+        for (++matrixColumnIt; *matrixColumnIt < StartOfRowIndicator; ++matrixColumnIt, ++matrixValueIt) {
+            if constexpr (isPair<OperandType>::value) {
+                result.first += operand.first[*matrixColumnIt] * (*matrixValueIt);
+                result.second += operand.second[*matrixColumnIt] * (*matrixValueIt);
+            } else {
+                result += operand[*matrixColumnIt] * (*matrixValueIt);
+            }
+        }
+        return result;
+    }
+
+    // Auxiliary helpers used for metaprogramming
+    template<bool Backward>
+    auto indexRange(IndexType start, IndexType end) const {
+        if constexpr (Backward) {
+            return boost::adaptors::reverse(boost::irange(start, end));
+        } else {
+            return boost::irange(start, end);
+        }
+    }
+
+    template<typename T>
+    uint64_t getSize(std::vector<T> const& vec) const {
+        return vec.size();
+    }
+
+    template<typename T1, typename T2>
+    uint64_t getSize(std::pair<T1, T2> const& pairOfVec) const {
+        return pairOfVec.first.size();
+    }
+
+    template<typename>
+    struct isPair : std::false_type {};
+
+    template<typename T1, typename T2>
+    struct isPair<std::pair<T1, T2>> : std::true_type {};
+
+    /*!
+     * Internal variant of setIgnoredRows
+     */
+    template<bool Backward = true>
+    void setIgnoredRows(bool useLocalRowIndices, std::function<bool(IndexType, IndexType)> const& ignore);
+
+    /*!
+     * Moves the given iterator to the end of the current row
+     */
+    void moveToEndOfRow(std::vector<IndexType>::iterator& matrixColumnIt) const;
+
+    /*!
+     * Skips the current row, if it is ignored. Advances the iterators accordingly
+     */
+    bool skipIgnoredRow(std::vector<IndexType>::const_iterator& matrixColumnIt, typename std::vector<ValueType>::const_iterator& matrixValueIt) const;
+
+    /*!
+     * Skips all ignored rows, advancing the iterators to the first successor row that is not ignored
+     */
+    uint64_t skipMultipleIgnoredRows(std::vector<IndexType>::const_iterator& matrixColumnIt,
+                                     typename std::vector<ValueType>::const_iterator& matrixValueIt) const;
+
+    /*!
+     * The non-zero matrix entries.
+     */
+    std::vector<ValueType> matrixValues;
+
+    /*!
+     * Row indicators and columns of the matrix entries. Has size #non-zero matrix entries + #rows + 1
+     * A row indicator is an index >= 1000...000. Before and after each row there is a row indicator.
+     */
+    std::vector<IndexType> matrixColumns;
+
+    /*!
+     * Row group indices as in the sparse matrix (even if the matrix is set in backwards order, this vector will not be reversed)
+     */
+    std::vector<IndexType> const* rowGroupIndices;
+
+    /*!
+     * True iff the matrix was set in backward orders
+     */
+    bool backwards{true};
+
+    /*!
+     * True iff there are some ignored rows
+     */
+    bool hasSkippedRows{false};
+
+    /*!
+     * Storage for the auxiliary vector
+     */
+    std::vector<ValueType> auxiliaryVector;
+
+    /*!
+     * True, if an auxiliary vector exists
+     */
+    bool auxiliaryVectorUsedExternally{false};
+
+    /*!
+     * Bitmask that indicates the start of a row in the 'matrixColumns' vector
+     */
+    IndexType const StartOfRowIndicator = 1ull << 63;  // 10000..0
+
+    /*!
+     * Bitmask that indicates the start of a row group in the 'matrixColumns' vector
+     */
+    IndexType const StartOfRowGroupIndicator = StartOfRowIndicator + (1ull << 62);  // 11000..0
+
+    /*!
+     * Ignored rows are encoded by adding the number of skipped entries to the row indicator. This Bitmask helps to get the number of skipped entries
+     */
+    IndexType const SkipNumEntriesMask = ~StartOfRowGroupIndicator;  // 00111..1
+};
+
+}  // namespace solver::helper
+}  // namespace storm

--- a/src/storm/storage/SparseMatrix.h
+++ b/src/storm/storage/SparseMatrix.h
@@ -12,6 +12,7 @@
 
 #include "storm/solver/OptimizationDirection.h"
 #include "storm/storage/BitVector.h"
+#include "storm/storage/sparse/StateType.h"
 
 #include "storm/adapters/IntelTbbAdapter.h"
 #include "storm/utility/OsDetection.h"
@@ -38,7 +39,7 @@ namespace storage {
 template<typename T>
 class SparseMatrix;
 
-typedef uint64_t SparseMatrixIndexType;
+typedef storm::storage::sparse::state_type SparseMatrixIndexType;
 
 template<typename IndexType, typename ValueType>
 class MatrixEntry {

--- a/src/storm/storage/sparse/StateType.h
+++ b/src/storm/storage/sparse/StateType.h
@@ -6,7 +6,7 @@
 namespace storm {
 namespace storage {
 namespace sparse {
-typedef uint_fast64_t state_type;
+typedef uint64_t state_type;
 }
 }  // namespace storage
 }  // namespace storm

--- a/src/storm/utility/Extremum.cpp
+++ b/src/storm/utility/Extremum.cpp
@@ -1,0 +1,139 @@
+#include "storm/utility/Extremum.h"
+
+#include "storm/adapters/RationalNumberAdapter.h"
+#include "storm/utility/macros.h"
+
+namespace storm::utility {
+
+template<storm::OptimizationDirection Dir, typename ValueType>
+Extremum<Dir, ValueType>::Extremum(ValueType const& value) : data({value}) {
+    if constexpr (!SupportsInfinity) {
+        data.empty = false;
+    }
+}
+
+template<storm::OptimizationDirection Dir, typename ValueType>
+Extremum<Dir, ValueType>::Extremum(ValueType&& value) : data({std::move(value)}) {
+    if constexpr (!SupportsInfinity) {
+        data.empty = false;
+    }
+}
+
+template<storm::OptimizationDirection Dir, typename ValueType>
+Extremum<Dir, ValueType>& Extremum<Dir, ValueType>::operator=(ValueType const& value) {
+    data.value = value;
+    if constexpr (!SupportsInfinity) {
+        data.empty = false;
+    }
+    return *this;
+}
+
+template<storm::OptimizationDirection Dir, typename ValueType>
+Extremum<Dir, ValueType>& Extremum<Dir, ValueType>::operator=(ValueType&& value) {
+    data.value = std::move(value);
+    if constexpr (!SupportsInfinity) {
+        data.empty = false;
+    }
+    return *this;
+}
+
+template<storm::OptimizationDirection Dir, typename ValueType>
+bool Extremum<Dir, ValueType>::better(ValueType const& value) const {
+    if constexpr (!SupportsInfinity) {
+        if (data.empty) {
+            return true;
+        }
+    }
+    if constexpr (storm::solver::minimize(Dir)) {
+        return value < data.value;
+    } else {
+        static_assert(storm::solver::maximize(Dir));
+        return value > data.value;
+    }
+}
+
+template<storm::OptimizationDirection Dir, typename ValueType>
+bool Extremum<Dir, ValueType>::operator&=(Extremum const& other) {
+    if (other.empty()) {
+        return false;
+    }
+    return *this &= *other;
+}
+
+template<storm::OptimizationDirection Dir, typename ValueType>
+bool Extremum<Dir, ValueType>::operator&=(Extremum&& other) {
+    if (other.empty()) {
+        return false;
+    }
+    return *this &= std::move(*other);
+}
+
+template<storm::OptimizationDirection Dir, typename ValueType>
+bool Extremum<Dir, ValueType>::operator&=(ValueType const& value) {
+    if (better(value)) {
+        data.value = value;
+        if constexpr (!SupportsInfinity) {
+            data.empty = false;
+        }
+        return true;
+    }
+    return false;
+}
+
+template<storm::OptimizationDirection Dir, typename ValueType>
+bool Extremum<Dir, ValueType>::operator&=(ValueType&& value) {
+    if (better(value)) {
+        data.value = std::move(value);
+        if constexpr (!SupportsInfinity) {
+            data.empty = false;
+        }
+        return true;
+    }
+    return false;
+}
+
+template<storm::OptimizationDirection Dir, typename ValueType>
+bool Extremum<Dir, ValueType>::empty() const {
+    if constexpr (SupportsInfinity) {
+        return data.value == data.baseValue();
+    } else {
+        return data.empty;
+    }
+}
+
+template<storm::OptimizationDirection Dir, typename ValueType>
+ValueType const& Extremum<Dir, ValueType>::operator*() const {
+    STORM_LOG_ASSERT(!empty(), "tried to get empty extremum.");
+    return data.value;
+}
+
+template<storm::OptimizationDirection Dir, typename ValueType>
+ValueType& Extremum<Dir, ValueType>::operator*() {
+    STORM_LOG_ASSERT(!empty(), "tried to get empty extremum.");
+    return data.value;
+}
+
+template<storm::OptimizationDirection Dir, typename ValueType>
+std::optional<ValueType> Extremum<Dir, ValueType>::getOptionalValue() const {
+    if (empty()) {
+        return {};
+    } else {
+        return data.value;
+    }
+}
+
+template<storm::OptimizationDirection Dir, typename ValueType>
+void Extremum<Dir, ValueType>::reset() {
+    if constexpr (SupportsInfinity) {
+        data.value = data.baseValue();
+    } else {
+        data.empty = true;
+    }
+}
+
+template class Extremum<storm::OptimizationDirection::Minimize, double>;
+template class Extremum<storm::OptimizationDirection::Maximize, double>;
+template class Extremum<storm::OptimizationDirection::Minimize, storm::RationalNumber>;
+template class Extremum<storm::OptimizationDirection::Maximize, storm::RationalNumber>;
+
+}  // namespace storm::utility

--- a/src/storm/utility/Extremum.h
+++ b/src/storm/utility/Extremum.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <limits>
+#include <optional>
+#include <type_traits>
+
+#include "storm/solver/OptimizationDirection.h"
+
+namespace storm::utility {
+
+/*!
+ * Stores and manages an extremal (maximal or minimal) value
+ */
+template<storm::OptimizationDirection Dir, typename ValueType>
+class Extremum {
+   public:
+    Extremum() = default;
+    Extremum(ValueType const& value);
+    Extremum(ValueType&& value);
+    Extremum(Extremum const&) = default;
+    Extremum(Extremum&&) = default;
+    Extremum& operator=(Extremum const&) = default;
+    Extremum& operator=(Extremum&&) = default;
+    ~Extremum() = default;
+
+    /*!
+     * Sets the extremum to the given value
+     * @return a reference to this
+     */
+    Extremum& operator=(ValueType const& value);
+
+    /*!
+     * Sets the extremum to the given value
+     * @return a reference to this
+     */
+    Extremum& operator=(ValueType&& value);
+
+    /*!
+     * @param value
+     * @return True if the provided value is strictly better (larger if we maximize; smaller if we minimize) than the stored value
+     */
+    bool better(ValueType const& value) const;
+
+    /*!
+     * Updates the stored value, if the given extremal value is better.
+     * @param other
+     * @return true if the extremum value of this changed
+     */
+    bool operator&=(Extremum const& other);
+
+    /*!
+     * Updates the stored value, if the given extremal value is better.
+     * @param other
+     * @return true if the extremum value of this changed
+     */
+    bool operator&=(Extremum&& other);
+
+    /*!
+     * Updates the stored value, if the given value is better.
+     * @param other
+     * @return true if the extremum value of this changed
+     */
+    bool operator&=(ValueType const& value);
+
+    /*!
+     * Updates the stored value, if the given value is better.
+     * @param other
+     * @return true if the extremum value of this changed
+     */
+    bool operator&=(ValueType&& value);
+
+    /*!
+     * @return true if this does not store any value (representing the extremum over an empty set)
+     */
+    bool empty() const;
+
+    /*!
+     * @pre this is not empty
+     * @return the stored extremal value
+     */
+    ValueType const& operator*() const;
+
+    /*!
+     * @pre this is not empty
+     * @return the stored extremal value
+     */
+    ValueType& operator*();
+
+    /*!
+     * @return the stored extremal value as an optional. Returns std::nullopt if this is empty
+     */
+    std::optional<ValueType> getOptionalValue() const;
+
+    /*!
+     * Forgets the extremal value so that this represents the extremum over an empty set.
+     */
+    void reset();
+
+   private:
+    /// indicates whether ValueType supports +/- infinity. If this is true we can use those values to encode an extremum over an empty set
+    static bool const SupportsInfinity = std::numeric_limits<ValueType>::is_iec559;
+
+    /// Data for the case that ValueType does not have infinity
+    struct DefaultData {
+        ValueType value;
+        bool empty{true};
+    };
+
+    /// Data for the case that ValueType has infinity
+    struct DataInfinity {
+        ValueType constexpr baseValue() const {
+            if constexpr (storm::solver::minimize(Dir)) {
+                return std::numeric_limits<ValueType>::infinity();
+            } else {
+                static_assert(storm::solver::maximize(Dir));
+                return -std::numeric_limits<ValueType>::infinity();
+            }
+        }
+        ValueType value{baseValue()};
+    };
+
+    /// Data
+    std::conditional_t<SupportsInfinity, DataInfinity, DefaultData> data;
+};
+
+template<typename ValueType>
+using Maximum = Extremum<storm::OptimizationDirection::Maximize, ValueType>;
+template<typename ValueType>
+using Minimum = Extremum<storm::OptimizationDirection::Minimize, ValueType>;
+
+}  // namespace storm::utility

--- a/src/storm/utility/KwekMehlhorn.cpp
+++ b/src/storm/utility/KwekMehlhorn.cpp
@@ -42,7 +42,7 @@ std::pair<typename NumberTraits<RationalType>::IntegerType, typename NumberTrait
 template<typename RationalType>
 std::pair<typename NumberTraits<RationalType>::IntegerType, typename NumberTraits<RationalType>::IntegerType> truncateToRational(double const& value,
                                                                                                                                  uint64_t precision) {
-    if (precision >= 18) {
+    if (precision > std::numeric_limits<double>::max_digits10) {
         throw storm::exceptions::PrecisionExceededException() << "Exceeded precision of double, consider switching to rational numbers.";
     }
 

--- a/src/storm/utility/vector.h
+++ b/src/storm/utility/vector.h
@@ -1092,6 +1092,7 @@ std::vector<T> getConstrainedOffsetVector(std::vector<T> const& offsetVector, st
 /*!
  * Converts the given vector to the given ValueType
  * Assumes that both, TargetType and SourceType are numeric
+ * @return the resulting vector
  */
 template<typename TargetType, typename SourceType>
 std::vector<TargetType> convertNumericVector(std::vector<SourceType> const& oldVector) {
@@ -1101,6 +1102,21 @@ std::vector<TargetType> convertNumericVector(std::vector<SourceType> const& oldV
         resultVector.push_back(storm::utility::convertNumber<TargetType>(oldValue));
     }
     return resultVector;
+}
+
+/*!
+ * Converts the given vector to the given ValueType
+ * Assumes that both, TargetType and SourceType are numeric
+ *
+ * @param inputVector the vector that needs to be converted
+ * @param targetVector the vector where the result is written to. Should have the same size as inputVector
+ *
+ * @note this does not allocate new memory
+ */
+template<typename TargetType, typename SourceType>
+void convertNumericVector(std::vector<SourceType> const& inputVector, std::vector<TargetType>& targetVector) {
+    assert(inputVector.size() == targetVector.size());
+    applyPointwise(inputVector, targetVector, [](SourceType const& v) { return storm::utility::convertNumber<TargetType>(v); });
 }
 
 /*!

--- a/src/test/storm/modelchecker/multiobjective/SparseMaPcaaMultiObjectiveModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/multiobjective/SparseMaPcaaMultiObjectiveModelCheckerTest.cpp
@@ -87,9 +87,10 @@ TEST(SparseMaPcaaMultiObjectiveModelCheckerTest, server) {
     auto expectedAchievableValues =
         storm::storage::geometry::Polytope<storm::RationalNumber>::createDownwardClosure(std::vector<std::vector<storm::RationalNumber>>(
             {storm::utility::vector::convertNumericVector<storm::RationalNumber>(p), storm::utility::vector::convertNumericVector<storm::RationalNumber>(q)}));
-    // due to precision issues, we enlarge one of the polytopes before checking containement
+    // due to precision issues, we enlarge one of the polytopes before checking containment
     storm::RationalNumber eps =
         storm::utility::convertNumber<storm::RationalNumber>(storm::settings::getModule<storm::settings::modules::GeneralSettings>().getPrecision());
+    eps += eps;
     std::vector<storm::RationalNumber> lb(2, -eps), ub(2, eps);
     auto bloatingBox = storm::storage::geometry::Hyperrectangle<storm::RationalNumber>(lb, ub).asPolytope();
 
@@ -97,7 +98,6 @@ TEST(SparseMaPcaaMultiObjectiveModelCheckerTest, server) {
         // TODO: z3 v4.8.8 is known to be broken here. Check if this is fixed in future versions >4.8.8
         GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
     }
-
     EXPECT_TRUE(
         expectedAchievableValues->minkowskiSum(bloatingBox)
             ->contains(result->asExplicitParetoCurveCheckResult<double>().getUnderApproximation()->convertNumberRepresentation<storm::RationalNumber>()));
@@ -105,7 +105,9 @@ TEST(SparseMaPcaaMultiObjectiveModelCheckerTest, server) {
                     .getOverApproximation()
                     ->convertNumberRepresentation<storm::RationalNumber>()
                     ->minkowskiSum(bloatingBox)
-                    ->contains(expectedAchievableValues));
+                    ->contains(expectedAchievableValues))
+        << "Result over-approximation is \n"
+        << result->asExplicitParetoCurveCheckResult<double>().getOverApproximation()->toString(true);
 }
 
 TEST(SparseMaPcaaMultiObjectiveModelCheckerTest, jobscheduler_pareto_3Obj) {

--- a/src/test/storm/solver/LinearEquationSolverTest.cpp
+++ b/src/test/storm/solver/LinearEquationSolverTest.cpp
@@ -23,6 +23,20 @@ class NativeDoublePowerEnvironment {
     }
 };
 
+class NativeDoublePowerRegMultEnvironment {
+   public:
+    typedef double ValueType;
+    static const bool isExact = false;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Native);
+        env.solver().native().setMethod(storm::solver::NativeLinearEquationSolverMethod::Power);
+        env.solver().native().setPrecision(storm::utility::convertNumber<storm::RationalNumber, std::string>("1e-10"));
+        env.solver().native().setPowerMethodMultiplicationStyle(storm::solver::MultiplicationStyle::Regular);
+        return env;
+    }
+};
+
 class NativeDoubleSoundValueIterationEnvironment {
    public:
     typedef double ValueType;
@@ -312,12 +326,13 @@ class LinearEquationSolverTest : public ::testing::Test {
     storm::Environment _environment;
 };
 
-typedef ::testing::Types<NativeDoublePowerEnvironment, NativeDoubleSoundValueIterationEnvironment, NativeDoubleOptimisticValueIterationEnvironment,
-                         NativeDoubleIntervalIterationEnvironment, NativeDoubleJacobiEnvironment, NativeDoubleGaussSeidelEnvironment,
-                         NativeDoubleSorEnvironment, NativeDoubleWalkerChaeEnvironment, NativeRationalRationalSearchEnvironment, EliminationRationalEnvironment,
-                         GmmGmresIluEnvironment, GmmGmresDiagonalEnvironment, GmmGmresNoneEnvironment, GmmBicgstabIluEnvironment, GmmQmrDiagonalEnvironment,
-                         EigenDGmresDiagonalEnvironment, EigenGmresIluEnvironment, EigenBicgstabNoneEnvironment, EigenDoubleLUEnvironment,
-                         EigenRationalLUEnvironment, TopologicalEigenRationalLUEnvironment>
+typedef ::testing::Types<NativeDoublePowerEnvironment, NativeDoublePowerRegMultEnvironment, NativeDoubleSoundValueIterationEnvironment,
+                         NativeDoubleOptimisticValueIterationEnvironment, NativeDoubleIntervalIterationEnvironment, NativeDoubleJacobiEnvironment,
+                         NativeDoubleGaussSeidelEnvironment, NativeDoubleSorEnvironment, NativeDoubleWalkerChaeEnvironment,
+                         NativeRationalRationalSearchEnvironment, EliminationRationalEnvironment, GmmGmresIluEnvironment, GmmGmresDiagonalEnvironment,
+                         GmmGmresNoneEnvironment, GmmBicgstabIluEnvironment, GmmQmrDiagonalEnvironment, EigenDGmresDiagonalEnvironment,
+                         EigenGmresIluEnvironment, EigenBicgstabNoneEnvironment, EigenDoubleLUEnvironment, EigenRationalLUEnvironment,
+                         TopologicalEigenRationalLUEnvironment>
     TestingTypes;
 
 TYPED_TEST_SUITE(LinearEquationSolverTest, TestingTypes, );

--- a/src/test/storm/solver/MinMaxLinearEquationSolverTest.cpp
+++ b/src/test/storm/solver/MinMaxLinearEquationSolverTest.cpp
@@ -24,6 +24,19 @@ class DoubleViEnvironment {
     }
 };
 
+class DoubleViRegMultEnvironment {
+   public:
+    typedef double ValueType;
+    static const bool isExact = false;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.solver().minMax().setMethod(storm::solver::MinMaxMethod::ValueIteration);
+        env.solver().minMax().setPrecision(storm::utility::convertNumber<storm::RationalNumber>(1e-8));
+        env.solver().minMax().setMultiplicationStyle(storm::solver::MultiplicationStyle::Regular);
+        return env;
+    }
+};
+
 class DoubleSoundViEnvironment {
    public:
     typedef double ValueType;
@@ -141,9 +154,9 @@ class MinMaxLinearEquationSolverTest : public ::testing::Test {
     storm::Environment _environment;
 };
 
-typedef ::testing::Types<DoubleViEnvironment, DoubleSoundViEnvironment, DoubleIntervalIterationEnvironment, DoubleOptimisticViEnvironment,
-                         DoubleTopologicalViEnvironment, DoubleTopologicalCudaViEnvironment, DoublePIEnvironment, RationalPIEnvironment,
-                         RationalRationalSearchEnvironment>
+typedef ::testing::Types<DoubleViEnvironment, DoubleViRegMultEnvironment, DoubleSoundViEnvironment, DoubleIntervalIterationEnvironment,
+                         DoubleOptimisticViEnvironment, DoubleTopologicalViEnvironment, DoubleTopologicalCudaViEnvironment, DoublePIEnvironment,
+                         RationalPIEnvironment, RationalRationalSearchEnvironment>
     TestingTypes;
 
 TYPED_TEST_SUITE(MinMaxLinearEquationSolverTest, TestingTypes, );


### PR DESCRIPTION
A re-implementation of 

* Value Iteration (VI)
* Optimistic Value Iteration (OVI)
* Sound Value Iteration (SVI)
* Interval Iteration (II)
* Rational Search (RS)

This provides a uniform way to implement Bellman-like operators using the new `ValueIterationOperator` class. Thanks to C++ templating, different *backends* can be provided to the operator to implement the different kinds of value iteration.

The new code removes quite a few code duplications (e.g. there was both DTMC + MDP code for VI,II, and RS; the OVI+SVI helper classes both had code doing the job of the new `ValueIterationOperator`). The hope is that this is now easier to maintain and extend towards e.g. other VI variants.

The new implementation improves performance, in particular for SVI, OVI, and II. Here are a few plots comparing runtime between the new/old versions of VI/OVI



<img width="747" alt="image" src="https://user-images.githubusercontent.com/17703338/233610506-e1314383-1949-415d-a561-7df01440cbcd.png">
