### PR TITLE
Use latest clang-format version in CI

### DIFF
--- a/.github/workflows/formatapply.yml
+++ b/.github/workflows/formatapply.yml
@@ -9,13 +9,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # apply the formatting twice as a workaround for a clang-format bug
-      - uses: DoozyX/clang-format-lint-action@v0.16.1
+      - uses: DoozyX/clang-format-lint-action@v0.16.2
         with:
           source: './src'
           clangFormatVersion: 16
           style: file
           inplace: True
-      - uses: DoozyX/clang-format-lint-action@v0.16.1
+      - uses: DoozyX/clang-format-lint-action@v0.16.2
         with:
           source: './src'
           clangFormatVersion: 16

--- a/.github/workflows/formatcheck.yml
+++ b/.github/workflows/formatcheck.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.16.1
+    - uses: DoozyX/clang-format-lint-action@v0.16.2
       with:
         source: './src'
         clangFormatVersion: 16


### PR DESCRIPTION
Clang-format 16.0.0 caused some whitespace issues (see https://github.com/llvm/llvm-project/issues/62161). This PR updates the CI action to  which now uses clang-format in version 16.0.3.

Some formatting introduced with https://github.com/moves-rwth/storm/pull/370 will be reverted after we apply the auto-format.