### PR TITLE
Fixed compilation if Z3 is not present

### DIFF
--- a/src/storm/models/sparse/StandardRewardModel.h
+++ b/src/storm/models/sparse/StandardRewardModel.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <set>
 #include <vector>
 

--- a/src/storm/utility/solver.cpp
+++ b/src/storm/utility/solver.cpp
@@ -1,14 +1,14 @@
 #include "storm/utility/solver.h"
 
-#include "storm/solver/GlpkLpSolver.h"
-#include "storm/solver/GurobiLpSolver.h"
-#include "storm/solver/SoplexLpSolver.h"
-#include "storm/solver/Z3LpSolver.h"
-
+#include "storm/exceptions/InvalidOperationException.h"
 #include "storm/settings/SettingsManager.h"
 #include "storm/settings/modules/CoreSettings.h"
 #include "storm/settings/modules/GeneralSettings.h"
+#include "storm/solver/GlpkLpSolver.h"
+#include "storm/solver/GurobiLpSolver.h"
 #include "storm/solver/MathsatSmtSolver.h"
+#include "storm/solver/SoplexLpSolver.h"
+#include "storm/solver/Z3LpSolver.h"
 #include "storm/solver/Z3SmtSolver.h"
 #include "storm/utility/NumberTraits.h"
 

--- a/src/test/storm/solver/LpSolverTest.cpp
+++ b/src/test/storm/solver/LpSolverTest.cpp
@@ -355,10 +355,12 @@ TYPED_TEST(LpSolverTest, MILPOptimizeMin) {
     ASSERT_NO_THROW(solver->addConstraint("", y - x <= solver->getConstant(this->parseNumber("11/2"))));
     ASSERT_NO_THROW(solver->update());
 
+#ifdef STORM_HAVE_Z3_OPTIMIZE
     if (this->solverSelection() == storm::solver::LpSolverTypeSelection::Z3 && storm::test::z3AtLeastVersion(4, 8, 8)) {
         // TODO: z3 v4.8.8 is known to be broken here. Check if this is fixed in future versions >4.8.8
         GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
     }
+#endif
 
     ASSERT_NO_THROW(solver->optimize());
     ASSERT_TRUE(solver->isOptimal());
@@ -525,9 +527,11 @@ TYPED_TEST(LpSolverTest, Incremental) {
     ASSERT_TRUE(solver->isOptimal());
     EXPECT_NEAR(this->parseNumber("12"), solver->getContinuousValue(x), this->precision());
 
+#ifdef STORM_HAVE_Z3_OPTIMIZE
     if (this->solverSelection() == storm::solver::LpSolverTypeSelection::Z3 && !storm::test::z3AtLeastVersion(4, 8, 5)) {
         GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
     }
+#endif
 
     solver->push();
     ASSERT_NO_THROW(y = solver->addUnboundedContinuousVariable("y", 10));


### PR DESCRIPTION
In 99% of cases, z3 should be present anyway, but at least it should compile without it as well.