### PR TITLE
Provide guidance how to trigger CI in auto-format PR

### DIFF
--- a/.github/workflows/formatapply.yml
+++ b/.github/workflows/formatapply.yml
@@ -41,4 +41,6 @@ jobs:
           delete-branch: true
           title: 'Code formatting'
           body: |
-            Auto-generated pull request triggered by the `apply-code-format` workflow. Make sure to **merge** (and not rebase) this PR so that the added commit hash in `.git-blame-ignore-revs`  remains valid. 
+            Auto-generated pull request triggered by the `apply-code-format` workflow.
+            - Manually close and reopen this PR to trigger the CI.
+            - Make sure to **merge** (and not rebase) this PR so that the added commit hash in `.git-blame-ignore-revs` remains valid.


### PR DESCRIPTION
The auto-format CI action does not automatically trigger the CI checks. This is intended behaviour by Github, see [here](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow). Following the possible workarounds listed [here](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs), I suggest to use the simplest one: just inform the developer to manually close and open the PR.