### PR TITLE
Website: Update home and build instructions

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -31,7 +31,7 @@
                 <div class="item">
                     <div class="jumbotron bg-front">
                         <h1>Efficient.</h1>
-                        <p>Its C++14 core focuses on time and memory efficiency.</p>
+                        <p>Its C++17 core focuses on time and memory efficiency.</p>
                         <div>
                             <a href="about.html" class="btn btn-default btn-md active" role="button" aria-pressed="true">Read more</a>
                         </div>
@@ -99,10 +99,12 @@
                             <div class="panel-body">
                                 Storm is built around discrete- and continuous-time Markov models:
                                 <ul>
-                                    <li>Discrete Time Markov Chains</li>
+                                    <li>Discrete-time Markov Chains</li>
                                     <li>Markov Decision Processes</li>
-                                    <li>Continuous Time Markov Chains</li>
+                                    <li>Continuous-time Markov Chains</li>
                                     <li>Markov Automata</li>
+                                    <li>Parametric Markov Models</li>
+                                    <li>Partially Observable Markov Models</li>
                                 </ul>
                                 <div class="pull-right">
                                     <a href="{{ '/documentation/background/models.html' | relative_url }}" class="btn btn-sm btn-default">Read more</a>
@@ -141,13 +143,14 @@
                                 <h3 class="panel-title">Properties</h3>
                             </div>
                             <div class="panel-body">
-                                Storm focuses on reachability queries and its support includes
+                                Supported model checking queries include
                                 <ul>
-                                    <li>PCTL and CSL</li>
-                                    <li>Expected Rewards</li>
+                                    <li>Reachability and Reach-Avoid Probabilities
+                                    <li>PCTL, CSL, and LTL Specifications</li>
+                                    <li>Expected Accumulated Rewards</li>
                                     <li>Long-run Average Rewards</li>
                                     <li>Conditional Probabilities</li>
-                                    <li>Multi-objective Model Checking</li>
+                                    <li>Multi-objective Analysis</li>
                                 </ul>
                                 <div class="pull-right">
                                     <a href="{{ '/documentation/background/properties.html' | relative_url }}" class="btn btn-sm btn-default">Read more</a>

--- a/documentation/obtain-storm/apple-silicon.md
+++ b/documentation/obtain-storm/apple-silicon.md
@@ -5,11 +5,23 @@ layout: default
 
 <h1>Building for ARM-based Apple Silicon Systems </h1>
 
-{:.alert .alert-info}
-_Native_ code compilation on ARM-based Apple Silicon systems is not yet supported. However, compilation with x86 emulation (Rosetta 2) does work just fine. We provide detailed installation steps for that below.
-Native ARM compilation is work in progress.
+## Native Compilation to an ARM binary (recommended)
 
