### PR TITLE
More robust cudd compilation

### DIFF
--- a/resources/3rdparty/cudd-3.0.0/configure.ac
+++ b/resources/3rdparty/cudd-3.0.0/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([cudd], [3.0.0], [Fabio@Colorado.EDU])
+AC_INIT([cudd],[3.0.0],[Fabio@Colorado.EDU])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CANONICAL_HOST
@@ -130,14 +130,14 @@ AC_CHECK_FUNCS([powl gethostname getrlimit getrusage sysconf])
 # Specifically, check for correct treatment of +Infinity
 AC_MSG_CHECKING([for +Infinity (IEEE 754 floating point)])
 AC_CACHE_VAL(ac_cv_have_ieee_754,
-[ AC_TRY_RUN([
+[ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <math.h>
 main(void)
 {
     if (HUGE_VAL != HUGE_VAL * 3 || HUGE_VAL != HUGE_VAL / 3) return 1;
     return 0;
 }
-],ac_cv_have_ieee_754=yes,ac_cv_have_ieee_754=no,ac_cv_have_ieee_754=maybe)])
+]])],[ac_cv_have_ieee_754=yes],[ac_cv_have_ieee_754=no],[ac_cv_have_ieee_754=maybe])])
 if test x$ac_cv_have_ieee_754 = xmaybe ; then
   AC_COMPILE_IFELSE(
   [AC_LANG_PROGRAM([#include <math.h>], [  double x = INFINITY])],

--- a/resources/3rdparty/include_cudd.cmake
+++ b/resources/3rdparty/include_cudd.cmake
@@ -1,18 +1,16 @@
 
 ####
-#### Find autoreconf for cudd update step
-find_program(AUTORECONF autoreconf)
-find_program(ACLOCAL aclocal)
-mark_as_advanced(AUTORECONF)
-mark_as_advanced(ACLOCAL)
-
-if (NOT AUTORECONF)
-    message(FATAL_ERROR "Cannot find autoreconf, cannot compile cudd3.")
-endif()
-
-if (NOT ACLOCAL)
-    message(FATAL_ERROR "Cannot find aclocal, cannot compile cudd3.")
-endif()
+#### Find autotools for cudd update step
+set(CUDD_AUTOTOOLS_LOCATIONS "")
+foreach (TOOL_VAR AUTORECONF ACLOCAL AUTOMAKE AUTOCONF AUTOHEADER)
+	string(TOLOWER ${TOOL_VAR} PROG_NAME)
+	find_program(${TOOL_VAR} ${PROG_NAME})
+	if (NOT ${TOOL_VAR})
+		message(FATAL_ERROR "Cannot find ${PROG_NAME}, cannot compile cudd3.")
+	endif()
+    mark_as_advanced(${TOOL_VAR})
+	string(APPEND CUDD_AUTOTOOLS_LOCATIONS "${TOOL_VAR}=${${TOOL_VAR}};")
+endforeach()
 
 set(CUDD_LIB_DIR ${STORM_3RDPARTY_BINARY_DIR}/cudd-3.0.0/lib)
 
@@ -51,10 +49,10 @@ ExternalProject_Add(
         DOWNLOAD_COMMAND ""
         SOURCE_DIR ${STORM_3RDPARTY_SOURCE_DIR}/cudd-3.0.0
         PREFIX ${STORM_3RDPARTY_BINARY_DIR}/cudd-3.0.0
-        PATCH_COMMAND ${AUTORECONF}
+        PATCH_COMMAND ${CMAKE_COMMAND} -E env ${CUDD_AUTOTOOLS_LOCATIONS} ${AUTORECONF}
         CONFIGURE_COMMAND ${STORM_3RDPARTY_SOURCE_DIR}/cudd-3.0.0/configure --enable-shared --enable-obj --with-pic=yes --prefix=${STORM_3RDPARTY_BINARY_DIR}/cudd-3.0.0 --libdir=${CUDD_LIB_DIR} CC=${CMAKE_C_COMPILER} CXX=${CUDD_CXX_COMPILER} ${CUDD_INCLUDE_FLAGS}
-        BUILD_COMMAND make ${STORM_CUDD_FLAGS}
-        INSTALL_COMMAND make install -j${STORM_RESOURCES_BUILD_JOBCOUNT}
+        BUILD_COMMAND make ${STORM_CUDD_FLAGS} ${CUDD_AUTOTOOLS_LOCATIONS}
+        INSTALL_COMMAND make install -j${STORM_RESOURCES_BUILD_JOBCOUNT} ${CUDD_AUTOTOOLS_LOCATIONS}
         BUILD_IN_SOURCE 0
         LOG_CONFIGURE ON
         LOG_BUILD ON


### PR DESCRIPTION
* Makes sure that necessary autotools binaries are found and that their location is passed to `autoreconf` and `make`
* fixes these warnings
```console
configure.ac:132: warning: The macro `AC_TRY_RUN' is obsolete.
configure.ac:132: You should run autoupdate.
./lib/autoconf/general.m4:2997: AC_TRY_RUN is expanded from...
lib/m4sugar/m4sh.m4:692: _AS_IF_ELSE is expanded from...
lib/m4sugar/m4sh.m4:699: AS_IF is expanded from...
./lib/autoconf/general.m4:2249: AC_CACHE_VAL is expanded from...
configure.ac:132: the top level
```
(I just ran `autoupdate` as suggested)