### PR TITLE
CI tests with different compilers

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -25,6 +25,7 @@ env:
   CARL_CMAKE_RELEASE: "-DCMAKE_BUILD_TYPE=Release"
 
 jobs:
+  # Perform in-depth tests with different configurations
   indepthTests:
     name: Indepth Tests (${{ matrix.cmakeArgs.name }})
     runs-on: ubuntu-latest
@@ -53,6 +54,37 @@ jobs:
         run: sudo docker exec storm bash -c "cd /opt/storm/build; make -j ${NR_JOBS}"
       - name: Run unit tests
         run: sudo docker exec storm bash -c "cd /opt/storm/build; ASAN_OPTIONS=detect_leaks=0,detect_odr_violation=0 ctest test --output-on-failure"
+
+  compilerTests:
+    # Build and run with different compilers (GCC, Clang)
+    # Run on latest Archlinux version to get most recent compiler versions
+    name: Compiler Tests (${{ matrix.compilers.name }})
+    runs-on: ubuntu-latest
+    env:
+      DISTRO: "archlinux:latest"
+    strategy:
+      matrix:
+        compilers:
+          - {name: "GCC", args: "-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++", packages: ""}
+          - {name: "Clang", args: "-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++", packages: "clang"}
+    steps:
+      - name: Init Docker
+        run: sudo docker run -d -it --name storm --privileged ${DISTRO}
+      - name: Sync Archlinux
+        run: sudo docker exec storm bash -c "pacman -Sy"
+      - name: Install dependencies
+        run: sudo docker exec storm bash -c "pacman -S --noconfirm base-devel git cmake boost cln gmp ginac glpk hwloc z3 xerces-c eigen ${{ matrix.compilers.packages }}"
+      - name: Git clone
+        # git clone cannot clone individual commits based on a sha and some other refs
+        # this workaround fixes this and fetches only one commit
+        run: |
+          sudo docker exec storm bash -c "mkdir /opt/storm; cd /opt/storm; git init && git remote add origin ${STORM_GIT_URL} && git fetch --depth 1 origin ${STORM_BRANCH} && git checkout FETCH_HEAD"
+      - name: Run cmake
+        run: sudo docker exec storm bash -c "mkdir /opt/storm/build; cd /opt/storm/build; cmake .. ${{ matrix.compilers.args }} ${CMAKE_RELEASE}"
+      - name: Build storm
+        run: sudo docker exec storm bash -c "cd /opt/storm/build; make -j ${NR_JOBS}"
+      - name: Run unit tests
+        run: sudo docker exec storm bash -c "cd /opt/storm/build; ctest test --output-on-failure"
 
   noDeploy:
     name: Build and Test


### PR DESCRIPTION
Adds compiler tests to the CI: building Storm with GCC and Clang on Archlinux. Using Archlinux as OS allows to use the most recent compiler versions.

Note that the tests will currently fail. These compile issues should be fixed by https://github.com/moves-rwth/storm/pull/368.