### PR TITLE
Fixed path for carl in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG no_threads=1
 WORKDIR /opt/
 
 # Obtain Carl from public repository
-RUN git clone https://github.com/moves-rwth/carl-storm.git
+RUN git clone https://github.com/moves-rwth/carl-storm.git carl
 
 # Switch to build directory
 RUN mkdir -p /opt/carl/build


### PR DESCRIPTION
Keep using the path `/opt/carl` in Dockerfile.