-##  Installing Dependencies
+Storm compiles natively on ARM-based Apple Silicon processors. 
+However, there are a few points to consider for troubleshooting.
+
+* Make sure you have the latest version of Storm (Version 1.8.0 or later)
+* Make sure that you use an ARM compiled `cmake` binary (check with `where cmake` and `file path/to/cmake`)
+* Dependencies need to be installed using the *ARM* version of homebrew. Skip `cln` and `ginac` since (at the time of writing) they do not have an ARM version supported by homebrew
+* Carl also needs to be build without `cln` and `ginac`.
+* If you previously had an x86 version installed, you need to re-build Storm (and carl, if installed manually) from scratch. For this, remove the corresponding `build` folders and invoke the building steps again.
+* Examine the `cmake` output. It might have found an `x86` version of carl or another dependency. Homebrew dependencies should normally be found in `/opt/homebrew`, *not* in `/usr/local/`.
+* Contact us at [support@stormchecker.org](mailto:support@stormchecker.org) or on [GitHub](https://github.com/moves-rwth/storm) in case of issues.
+
+
+##  Compiling with x86 Emulation
+
+In some cases, e.g. when an older Storm version needs to be used, it might be necessary to compile an x86 version of Storm that can be run on Apple Silicon systems using Emulation via Rosetta 2.
 
 ### x86 Emulation and Development Tools
 Install Rosetta 2 and either the command line tools (CLT) or Xcode. Installing Rosetta 2 and the CLT can be done using the terminal by executing
@@ -18,8 +30,16 @@ $ softwareupdate --install-rosetta
 $ xcode-select --install
 ```
 
-{:.alert .alert-danger}
-Older versions of the CLT are known to cause issues during the installation. The following steps have successfully been tested using the CLT in version ```12.4.0.0.1.1610135815```. More recent versions should work as well.
+The following steps should be performed inside a x86 shell so that universal binaries are invoked correctly.
+If you are using `zsh` (which is the default shell on macOS), this can be done by executing `arch -x86_64 zsh`.
+To easily see that your shell runs in x86 mode, you can add the following lines to your `~/.zshrc` file:
+
+```console
+# modify the prompt if in x86 mode
+if [[ $(uname -m) == 'x86_64' ]]; then
+	expot PROMPT="%F{cyan}x86%f:$PROMPT"
+fi
+```
 
 ### Homebrew
 
@@ -59,20 +79,10 @@ Rosetta 2: true
 you are ready to continue.
 
 ### General Dependencies
-Install the x86 version of the [general dependencies](dependencies.html#general-dependencies) of Storm using homebrew. You need to enable x86 emulation (through Rosetta 2) by prefixing the brew command with `arch -x86_64`, e.g. by using the `brew86` alias:
-
-- Required:
-``` console
-$ brew86 install cln ginac automake cmake boost gmp glpk hwloc
-```
-
-- Recommended:
-``` console
-$ brew86 install cln ginac automake cmake boost gmp glpk hwloc z3 xerces-c
-```
+Install the x86 version of the [general dependencies](dependencies.html#general-dependencies) of Storm using homebrew. You need to enable x86 emulation (through Rosetta 2) by prefixing the `brew` command with `arch -x86_64`, e.g. by using the `brew86` alias that we set above.
  
 {:.alert .alert-info}
-If the wrong homebrew installation is specified, the installations are done to paths used for ARM binaries which will not work with Storm.
+If the wrong homebrew installation is specified, the installations are done to paths used for ARM binaries which will not work for x86 emulation.
 
 ### CMake
 ARM versions of CMake do often not play nicely with the compilation of dependencies Storm is using, which is why we recommend to use a x86 version of cmake. Check which architecture your cmake executable is targeting by executing:
@@ -93,15 +103,6 @@ where ```$X86_BREW``` is as explained [above](apple-silicon.html#homebrew).
 There are known issues when compiling Storm using older versions of CMake.
 These issues seem to have been fixed with cmake version ```3.19.5```. Make sure to use the latest version of CMake.
 
-## Building Storm from Source.
+### Building Storm from Source.
 
 You can now obtain, configure, and build Storm as outlined [here](build.html#obtaining-the-source-code).
-However, you need to ensure that you invoke universal binaries, in particular `cmake` and `make`, using ```arch -x86_64``` as a prefix.
-
-An easy way to ensure this is to start a new terminal session in x86 mode via
-```console
-arch -x86_64 zsh
-```
-
-{:.alert .alert-info}
-The prefix ```arch -x86_64``` is not necessary for non-universal x86 binaries. However, if you are not sure, you can just apply the prefix to all commands.

--- a/documentation/obtain-storm/build.md
+++ b/documentation/obtain-storm/build.md
@@ -24,17 +24,11 @@ While compiling the source code is not always a breeze (depending on your operat
 
 Currently, we provide support for
 
-- <i class="fa fa-apple" aria-hidden="true"></i> macOS 10.12 "Sierra" and higher on either x86- or [ARM-based](apple-silicon.html) CPUs
-- <i class="icon-debian"></i> Debian 9 "Stretch" and higher
-- <i class="icon-ubuntu"></i> Ubuntu 16.10 "Yakkety Yak" and higher
+- <i class="fa fa-apple" aria-hidden="true"></i> macOS on either x86- or [ARM-based](apple-silicon.html) CPUs
+- <i class="icon-debian"></i> Debian 10 and higher
+- <i class="icon-ubuntu"></i> Ubuntu 20.04 and higher
 
-which are known to enable the easy installation of Storm. Other Linux distributions are likely to work too, but it may take significant effort to get the required versions of the dependencies up and running. For example, thanks to [Joachim Klein](http://www.inf.tu-dresden.de/index.php?node_id=1473){:target="_blank"}, there is a [script]({{ '/resources/scripts/installation/storm-build-debian-jessie.sh' | relative_url }}) that installs Storm and some crucial dependencies on Debian 8 "Jessie".
-
-{:.alert .alert-danger}
-Note that in particular <i class="icon-ubuntu"></i>Ubuntu 16.04 "Xenial Xerus" is *not* supported anymore as the shipped GCC version is too old.
-
-{:.alert .alert-danger}
-For ARM-based <i class="fa fa-apple" aria-hidden="true"></i> Apple Silicon CPUs [further steps are necessary](apple-silicon.html){:.alert-link}.
+which are known to enable the easy installation of Storm. Other Linux distributions are likely to work too, but it may take significant effort to get the required versions of the dependencies up and running.
 
 ## Dependencies
 

--- a/documentation/obtain-storm/dependencies.md
+++ b/documentation/obtain-storm/dependencies.md
@@ -14,16 +14,7 @@ We both give a general list, as well as operating system specific hints how to i
 
 ## Compiler
 
-For the compilation step, a C++14-compliant compiler is required. Storm is known to work with
-
-- GCC 5.3, GCC 6
-- clang 3.5.0
-- AppleClang 8.0.0
-
-Newer versions of these compilers will probably work, but are not necessarily tested. In particular, the following list of compilers is known to *not* work.
-
-- GCC versions 4.9.1 and older
-- clang 3.4 and older
+For the compilation step, a C++17-compliant compiler is required. Storm is known to work with GCC, Clang, and AppleClang.
 
 ## General Dependencies
 
@@ -43,7 +34,6 @@ Required:
 Recommended:
 - [Z3](https://github.com/Z3Prover/z3){:target="_blank"} (not strictly required, but already needed for standard tasks like PRISM/JANI model building)
 - [xerces-c](https://xerces.apache.org/xerces-c/){:target="_blank"} (needed for the parsing and export of XML files, in particular for GSPNs)
-- [Eigen3](http://eigen.tuxfamily.org/index.php){:target="_blank"} (installation prevents an expensive part of the build step)
 - [MathSAT](http://mathsat.fbk.eu/){:target="_blank"} (needed by the abstraction refinement engine, needs to be configured manually during the [configuration](manual-configuration.html#mathsat))
 
 
@@ -53,14 +43,29 @@ We collected some platform specific hints to ease the installation of Storm on t
 Since Storm has some optional dependencies that enhance it's functionality, and some dependencies that are strictly required, we show how to install both the *required* and *recommended* dependencies.
 The installation instructions of the *recommended* dependencies already include the *required* dependencies.
 
-### <i class="fa fa-apple" aria-hidden="true"></i> macOS 10.12 "Sierra" and higher
+### <i class="fa fa-apple" aria-hidden="true"></i> macOS
+
+Make sure that you use a recent macOS version.
+You need to download and install Xcode or its command line tools (CLT) to have the suitable tools needed for compilation. For more details, we refer to [this tutorial](https://www.moncefbelyamani.com/how-to-install-xcode-homebrew-git-rvm-ruby-on-mac/){:target="_blank"}.
+
+Furthermore, we recommend the usage of [Homebrew](https://brew.sh){:target="_blank"} to install the missing packages.
+
+#### Apple Silicon Systems
 
 {:.alert .alert-danger}
-For ARM-based <i class="fa fa-apple" aria-hidden="true"></i> Apple Silicon CPUs please refer to [this page](apple-silicon.html){:.alert-link}.
+For troubleshooting building on ARM-based <i class="fa fa-apple" aria-hidden="true"></i>  Apple Silicon CPUs and for building using x86 emulations, please refer to [this page](apple-silicon.html){:.alert-link}.
 
-First of all, you need to download and install Xcode or its command line tools (CLT) to have the suitable tools needed for compilation. For more details, we refer to [this tutorial](https://www.moncefbelyamani.com/how-to-install-xcode-homebrew-git-rvm-ruby-on-mac/){:target="_blank"}.
+- Required:
+``` console
+$ brew install automake cmake boost gmp glpk hwloc
+```
 
-Furthermore, we recommend the usage of [Homebrew](https://brew.sh){:target="_blank"} to install the missing packages, but MacPorts might (at some point) have the desired dependencies as well.
+- Recommended:
+``` console
+$ brew install automake cmake boost gmp glpk hwloc z3 xerces-c
+```
+
+#### Intel-based Systems
 
 - Required:
 ``` console
@@ -72,9 +77,11 @@ $ brew install cln ginac automake cmake boost gmp glpk hwloc
 $ brew install cln ginac automake cmake boost gmp glpk hwloc z3 xerces-c
 ```
 
-### <i class="icon-debian"></i> Debian 9 "Stretch" and higher, and
-### <i class="icon-ubuntu"></i> Ubuntu 18.04 "Bionic Beaver" and higher
+
+### <i class="icon-debian"></i> Debian and <i class="icon-ubuntu"></i> Ubuntu
 <!-- If these are changed, also change them in `vm.md` -->
+
+We currently support Debian from version 10 and Ubuntu from version 20.04.
 
 - Required:
 ``` console
@@ -91,19 +98,16 @@ $ sudo apt-get install build-essential git cmake libboost-all-dev libcln-dev lib
 
 ### CArL
 
-Storm makes use of [CArL](https://github.com/ths-rwth/carl){:target="_blank"} for the representation of rationals and rational functions. If you don't have it installed on your system, our build script will download and configure it automatically for you. However, under certain circumstances, you might want to install CArL yourself. This may for example be advantageous if you need to repeatedly build Storm from scratch or you want to change its source code. Installing CArL is as easy as
+Storm makes use of [CArL](https://github.com/moves-rwth/carl-storm){:target="_blank"} for the representation of rationals and rational functions. If you don't have it installed on your system, our build script will download and configure it automatically for you. However, under certain circumstances, you might want to install CArL yourself. This may for example be advantageous if you need to repeatedly build Storm from scratch or you want to change its source code. Installing CArL is as easy as
 
 ```console
-$ git clone -b master14 https://github.com/ths-rwth/carl
-$ cd carl
+$ git clone https://github.com/moves-rwth/carl-storm
+$ cd carl-storm
 $ mkdir build
 $ cd build
-$ cmake -DUSE_CLN_NUMBERS=ON -DUSE_GINAC=ON -DTHREAD_SAFE=ON ..
+$ cmake ..
 $ make lib_carl
 ```
-
-{:.alert .alert-warning}
-Make sure you are using the `master14` branch of CArL as the current master branch uses a newer C++ standard that Storm does not require and therefore does not enable.
 
 Once it is build, it will register itself to cmake so Storm can find your build automatically.
 
@@ -112,5 +116,5 @@ There may be problems with this auto-detection mechanism if you have multiple ve
 
 ## Boost
 
-Storm requires [Boost](http://www.boost.org/){:target="_blank"} to be available in a version that is at least 1.65.1. On the [supported operating systems](requirements.html) this can be easily achieved with readily available package managers.
+Storm requires [Boost](http://www.boost.org/){:target="_blank"} to be available in a recent version. On the [supported operating systems](requirements.html) this can be easily achieved with readily available package managers.
 If Boost is not present in a standard system locations (for example because it was manually built), it might not automatically be found by Storm. You can make Storm aware of the Boost location by passing `-DBOOST_ROOT=/path/to/boost` to the `cmake` invocation in the [configuration step](installation.html#configuration-step).


### PR DESCRIPTION
I generally tried to reduce statements like `we require at least version x.y of library Z`.
In most cases, its hard to maintain and test those statements and I'm sure at least some of them were quite outdated.

Also, any Ubuntu, Debian, or macOS systems that has been updated within the last two years should be fine, so these kind of statements are not as relevant as they were a couple of years ago.