### PR TITLE
Fix missing declaration

### DIFF
--- a/src/storm-pomdp/analysis/WinningRegion.h
+++ b/src/storm-pomdp/analysis/WinningRegion.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <vector>
 #include "storm/adapters/RationalNumberForward.h"
 #include "storm/storage/BitVector.h"

--- a/src/storm-pomdp/analysis/WinningRegion.h
+++ b/src/storm-pomdp/analysis/WinningRegion.h
@@ -5,6 +5,9 @@
 #include "storm/storage/BitVector.h"
 
 namespace storm {
+namespace expressions {
+class Expression;
+}
 namespace pomdp {
 class WinningRegion {
    public:


### PR DESCRIPTION
After applying the formatting, for some reason WinningRegion.h is missing the declaration of storm::expressions::Expression which prevents compilation.
This fixes the issue. Thanks to @volkm for bringing this to my attention.