### PR TITLE
Update clang-format actions to version 16

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -143,7 +143,7 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
-Standard:        c++14
+Standard:        c++17
 TabWidth:        4
 UseCRLF:         false
 UseTab:          Never

--- a/.github/workflows/formatapply.yml
+++ b/.github/workflows/formatapply.yml
@@ -9,16 +9,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # apply the formatting twice as a workaround for a clang-format bug
-      - uses: DoozyX/clang-format-lint-action@v0.14
+      - uses: DoozyX/clang-format-lint-action@v0.16.1
         with:
           source: './src'
-          clangFormatVersion: 14
+          clangFormatVersion: 16
           style: file
           inplace: True
-      - uses: DoozyX/clang-format-lint-action@v0.14
+      - uses: DoozyX/clang-format-lint-action@v0.16.1
         with:
           source: './src'
-          clangFormatVersion: 14
+          clangFormatVersion: 16
           style: file
           inplace: True
       - name: Commit Formatting

--- a/.github/workflows/formatcheck.yml
+++ b/.github/workflows/formatcheck.yml
@@ -8,8 +8,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.14
+    - uses: DoozyX/clang-format-lint-action@v0.16.1
       with:
         source: './src'
-        clangFormatVersion: 14
+        clangFormatVersion: 16
         style: file


### PR DESCRIPTION
- use latest version of the [clang-format-lint action](https://github.com/marketplace/actions/clang-format-lint)
- updated C++ standard used by clang-format to C++17