### PR TITLE
Add Storm-POMDP to auto-formatting

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,6 +1,3 @@
 ./src/storm-pars/*
 ./src/storm-pars-cli/*
-./src/storm-pomdp/*
-./src/storm-pomdp-cli/*
 ./src/test/storm-pars/*
-./src/test/storm-pomdp/*


### PR DESCRIPTION
This adds Storm-POMDP as a target for formatting.