### PR TITLE
Added `#include <cstdint>` to some files

### DIFF
--- a/resources/3rdparty/modernjson/src/basic_json_forward.h
+++ b/resources/3rdparty/modernjson/src/basic_json_forward.h
@@ -2,6 +2,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace nlohmann {
 template<template<typename U, typename V, typename... Args> class ObjectType = std::map, template<typename U, typename... Args> class ArrayType = std::vector,

--- a/src/storm-cli-utilities/cli.h
+++ b/src/storm-cli-utilities/cli.h
@@ -1,8 +1,8 @@
 #ifndef STORM_UTILITY_CLI_H_
 #define STORM_UTILITY_CLI_H_
 
-#include <string>
 #include <cstdint>
+#include <string>
 
 namespace storm {
 namespace cli {

--- a/src/storm-cli-utilities/cli.h
+++ b/src/storm-cli-utilities/cli.h
@@ -2,6 +2,7 @@
 #define STORM_UTILITY_CLI_H_
 
 #include <string>
+#include <cstdint>
 
 namespace storm {
 namespace cli {

--- a/src/storm-gspn/builder/ExplicitGspnModelBuilder.cpp
+++ b/src/storm-gspn/builder/ExplicitGspnModelBuilder.cpp
@@ -1,332 +1,332 @@
-//#include "storm/builder/ExplicitGspnModelBuilder.h"
-//
-//#include "storm/models/sparse/StandardRewardModel.h"
-//
-//#include "storm/utility/macros.h"
-//#include "storm/exceptions/NotImplementedException.h"
-//#include "storm/storage/expressions/ExpressionManager.h"
-//#include "storm-parsers/parser/FormulaParser.h"
-//#include "storm/storage/expressions/ExpressionEvaluator.h"
-//
-// namespace storm {
-//    namespace builder {
-//
-//        template<typename ValueType>
-//        storm::models::sparse::MarkovAutomaton<ValueType> ExplicitGspnModelBuilder<ValueType>::translateGspn(storm::gspn::GSPN const& gspn, std::string const&
-//        formula) {
-//            // set the given gspn and compute the limits of the net
-//            this->gspn = gspn;
-//            computeCapacities(gspn);
-//
-//            // markings maps markings to their corresponding rowgroups (indices)
-//            markings = storm::storage::BitVectorHashMap<uint_fast64_t>(numberOfTotalBits, 100);
-//            builder = storm::storage::SparseMatrixBuilder<double>(0, 0, 0, false, true);
-//
-//            // add initial marking to todo list
-//            auto bitvector = gspn.getInitialMarking(numberOfBits, numberOfTotalBits)->getBitVector();
-//            findOrAddBitvectorToMarkings(*bitvector);
-//            currentRowIndex = 0;
-//
-//            // vector marking markovian states (vector contains an 1 if the state is markovian)
-//            storm::storage::BitVector markovianStates(0);
-//
-//            // vector containing the exit rates for the markovian states
-//            std::vector<ValueType> exitRates;
-//
-//
-//            while (!todo.empty()) {
-//                // take next element from the todo list
-//                auto currentBitvector = todo.front();
-//                todo.pop_front();
-//                auto currentMarking = storm::gspn::Marking(gspn.getNumberOfPlaces(), numberOfBits, *currentBitvector);
-//
-//                // increment list of states by one
-//                markovianStates.resize(markovianStates.size() + 1, 0);
-//
-//                // create new row group for the current marking
-//                builder.newRowGroup(markings.getValue(*currentBitvector));
-//
-//                std::cout << "work on: " << *currentBitvector << '\n';
-//
-//                auto enabledImmediateTransitions = getEnabledImmediateTransition(currentMarking);
-//                if (!enabledImmediateTransitions.empty()) {
-//                    markovianStates.set(currentRowIndex, 0);
-//                    exitRates.push_back(0);
-//
-//                    auto partitions = partitonEnabledImmediateTransitions(currentMarking, enabledImmediateTransitions);
-//                    addRowForPartitions(partitions, currentMarking);
-//                } else {
-//
-//                    auto enabledTimedTransitions = getEnabledTimedTransition(currentMarking);
-//                    if (!enabledTimedTransitions.empty()) {
-//                        markovianStates.set(currentRowIndex, 1);
-//
-//                        auto accRate = getAccumulatedRate(enabledTimedTransitions);
-//                        std::cout << "\t\tacc. rate: " << accRate << '\n';
-//                        exitRates.push_back(accRate);
-//
-//                        addRowForTimedTransitions(enabledTimedTransitions, currentMarking, accRate);
-//                    } else {
-//                        markovianStates.set(currentRowIndex, 1);
-//                    }
-//                }
-//                ++currentRowIndex;
-//            }
-//
-//            auto matrix = builder.build();
-//
-//            // create expression manager and add variables from the gspn
-//            auto expressionManager = std::make_shared<storm::expressions::ExpressionManager>();
-//            for (auto& place : gspn.getPlaces()) {
-//                expressionManager->declareIntegerVariable(place.getName());
-//            }
-//
-//            // parse formula
-//            storm::parser::FormulaParser formulaParser(expressionManager);
-//            auto formulaPtr = formulaParser.parseSingleFormulaFromString(formula);
-//            auto atomicFormulas = formulaPtr->getAtomicExpressionFormulas();
-//
-//            // create empty state labeling
-//            storm::models::sparse::StateLabeling labeling(markings.size());
-//            storm::expressions::ExpressionEvaluator<double> expressionEvaluator(*expressionManager);
-//
-//            std::cout << '\n';
-//            std::cout << "build labeling:\n";
-//            for (auto& atomicFormula : atomicFormulas) {
-//                std::cout << atomicFormula;
-//                auto label = atomicFormula->toString();
-//                labeling.addLabel(label);
-//
-//                for (auto statePair : markings) {
-//                    auto marking = storm::gspn::Marking(gspn.getNumberOfPlaces(), numberOfBits, statePair.first);
-//                    for (auto& place : gspn.getPlaces()) {
-//                        auto variable = expressionManager->getVariable(place.getName());
-//                        expressionEvaluator.setIntegerValue(variable, marking.getNumberOfTokensAt(place.getID()));
-//                    }
-//                    bool hold = expressionEvaluator.asBool(atomicFormula->getExpression());
-//                    if (hold) {
-//                        labeling.addLabelToState(label, statePair.second);
-//                    }
-//                }
-//
-//            }
-//
-//            //auto labeling = getStateLabeling();
-//
-//            return storm::models::sparse::MarkovAutomaton<double>(matrix, labeling, markovianStates, exitRates);
-//        }
-//
-//        template<typename ValueType>
-//        void ExplicitGspnModelBuilder<ValueType>::addRowForPartitions(std::vector<std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>>>
-//        const& partitions, storm::gspn::Marking const& currentMarking) {
-//            for (auto& partition : partitions) {
-//                std::cout << "\tnew partition:\n";
-//                auto accWeight = getAccumulatedWeight(partition);
-//                std::cout << "\t\tacc. weight: " << accWeight << '\n';
-//
-//                std::map<uint_fast64_t , double, storm::builder::ExplicitGspnModelBuilder<ValueType>::cmpByIndex> weights;
-//                for (auto& trans : partition) {
-//                    std::cout << "\t\ttransname: " << trans.getName() << '\n';
-//                    auto newMarking = trans.fire(currentMarking);
-//                    std::cout << "\t\t\t target marking: " << *newMarking.getBitVector() << '\n';
-//
-//                    findOrAddBitvectorToMarkings(*newMarking.getBitVector());
-//
-//                    auto it = weights.find(markings.getValue(*newMarking.getBitVector()));
-//                    double currentWeight = 0;
-//                    if (it != weights.end()) {
-//                        currentWeight = weights.at(markings.getValue(*newMarking.getBitVector()));
-//                    }
-//                    currentWeight += trans.getWeight() / accWeight;
-//                    weights[markings.getValue(*newMarking.getBitVector())] = currentWeight;
-//                }
-//
-//                addValuesToBuilder(weights);
-//            }
-//        }
-//
-//        template<typename ValueType>
-//        void ExplicitGspnModelBuilder<ValueType>::addRowForTimedTransitions(std::vector<std::shared_ptr<storm::gspn::TimedTransition<double>>> const&
-//        enabledTimedTransitions, storm::gspn::Marking const& currentMarking, double const& accRate) {
-//            std::map<uint_fast64_t , double, storm::builder::ExplicitGspnModelBuilder<ValueType>::cmpByIndex> rates;
-//            for (auto& trans : enabledTimedTransitions) {
-//                std::cout << "\t\ttransname: " << trans.getName() << '\n';
-//                auto newMarking = trans.fire(currentMarking);
-//                std::cout << "\t\t\t target marking: " << *newMarking.getBitVector() << '\n';
-//
-//                findOrAddBitvectorToMarkings(*newMarking.getBitVector());
-//
-//                auto it = rates.find(markings.getValue(*newMarking.getBitVector()));
-//                double currentWeightRate = 0;
-//                if (it != rates.end()) {
-//                    currentWeightRate = rates.at(markings.getValue(*newMarking.getBitVector()));
-//                }
-//                currentWeightRate += trans.getRate() / accRate;
-//                rates[markings.getValue(*newMarking.getBitVector())] = currentWeightRate;
-//
-//            }
-//
-//            addValuesToBuilder(rates);
-//        }
-//
-//        template<typename ValueType>
-//        void ExplicitGspnModelBuilder<ValueType>::addValuesToBuilder(std::map<uint_fast64_t , double,
-//        storm::builder::ExplicitGspnModelBuilder<ValueType>::cmpByIndex> const& values) {
-//            for (auto& it : values) {
-//                std::cout << "\t\tadd value \"" << it.second << "\" to " << getBitvector(it.first) << '\n';
-//                builder.addNextValue(currentRowIndex, it.first, it.second);
-//            }
-//        }
-//
-//        template<typename ValueType>
-//        std::vector<std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>>>
-//        ExplicitGspnModelBuilder<ValueType>::partitonEnabledImmediateTransitions(
-//                storm::gspn::Marking const& marking,
-//                std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>> const& enabledImmediateTransitions) {
-//            decltype(partitonEnabledImmediateTransitions(marking, enabledImmediateTransitions)) result;
-//
-//            std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>> weightedTransitions;
-//
-//            for (auto& trans : enabledImmediateTransitions) {
-//                if (trans.noWeightAttached()) {
-//                    decltype(weightedTransitions) singleton;
-//                    singleton.push_back(trans);
-//                    result.push_back(singleton);
-//                } else {
-//                    weightedTransitions.push_back(trans);
-//                }
-//            }
-//
-//            if (weightedTransitions.size() != 0) {
-//                result.push_back(weightedTransitions);
-//            }
-//
-//            return result;
-//        }
-//
-//        template<typename ValueType>
-//        double ExplicitGspnModelBuilder<ValueType>::getAccumulatedWeight(std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>> const& vector)
-//        const {
-//            double result = 0;
-//
-//            for (auto &trans : vector) {
-//                result += trans.getWeight();
-//            }
-//
-//            return result;
-//        }
-//
-//        template<typename ValueType>
-//        void ExplicitGspnModelBuilder<ValueType>::computeCapacities(storm::gspn::GSPN const& gspn) {
-//            uint_fast64_t sum = 0;
-//            for (auto& place : gspn.getPlaces()) {//TODO
-//                numberOfBits[place.getID()] = 1;
-//                sum += numberOfBits[place.getID()];
-//            }
-//
-//            // compute next multiple of 64
-//            uint_fast64_t rem = sum % 64;
-//            numberOfTotalBits = sum + 64 - rem;
-//        }
-//
-//        template<typename ValueType>
-//        std::vector<std::shared_ptr<storm::gspn::TimedTransition<double>>> ExplicitGspnModelBuilder<ValueType>::getEnabledTimedTransition(
-//                storm::gspn::Marking const& marking) {
-//            std::vector<std::shared_ptr<storm::gspn::TimedTransition<double>>>result;
-//
-//            uint_fast64_t highestSeenPriority = 0;
-//
-//            for (auto& trans : gspn.getTimedTransitions()) {
-//                if (trans.isEnabled(marking)) {
-//                    if (trans.getPriority() > highestSeenPriority) {
-//                        highestSeenPriority = trans.getPriority();
-//                        result.clear();
-//                    }
-//                    result.push_back(trans);
-//                }
-//            }
-//
-//            return result;
-//        }
-//
-//        template<typename ValueType>
-//        std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>> ExplicitGspnModelBuilder<ValueType>::getEnabledImmediateTransition(
-//                storm::gspn::Marking const& marking) {
-//            std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>>result;
-//
-//            uint_fast64_t highestSeenPriority = 0;
-//
-//            for (auto& trans : gspn.getImmediateTransitions()) {
-//                if (trans.isEnabled(marking)) {
-//                    if (trans.getPriority() > highestSeenPriority) {
-//                        highestSeenPriority = trans.getPriority();
-//                        result.clear();
-//                    }
-//                    result.push_back(trans);
-//                }
-//            }
-//
-//            return result;
-//        }
-//
-//        template<typename ValueType>
-//        double ExplicitGspnModelBuilder<ValueType>::getAccumulatedRate(std::vector<std::shared_ptr<storm::gspn::TimedTransition<double>>> const& vector) {
-//            double result = 0;
-//            for (auto trans : vector) {
-//                result += trans.getRate();
-//            }
-//
-//            return result;
-//        }
-//
-//        template<typename ValueType>
-//        storm::storage::BitVector ExplicitGspnModelBuilder<ValueType>::getBitvector(uint_fast64_t const& index) {
-//            for (auto it = markings.begin(); it != markings.end(); ++it) {
-//                if (std::get<1>(*it) == index) {
-//                    return std::get<0>(*it);
-//                }
-//            }
-//            return storm::storage::BitVector();
-//        }
-//
-//        template<typename ValueType>
-//        uint_fast64_t ExplicitGspnModelBuilder<ValueType>::findOrAddBitvectorToMarkings(storm::storage::BitVector const &bitvector) {
-//            auto index = markings.findOrAdd(bitvector, nextRowGroupIndex);
-//
-//            if (index == nextRowGroupIndex) {
-//                // bitvector was not already in the map
-//                ++nextRowGroupIndex;
-//                // bitvector was also never in the todo list
-//                todo.push_back(std::make_shared<storm::storage::BitVector>(bitvector));
-//            }
-//            return index;
-//        }
-//
-//        template<typename ValueType>
-//        storm::models::sparse::StateLabeling ExplicitGspnModelBuilder<ValueType>::getStateLabeling() const {
-//            storm::models::sparse::StateLabeling labeling(markings.size());
-//
-//            std::map<uint_fast64_t , std::string> idToName;
-//            for (auto& place : gspn.getPlaces()) {
-//                idToName[place.getID()] = place.getName();
-//                labeling.addLabel(place.getName());
-//            }
-//
-//            auto it = markings.begin();
-//            for ( ; it != markings.end() ; ++it) {
-//                auto bitvector = std::get<0>(*it);
-//                storm::gspn::Marking marking(gspn.getNumberOfPlaces(), numberOfBits, bitvector);
-//                for (auto i = 0; i < marking.getNumberOfPlaces(); i++) {
-//                    if (marking.getNumberOfTokensAt(i) > 0) {
-//                        std::cout << i << '\n';
-//                        labeling.addLabelToState(idToName.at(i), i);
-//                    }
-//                }
-//            }
-//
-//            return labeling;
-//        }
-//
-//        template class ExplicitGspnModelBuilder<double>;
-//    }
-//}
+// #include "storm/builder/ExplicitGspnModelBuilder.h"
+//
+// #include "storm/models/sparse/StandardRewardModel.h"
+//
+// #include "storm/utility/macros.h"
+// #include "storm/exceptions/NotImplementedException.h"
+// #include "storm/storage/expressions/ExpressionManager.h"
+// #include "storm-parsers/parser/FormulaParser.h"
+// #include "storm/storage/expressions/ExpressionEvaluator.h"
+//
+//  namespace storm {
+//     namespace builder {
+//
+//         template<typename ValueType>
+//         storm::models::sparse::MarkovAutomaton<ValueType> ExplicitGspnModelBuilder<ValueType>::translateGspn(storm::gspn::GSPN const& gspn, std::string
+//         const& formula) {
+//             // set the given gspn and compute the limits of the net
+//             this->gspn = gspn;
+//             computeCapacities(gspn);
+//
+//             // markings maps markings to their corresponding rowgroups (indices)
+//             markings = storm::storage::BitVectorHashMap<uint_fast64_t>(numberOfTotalBits, 100);
+//             builder = storm::storage::SparseMatrixBuilder<double>(0, 0, 0, false, true);
+//
+//             // add initial marking to todo list
+//             auto bitvector = gspn.getInitialMarking(numberOfBits, numberOfTotalBits)->getBitVector();
+//             findOrAddBitvectorToMarkings(*bitvector);
+//             currentRowIndex = 0;
+//
+//             // vector marking markovian states (vector contains an 1 if the state is markovian)
+//             storm::storage::BitVector markovianStates(0);
+//
+//             // vector containing the exit rates for the markovian states
+//             std::vector<ValueType> exitRates;
+//
+//
+//             while (!todo.empty()) {
+//                 // take next element from the todo list
+//                 auto currentBitvector = todo.front();
+//                 todo.pop_front();
+//                 auto currentMarking = storm::gspn::Marking(gspn.getNumberOfPlaces(), numberOfBits, *currentBitvector);
+//
+//                 // increment list of states by one
+//                 markovianStates.resize(markovianStates.size() + 1, 0);
+//
+//                 // create new row group for the current marking
+//                 builder.newRowGroup(markings.getValue(*currentBitvector));
+//
+//                 std::cout << "work on: " << *currentBitvector << '\n';
+//
+//                 auto enabledImmediateTransitions = getEnabledImmediateTransition(currentMarking);
+//                 if (!enabledImmediateTransitions.empty()) {
+//                     markovianStates.set(currentRowIndex, 0);
+//                     exitRates.push_back(0);
+//
+//                     auto partitions = partitonEnabledImmediateTransitions(currentMarking, enabledImmediateTransitions);
+//                     addRowForPartitions(partitions, currentMarking);
+//                 } else {
+//
+//                     auto enabledTimedTransitions = getEnabledTimedTransition(currentMarking);
+//                     if (!enabledTimedTransitions.empty()) {
+//                         markovianStates.set(currentRowIndex, 1);
+//
+//                         auto accRate = getAccumulatedRate(enabledTimedTransitions);
+//                         std::cout << "\t\tacc. rate: " << accRate << '\n';
+//                         exitRates.push_back(accRate);
+//
+//                         addRowForTimedTransitions(enabledTimedTransitions, currentMarking, accRate);
+//                     } else {
+//                         markovianStates.set(currentRowIndex, 1);
+//                     }
+//                 }
+//                 ++currentRowIndex;
+//             }
+//
+//             auto matrix = builder.build();
+//
+//             // create expression manager and add variables from the gspn
+//             auto expressionManager = std::make_shared<storm::expressions::ExpressionManager>();
+//             for (auto& place : gspn.getPlaces()) {
+//                 expressionManager->declareIntegerVariable(place.getName());
+//             }
+//
+//             // parse formula
+//             storm::parser::FormulaParser formulaParser(expressionManager);
+//             auto formulaPtr = formulaParser.parseSingleFormulaFromString(formula);
+//             auto atomicFormulas = formulaPtr->getAtomicExpressionFormulas();
+//
+//             // create empty state labeling
+//             storm::models::sparse::StateLabeling labeling(markings.size());
+//             storm::expressions::ExpressionEvaluator<double> expressionEvaluator(*expressionManager);
+//
+//             std::cout << '\n';
+//             std::cout << "build labeling:\n";
+//             for (auto& atomicFormula : atomicFormulas) {
+//                 std::cout << atomicFormula;
+//                 auto label = atomicFormula->toString();
+//                 labeling.addLabel(label);
+//
+//                 for (auto statePair : markings) {
+//                     auto marking = storm::gspn::Marking(gspn.getNumberOfPlaces(), numberOfBits, statePair.first);
+//                     for (auto& place : gspn.getPlaces()) {
+//                         auto variable = expressionManager->getVariable(place.getName());
+//                         expressionEvaluator.setIntegerValue(variable, marking.getNumberOfTokensAt(place.getID()));
+//                     }
+//                     bool hold = expressionEvaluator.asBool(atomicFormula->getExpression());
+//                     if (hold) {
+//                         labeling.addLabelToState(label, statePair.second);
+//                     }
+//                 }
+//
+//             }
+//
+//             //auto labeling = getStateLabeling();
+//
+//             return storm::models::sparse::MarkovAutomaton<double>(matrix, labeling, markovianStates, exitRates);
+//         }
+//
+//         template<typename ValueType>
+//         void ExplicitGspnModelBuilder<ValueType>::addRowForPartitions(std::vector<std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>>>
+//         const& partitions, storm::gspn::Marking const& currentMarking) {
+//             for (auto& partition : partitions) {
+//                 std::cout << "\tnew partition:\n";
+//                 auto accWeight = getAccumulatedWeight(partition);
+//                 std::cout << "\t\tacc. weight: " << accWeight << '\n';
+//
+//                 std::map<uint_fast64_t , double, storm::builder::ExplicitGspnModelBuilder<ValueType>::cmpByIndex> weights;
+//                 for (auto& trans : partition) {
+//                     std::cout << "\t\ttransname: " << trans.getName() << '\n';
+//                     auto newMarking = trans.fire(currentMarking);
+//                     std::cout << "\t\t\t target marking: " << *newMarking.getBitVector() << '\n';
+//
+//                     findOrAddBitvectorToMarkings(*newMarking.getBitVector());
+//
+//                     auto it = weights.find(markings.getValue(*newMarking.getBitVector()));
+//                     double currentWeight = 0;
+//                     if (it != weights.end()) {
+//                         currentWeight = weights.at(markings.getValue(*newMarking.getBitVector()));
+//                     }
+//                     currentWeight += trans.getWeight() / accWeight;
+//                     weights[markings.getValue(*newMarking.getBitVector())] = currentWeight;
+//                 }
+//
+//                 addValuesToBuilder(weights);
+//             }
+//         }
+//
+//         template<typename ValueType>
+//         void ExplicitGspnModelBuilder<ValueType>::addRowForTimedTransitions(std::vector<std::shared_ptr<storm::gspn::TimedTransition<double>>> const&
+//         enabledTimedTransitions, storm::gspn::Marking const& currentMarking, double const& accRate) {
+//             std::map<uint_fast64_t , double, storm::builder::ExplicitGspnModelBuilder<ValueType>::cmpByIndex> rates;
+//             for (auto& trans : enabledTimedTransitions) {
+//                 std::cout << "\t\ttransname: " << trans.getName() << '\n';
+//                 auto newMarking = trans.fire(currentMarking);
+//                 std::cout << "\t\t\t target marking: " << *newMarking.getBitVector() << '\n';
+//
+//                 findOrAddBitvectorToMarkings(*newMarking.getBitVector());
+//
+//                 auto it = rates.find(markings.getValue(*newMarking.getBitVector()));
+//                 double currentWeightRate = 0;
+//                 if (it != rates.end()) {
+//                     currentWeightRate = rates.at(markings.getValue(*newMarking.getBitVector()));
+//                 }
+//                 currentWeightRate += trans.getRate() / accRate;
+//                 rates[markings.getValue(*newMarking.getBitVector())] = currentWeightRate;
+//
+//             }
+//
+//             addValuesToBuilder(rates);
+//         }
+//
+//         template<typename ValueType>
+//         void ExplicitGspnModelBuilder<ValueType>::addValuesToBuilder(std::map<uint_fast64_t , double,
+//         storm::builder::ExplicitGspnModelBuilder<ValueType>::cmpByIndex> const& values) {
+//             for (auto& it : values) {
+//                 std::cout << "\t\tadd value \"" << it.second << "\" to " << getBitvector(it.first) << '\n';
+//                 builder.addNextValue(currentRowIndex, it.first, it.second);
+//             }
+//         }
+//
+//         template<typename ValueType>
+//         std::vector<std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>>>
+//         ExplicitGspnModelBuilder<ValueType>::partitonEnabledImmediateTransitions(
+//                 storm::gspn::Marking const& marking,
+//                 std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>> const& enabledImmediateTransitions) {
+//             decltype(partitonEnabledImmediateTransitions(marking, enabledImmediateTransitions)) result;
+//
+//             std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>> weightedTransitions;
+//
+//             for (auto& trans : enabledImmediateTransitions) {
+//                 if (trans.noWeightAttached()) {
+//                     decltype(weightedTransitions) singleton;
+//                     singleton.push_back(trans);
+//                     result.push_back(singleton);
+//                 } else {
+//                     weightedTransitions.push_back(trans);
+//                 }
+//             }
+//
+//             if (weightedTransitions.size() != 0) {
+//                 result.push_back(weightedTransitions);
+//             }
+//
+//             return result;
+//         }
+//
+//         template<typename ValueType>
+//         double ExplicitGspnModelBuilder<ValueType>::getAccumulatedWeight(std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>> const&
+//         vector) const {
+//             double result = 0;
+//
+//             for (auto &trans : vector) {
+//                 result += trans.getWeight();
+//             }
+//
+//             return result;
+//         }
+//
+//         template<typename ValueType>
+//         void ExplicitGspnModelBuilder<ValueType>::computeCapacities(storm::gspn::GSPN const& gspn) {
+//             uint_fast64_t sum = 0;
+//             for (auto& place : gspn.getPlaces()) {//TODO
+//                 numberOfBits[place.getID()] = 1;
+//                 sum += numberOfBits[place.getID()];
+//             }
+//
+//             // compute next multiple of 64
+//             uint_fast64_t rem = sum % 64;
+//             numberOfTotalBits = sum + 64 - rem;
+//         }
+//
+//         template<typename ValueType>
+//         std::vector<std::shared_ptr<storm::gspn::TimedTransition<double>>> ExplicitGspnModelBuilder<ValueType>::getEnabledTimedTransition(
+//                 storm::gspn::Marking const& marking) {
+//             std::vector<std::shared_ptr<storm::gspn::TimedTransition<double>>>result;
+//
+//             uint_fast64_t highestSeenPriority = 0;
+//
+//             for (auto& trans : gspn.getTimedTransitions()) {
+//                 if (trans.isEnabled(marking)) {
+//                     if (trans.getPriority() > highestSeenPriority) {
+//                         highestSeenPriority = trans.getPriority();
+//                         result.clear();
+//                     }
+//                     result.push_back(trans);
+//                 }
+//             }
+//
+//             return result;
+//         }
+//
+//         template<typename ValueType>
+//         std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>> ExplicitGspnModelBuilder<ValueType>::getEnabledImmediateTransition(
+//                 storm::gspn::Marking const& marking) {
+//             std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>>result;
+//
+//             uint_fast64_t highestSeenPriority = 0;
+//
+//             for (auto& trans : gspn.getImmediateTransitions()) {
+//                 if (trans.isEnabled(marking)) {
+//                     if (trans.getPriority() > highestSeenPriority) {
+//                         highestSeenPriority = trans.getPriority();
+//                         result.clear();
+//                     }
+//                     result.push_back(trans);
+//                 }
+//             }
+//
+//             return result;
+//         }
+//
+//         template<typename ValueType>
+//         double ExplicitGspnModelBuilder<ValueType>::getAccumulatedRate(std::vector<std::shared_ptr<storm::gspn::TimedTransition<double>>> const& vector) {
+//             double result = 0;
+//             for (auto trans : vector) {
+//                 result += trans.getRate();
+//             }
+//
+//             return result;
+//         }
+//
+//         template<typename ValueType>
+//         storm::storage::BitVector ExplicitGspnModelBuilder<ValueType>::getBitvector(uint_fast64_t const& index) {
+//             for (auto it = markings.begin(); it != markings.end(); ++it) {
+//                 if (std::get<1>(*it) == index) {
+//                     return std::get<0>(*it);
+//                 }
+//             }
+//             return storm::storage::BitVector();
+//         }
+//
+//         template<typename ValueType>
+//         uint_fast64_t ExplicitGspnModelBuilder<ValueType>::findOrAddBitvectorToMarkings(storm::storage::BitVector const &bitvector) {
+//             auto index = markings.findOrAdd(bitvector, nextRowGroupIndex);
+//
+//             if (index == nextRowGroupIndex) {
+//                 // bitvector was not already in the map
+//                 ++nextRowGroupIndex;
+//                 // bitvector was also never in the todo list
+//                 todo.push_back(std::make_shared<storm::storage::BitVector>(bitvector));
+//             }
+//             return index;
+//         }
+//
+//         template<typename ValueType>
+//         storm::models::sparse::StateLabeling ExplicitGspnModelBuilder<ValueType>::getStateLabeling() const {
+//             storm::models::sparse::StateLabeling labeling(markings.size());
+//
+//             std::map<uint_fast64_t , std::string> idToName;
+//             for (auto& place : gspn.getPlaces()) {
+//                 idToName[place.getID()] = place.getName();
+//                 labeling.addLabel(place.getName());
+//             }
+//
+//             auto it = markings.begin();
+//             for ( ; it != markings.end() ; ++it) {
+//                 auto bitvector = std::get<0>(*it);
+//                 storm::gspn::Marking marking(gspn.getNumberOfPlaces(), numberOfBits, bitvector);
+//                 for (auto i = 0; i < marking.getNumberOfPlaces(); i++) {
+//                     if (marking.getNumberOfTokensAt(i) > 0) {
+//                         std::cout << i << '\n';
+//                         labeling.addLabelToState(idToName.at(i), i);
+//                     }
+//                 }
+//             }
+//
+//             return labeling;
+//         }
+//
+//         template class ExplicitGspnModelBuilder<double>;
+//     }
+// }

--- a/src/storm-gspn/builder/ExplicitGspnModelBuilder.h
+++ b/src/storm-gspn/builder/ExplicitGspnModelBuilder.h
@@ -1,175 +1,175 @@
-//#ifndef STORM_BUILDER_EXPLICITGSPNMODELBUILDER_H_
-//#define STORM_BUILDER_EXPLICITGSPNMODELBUILDER_H_
+// #ifndef STORM_BUILDER_EXPLICITGSPNMODELBUILDER_H_
+// #define STORM_BUILDER_EXPLICITGSPNMODELBUILDER_H_
 //
-//#include <string>
+// #include <string>
 //
-//#include "storm/models/sparse/MarkovAutomaton.h"
-//#include "storm/models/sparse/StandardRewardModel.h"
-//#include "storm/storage/BitVector.h"
-//#include "storm/storage/BitVectorHashMap.h"
-//#include "storm/storage/gspn/GSPN.h"
-//#include "storm/storage/gspn/ImmediateTransition.h"
-//#include "storm/storage/gspn/TimedTransition.h"
+// #include "storm/models/sparse/MarkovAutomaton.h"
+// #include "storm/models/sparse/StandardRewardModel.h"
+// #include "storm/storage/BitVector.h"
+// #include "storm/storage/BitVectorHashMap.h"
+// #include "storm/storage/gspn/GSPN.h"
+// #include "storm/storage/gspn/ImmediateTransition.h"
+// #include "storm/storage/gspn/TimedTransition.h"
 //
-// namespace storm {
-//    namespace builder {
+//  namespace storm {
+//     namespace builder {
 //
-//        /*!
-//         * This class provides the facilities for building an markov automaton.
-//         */
-//        template<typename ValueType=double>
-//        class ExplicitGspnModelBuilder {
-//        public:
+//         /*!
+//          * This class provides the facilities for building an markov automaton.
+//          */
+//         template<typename ValueType=double>
+//         class ExplicitGspnModelBuilder {
+//         public:
 //
-//            /*!
-//             * Builds an MarkovAutomaton from the given GSPN.
-//             *
-//             * @param gspn The gspn whose semantic is covered by the MarkovAutomaton
-//             * @return The resulting MarkovAutomaton
-//             */
-//            storm::models::sparse::MarkovAutomaton<ValueType> translateGspn(storm::gspn::GSPN const& gspn, std::string const& formula);
-//        private:
+//             /*!
+//              * Builds an MarkovAutomaton from the given GSPN.
+//              *
+//              * @param gspn The gspn whose semantic is covered by the MarkovAutomaton
+//              * @return The resulting MarkovAutomaton
+//              */
+//             storm::models::sparse::MarkovAutomaton<ValueType> translateGspn(storm::gspn::GSPN const& gspn, std::string const& formula);
+//         private:
 //
-//            /*!
-//             * Add for each partition a new row in the probability matrix.
-//             *
-//             * @param partitions The partitioned immediate transitions.
-//             * @param currentMarking The current marking which is considered at the moment.
-//             */
-//            void addRowForPartitions(std::vector<std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>>> const& partitions,
-//            storm::gspn::Marking const& currentMarking);
-//
-//
-//            /*!
-//             * Add row for a markovian state.
-//             *
-//             * @param enabledTimedTransitions List of enabled timed transitions.
-//             * @param currentMarking The current marking which is considered at the moment.
-//             * @param accRate The sum of all rates of the enabled timed transisitons
-//             */
-//            void addRowForTimedTransitions(std::vector<std::shared_ptr<storm::gspn::TimedTransition<double>>> const& enabledTimedTransitions,
-//            storm::gspn::Marking const& currentMarking, double const& accRate);
-//
-//            /*!
-//             * Struct for comparing unsigned integer for maps
-//             */
-//            struct cmpByIndex {
-//                bool operator()(const uint_fast64_t &a, const uint_fast64_t &b) const {
-//                    return a < b;
-//                }
-//            };
-//
-//            /*!
-//             * This method insert the values from a map into the matrix
-//             *
-//             * @param values The values which are inserted
-//             */
-//            void addValuesToBuilder(std::map<uint_fast64_t , double, storm::builder::ExplicitGspnModelBuilder<ValueType>::cmpByIndex> const& values);
+//             /*!
+//              * Add for each partition a new row in the probability matrix.
+//              *
+//              * @param partitions The partitioned immediate transitions.
+//              * @param currentMarking The current marking which is considered at the moment.
+//              */
+//             void addRowForPartitions(std::vector<std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>>> const& partitions,
+//             storm::gspn::Marking const& currentMarking);
 //
 //
-//            /*!
-//             * This method partitions all enabled immediate transitions w.r.t. a marking.
-//             * All enabled weighted immediate transitions are in one vector. Between these transitions
-//             * is chosen probabilistically by the weights.
-//             *
-//             * All other enabled non-weighted immediate transitions are in an singleton vector.
-//             * Between different vectors is chosen non-deterministically.
-//             *
-//             * @param marking The current marking which is considered.
-//             * @param enabledImmediateTransistions A vector of enabled immediate transitions.
-//             * @return The vector of vectors which is described above.
-//             */
-//            std::vector<std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>>> partitonEnabledImmediateTransitions(storm::gspn::Marking
-//            const& marking, std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>> const& enabledImmediateTransitions);
+//             /*!
+//              * Add row for a markovian state.
+//              *
+//              * @param enabledTimedTransitions List of enabled timed transitions.
+//              * @param currentMarking The current marking which is considered at the moment.
+//              * @param accRate The sum of all rates of the enabled timed transisitons
+//              */
+//             void addRowForTimedTransitions(std::vector<std::shared_ptr<storm::gspn::TimedTransition<double>>> const& enabledTimedTransitions,
+//             storm::gspn::Marking const& currentMarking, double const& accRate);
 //
-//            /*!
-//             * Computes the accumulated weight of immediate transisions which are stored in a list.
-//             *
-//             * @param vector List of immediate transisitions.
-//             */
-//            double getAccumulatedWeight(std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>> const& vector) const;
+//             /*!
+//              * Struct for comparing unsigned integer for maps
+//              */
+//             struct cmpByIndex {
+//                 bool operator()(const uint_fast64_t &a, const uint_fast64_t &b) const {
+//                     return a < b;
+//                 }
+//             };
 //
-//            /*!
-//             * Compute the upper bound for the number of tokens in each place.
-//             * Also computes the number of bits which are used to store a marking.
-//             *
-//             * @param gspn The corresponding gspn.
-//             */
-//            void computeCapacities(storm::gspn::GSPN const& gspn);
-//
-//            /*!
-//             * Returns the vector of enabled timed transition with the highest priority.
-//             *
-//             *
-//             * @param marking The current marking which is considered.
-//             * @return The vector of enabled timed transitions.
-//             */
-//            std::vector<std::shared_ptr<storm::gspn::TimedTransition<double>>> getEnabledTimedTransition(
-//                    storm::gspn::Marking const& marking);
-//
-//            /*!
-//             * Returns the vector of active immediate transition with the highest priority.
-//             *
-//             * @param marking The current marking which is considered.
-//             * @return The vector of enabled immediate transitions.
-//             */
-//            std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>> getEnabledImmediateTransition(
-//                    storm::gspn::Marking const& marking);
-//
-//            /*!
-//             * Computes the accumulated rate of a vector of timed transitions.
-//             *
-//             * @param vector The vector of timed transitions.
-//             * @return The accumulated rate.
-//             */
-//            double getAccumulatedRate(std::vector<std::shared_ptr<storm::gspn::TimedTransition<double>>> const& vector);
-//
-//            // is only needed for debugging purposes
-//            // since markings is injective, we can determine the bitvector
-//            storm::storage::BitVector getBitvector(uint_fast64_t const& index);
-//
-//            /*!
-//             * Adds the bitvector to the marking-map.
-//             * If the bitvector corresponds to a new marking the bitvector is added to the todo list.
-//             *
-//             * @return The rowGroup index for the bitvector.
-//             */
-//            uint_fast64_t findOrAddBitvectorToMarkings(storm::storage::BitVector const& bitvector);
-//
-//            /*!
-//             * Computes the state labeling and returns it.
-//             * Every state is labeled with its name.
-//             *
-//             * @return The computed state labeling.
-//             */
-//            storm::models::sparse::StateLabeling getStateLabeling() const;
+//             /*!
+//              * This method insert the values from a map into the matrix
+//              *
+//              * @param values The values which are inserted
+//              */
+//             void addValuesToBuilder(std::map<uint_fast64_t , double, storm::builder::ExplicitGspnModelBuilder<ValueType>::cmpByIndex> const& values);
 //
 //
-//            // contains the number of bits which are used the store the number of tokens at each place
-//            std::map<uint_fast64_t, uint_fast64_t> numberOfBits;
+//             /*!
+//              * This method partitions all enabled immediate transitions w.r.t. a marking.
+//              * All enabled weighted immediate transitions are in one vector. Between these transitions
+//              * is chosen probabilistically by the weights.
+//              *
+//              * All other enabled non-weighted immediate transitions are in an singleton vector.
+//              * Between different vectors is chosen non-deterministically.
+//              *
+//              * @param marking The current marking which is considered.
+//              * @param enabledImmediateTransistions A vector of enabled immediate transitions.
+//              * @return The vector of vectors which is described above.
+//              */
+//             std::vector<std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>>> partitonEnabledImmediateTransitions(storm::gspn::Marking
+//             const& marking, std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>> const& enabledImmediateTransitions);
 //
-//            // contains the number of bits used to create markings
-//            uint_fast64_t numberOfTotalBits;
+//             /*!
+//              * Computes the accumulated weight of immediate transisions which are stored in a list.
+//              *
+//              * @param vector List of immediate transisitions.
+//              */
+//             double getAccumulatedWeight(std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>> const& vector) const;
 //
-//            // maps bitvectors (markings w.r.t. the capacity) to their rowgroup
-//            storm::storage::BitVectorHashMap<uint_fast64_t> markings = storm::storage::BitVectorHashMap<uint_fast64_t>(64, 1);
+//             /*!
+//              * Compute the upper bound for the number of tokens in each place.
+//              * Also computes the number of bits which are used to store a marking.
+//              *
+//              * @param gspn The corresponding gspn.
+//              */
+//             void computeCapacities(storm::gspn::GSPN const& gspn);
 //
-//            // a list of markings for which the outgoing edges need to be computed
-//            std::deque<std::shared_ptr<storm::storage::BitVector>> todo;
+//             /*!
+//              * Returns the vector of enabled timed transition with the highest priority.
+//              *
+//              *
+//              * @param marking The current marking which is considered.
+//              * @return The vector of enabled timed transitions.
+//              */
+//             std::vector<std::shared_ptr<storm::gspn::TimedTransition<double>>> getEnabledTimedTransition(
+//                     storm::gspn::Marking const& marking);
 //
-//            //the gspn which is transformed
-//            storm::gspn::GSPN gspn;
+//             /*!
+//              * Returns the vector of active immediate transition with the highest priority.
+//              *
+//              * @param marking The current marking which is considered.
+//              * @return The vector of enabled immediate transitions.
+//              */
+//             std::vector<std::shared_ptr<storm::gspn::ImmediateTransition<double>>> getEnabledImmediateTransition(
+//                     storm::gspn::Marking const& marking);
 //
-//            // the next index for a new rowgroup
-//            uint_fast64_t nextRowGroupIndex = 0;
+//             /*!
+//              * Computes the accumulated rate of a vector of timed transitions.
+//              *
+//              * @param vector The vector of timed transitions.
+//              * @return The accumulated rate.
+//              */
+//             double getAccumulatedRate(std::vector<std::shared_ptr<storm::gspn::TimedTransition<double>>> const& vector);
 //
-//            // builder object which is used to create the probability matrix
-//            storm::storage::SparseMatrixBuilder<double> builder;
+//             // is only needed for debugging purposes
+//             // since markings is injective, we can determine the bitvector
+//             storm::storage::BitVector getBitvector(uint_fast64_t const& index);
 //
-//            // contains the current row index during the computation
-//            uint_fast64_t currentRowIndex;
-//        };
-//    }
-//}
+//             /*!
+//              * Adds the bitvector to the marking-map.
+//              * If the bitvector corresponds to a new marking the bitvector is added to the todo list.
+//              *
+//              * @return The rowGroup index for the bitvector.
+//              */
+//             uint_fast64_t findOrAddBitvectorToMarkings(storm::storage::BitVector const& bitvector);
 //
-//#endif //STORM_BUILDER_EXPLICITGSPNMODELBUILDER_H_
+//             /*!
+//              * Computes the state labeling and returns it.
+//              * Every state is labeled with its name.
+//              *
+//              * @return The computed state labeling.
+//              */
+//             storm::models::sparse::StateLabeling getStateLabeling() const;
+//
+//
+//             // contains the number of bits which are used the store the number of tokens at each place
+//             std::map<uint_fast64_t, uint_fast64_t> numberOfBits;
+//
+//             // contains the number of bits used to create markings
+//             uint_fast64_t numberOfTotalBits;
+//
+//             // maps bitvectors (markings w.r.t. the capacity) to their rowgroup
+//             storm::storage::BitVectorHashMap<uint_fast64_t> markings = storm::storage::BitVectorHashMap<uint_fast64_t>(64, 1);
+//
+//             // a list of markings for which the outgoing edges need to be computed
+//             std::deque<std::shared_ptr<storm::storage::BitVector>> todo;
+//
+//             //the gspn which is transformed
+//             storm::gspn::GSPN gspn;
+//
+//             // the next index for a new rowgroup
+//             uint_fast64_t nextRowGroupIndex = 0;
+//
+//             // builder object which is used to create the probability matrix
+//             storm::storage::SparseMatrixBuilder<double> builder;
+//
+//             // contains the current row index during the computation
+//             uint_fast64_t currentRowIndex;
+//         };
+//     }
+// }
+//
+// #endif //STORM_BUILDER_EXPLICITGSPNMODELBUILDER_H_

--- a/src/storm/exceptions/ExceptionMacros.h
+++ b/src/storm/exceptions/ExceptionMacros.h
@@ -5,19 +5,21 @@
  * Macro to generate descendant exception classes. As all classes are nearly the same, this makes changing common
  * features much easier.
  */
-#define STORM_NEW_EXCEPTION(exception_name)                                   \
-    class exception_name : public BaseException {                             \
-       public:                                                                \
-        exception_name() : BaseException() {}                                 \
-        exception_name(char const* cstr) : BaseException(cstr) {}             \
-        exception_name(exception_name const& cp) : BaseException(cp) {}       \
-        ~exception_name() throw() {}                                          \
-        virtual std::string type() const override { return #exception_name; } \
-        template<typename T>                                                  \
-        exception_name& operator<<(T const& var) {                            \
-            this->stream << var;                                              \
-            return *this;                                                     \
-        }                                                                     \
+#define STORM_NEW_EXCEPTION(exception_name)                             \
+    class exception_name : public BaseException {                       \
+       public:                                                          \
+        exception_name() : BaseException() {}                           \
+        exception_name(char const* cstr) : BaseException(cstr) {}       \
+        exception_name(exception_name const& cp) : BaseException(cp) {} \
+        ~exception_name() throw() {}                                    \
+        virtual std::string type() const override {                     \
+            return #exception_name;                                     \
+        }                                                               \
+        template<typename T>                                            \
+        exception_name& operator<<(T const& var) {                      \
+            this->stream << var;                                        \
+            return *this;                                               \
+        }                                                               \
     };
 
 #endif /* STORM_EXCEPTIONS_EXCEPTIONMACROS_H_ */

--- a/src/storm/exceptions/ExceptionMacros.h
+++ b/src/storm/exceptions/ExceptionMacros.h
@@ -5,21 +5,19 @@
  * Macro to generate descendant exception classes. As all classes are nearly the same, this makes changing common
  * features much easier.
  */
-#define STORM_NEW_EXCEPTION(exception_name)                             \
-    class exception_name : public BaseException {                       \
-       public:                                                          \
-        exception_name() : BaseException() {}                           \
-        exception_name(char const* cstr) : BaseException(cstr) {}       \
-        exception_name(exception_name const& cp) : BaseException(cp) {} \
-        ~exception_name() throw() {}                                    \
-        virtual std::string type() const override {                     \
-            return #exception_name;                                     \
-        }                                                               \
-        template<typename T>                                            \
-        exception_name& operator<<(T const& var) {                      \
-            this->stream << var;                                        \
-            return *this;                                               \
-        }                                                               \
+#define STORM_NEW_EXCEPTION(exception_name)                                   \
+    class exception_name : public BaseException {                             \
+       public:                                                                \
+        exception_name() : BaseException() {}                                 \
+        exception_name(char const* cstr) : BaseException(cstr) {}             \
+        exception_name(exception_name const& cp) : BaseException(cp) {}       \
+        ~exception_name() throw() {}                                          \
+        virtual std::string type() const override { return #exception_name; } \
+        template<typename T>                                                  \
+        exception_name& operator<<(T const& var) {                            \
+            this->stream << var;                                              \
+            return *this;                                                     \
+        }                                                                     \
     };
 
 #endif /* STORM_EXCEPTIONS_EXCEPTIONMACROS_H_ */

--- a/src/storm/logic/RewardAccumulation.h
+++ b/src/storm/logic/RewardAccumulation.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <iostream>
+#include <cstdint>
 
 namespace storm {
 namespace logic {

--- a/src/storm/logic/RewardAccumulation.h
+++ b/src/storm/logic/RewardAccumulation.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <iostream>
 #include <cstdint>
+#include <iostream>
 
 namespace storm {
 namespace logic {

--- a/src/storm/modelchecker/prctl/helper/rewardbounded/EpochManager.h
+++ b/src/storm/modelchecker/prctl/helper/rewardbounded/EpochManager.h
@@ -3,6 +3,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace storm {
 namespace modelchecker {

--- a/src/storm/modelchecker/prctl/helper/rewardbounded/EpochManager.h
+++ b/src/storm/modelchecker/prctl/helper/rewardbounded/EpochManager.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <cstdint>
 #include <set>
 #include <string>
 #include <vector>
-#include <cstdint>
 
 namespace storm {
 namespace modelchecker {

--- a/src/storm/storage/jani/traverser/InformationCollector.h
+++ b/src/storm/storage/jani/traverser/InformationCollector.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <string>
 #include <cstdint>
+#include <string>
 
 #include "storm/storage/jani/ModelType.h"
 

--- a/src/storm/storage/jani/traverser/InformationCollector.h
+++ b/src/storm/storage/jani/traverser/InformationCollector.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 #include "storm/storage/jani/ModelType.h"
 

--- a/src/storm/utility/NumberTraits.h
+++ b/src/storm/utility/NumberTraits.h
@@ -3,6 +3,8 @@
 #include "storm/adapters/RationalFunctionForward.h"
 #include "storm/adapters/RationalNumberForward.h"
 
+#include <cstdint>
+
 namespace storm {
 template<typename ValueType>
 struct NumberTraits {

--- a/src/storm/utility/string.h
+++ b/src/storm/utility/string.h
@@ -3,6 +3,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace storm {
 namespace utility {

--- a/src/storm/utility/string.h
+++ b/src/storm/utility/string.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <cstdint>
 #include <set>
 #include <string>
 #include <vector>
-#include <cstdint>
 
 namespace storm {
 namespace utility {


### PR DESCRIPTION
Added `#include <cstdint>` to the following files:

- src/storm/logic/RewardAccumulation.h
- src/storm/modelchecker/prctl/helper/rewardbounded/EpochManager.h
- src/storm/utility/NumberTraits.h
- src/storm/storage/jani/traverser/InformationCollector.h
- src/storm/utility/string.h
- src/storm-cli-utilities/cli.h

I am not sure why, but the omission of this include caused errors on the latest versions of both GCC and Clang on Artix Linux.

Tested with the following C++ compilers
gcc (GCC) 13.1.1 20230429
clang version 15.0.7

CMake version:
cmake version 3.26.3