### PR TITLE
Moved parsing of explicit model files to storm-parsers

### DIFF
--- a/src/storm-parsers/api/explicit_models.h
+++ b/src/storm-parsers/api/explicit_models.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <boost/optional.hpp>
+#include <memory>
+#include <string>
+#include <type_traits>
+
+#include "storm-parsers/parser/AutoParser.h"
+#include "storm-parsers/parser/DirectEncodingParser.h"
+#include "storm-parsers/parser/ImcaMarkovAutomatonParser.h"
+#include "storm/exceptions/NotSupportedException.h"
+#include "storm/utility/macros.h"
+
+namespace storm::api {
+
+template<typename ValueType>
+inline std::shared_ptr<storm::models::sparse::Model<ValueType>> buildExplicitModel(std::string const& transitionsFile, std::string const& labelingFile,
+                                                                                   boost::optional<std::string> const& stateRewardsFile,
+                                                                                   boost::optional<std::string> const& transitionRewardsFile,
+                                                                                   boost::optional<std::string> const& choiceLabelingFile) {
+    if constexpr (std::is_same_v<ValueType, double>) {
+        return storm::parser::AutoParser<ValueType, ValueType>::parseModel(transitionsFile, labelingFile, stateRewardsFile ? stateRewardsFile.get() : "",
+                                                                           transitionRewardsFile ? transitionRewardsFile.get() : "",
+                                                                           choiceLabelingFile ? choiceLabelingFile.get() : "");
+    }
+    STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Exact or parametric models with explicit input are not supported.");
+}
+
+template<typename ValueType>
+std::shared_ptr<storm::models::sparse::Model<ValueType>> buildExplicitDRNModel(
+    std::string const& drnFile, storm::parser::DirectEncodingParserOptions const& options = storm::parser::DirectEncodingParserOptions()) {
+    return storm::parser::DirectEncodingParser<ValueType>::parseModel(drnFile, options);
+}
+
+template<typename ValueType>
+std::shared_ptr<storm::models::sparse::Model<ValueType>> buildExplicitIMCAModel(std::string const& imcaFile) {
+    if constexpr (std::is_same_v<ValueType, double>) {
+        return storm::parser::ImcaMarkovAutomatonParser<ValueType>::parseImcaFile(imcaFile);
+    }
+    STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Exact models with direct encoding are not supported.");
+}
+
+}  // namespace storm::api

--- a/src/storm-parsers/api/storm-parsers.h
+++ b/src/storm-parsers/api/storm-parsers.h
@@ -1,4 +1,5 @@
 #pragma once
 
+#include "storm-parsers/api/explicit_models.h"
 #include "storm-parsers/api/model_descriptions.h"
 #include "storm-parsers/api/properties.h"

--- a/src/storm/abstraction/MenuGameRefiner.cpp
+++ b/src/storm/abstraction/MenuGameRefiner.cpp
@@ -14,8 +14,6 @@
 #include "storm/utility/shortestPaths.h"
 #include "storm/utility/solver.h"
 
-#include "storm-parsers/parser/ExpressionParser.h"
-
 #include "storm/solver/MathsatSmtSolver.h"
 
 #include "storm/models/symbolic/StandardRewardModel.h"

--- a/src/storm/api/builder.h
+++ b/src/storm/api/builder.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#include "storm-parsers/parser/AutoParser.h"
-#include "storm-parsers/parser/DirectEncodingParser.h"
-#include "storm-parsers/parser/ImcaMarkovAutomatonParser.h"
-
 #include "storm/storage/SymbolicModelDescription.h"
 #include "storm/storage/jani/ModelFeatures.h"
 
@@ -138,40 +134,6 @@ std::shared_ptr<storm::models::sparse::Model<ValueType, RewardModelType>> buildS
         case storm::models::ModelType::Smg:
             return std::make_shared<storm::models::sparse::Smg<ValueType, RewardModelType>>(std::move(components));
     }
-}
-
-template<typename ValueType>
-std::shared_ptr<storm::models::sparse::Model<ValueType>> buildExplicitModel(std::string const& transitionsFile, std::string const& labelingFile,
-                                                                            boost::optional<std::string> const& stateRewardsFile = boost::none,
-                                                                            boost::optional<std::string> const& transitionRewardsFile = boost::none,
-                                                                            boost::optional<std::string> const& choiceLabelingFile = boost::none) {
-    STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Exact or parametric models with explicit input are not supported.");
-}
-
-template<>
-inline std::shared_ptr<storm::models::sparse::Model<double>> buildExplicitModel(std::string const& transitionsFile, std::string const& labelingFile,
-                                                                                boost::optional<std::string> const& stateRewardsFile,
-                                                                                boost::optional<std::string> const& transitionRewardsFile,
-                                                                                boost::optional<std::string> const& choiceLabelingFile) {
-    return storm::parser::AutoParser<double, double>::parseModel(transitionsFile, labelingFile, stateRewardsFile ? stateRewardsFile.get() : "",
-                                                                 transitionRewardsFile ? transitionRewardsFile.get() : "",
-                                                                 choiceLabelingFile ? choiceLabelingFile.get() : "");
-}
-
-template<typename ValueType>
-std::shared_ptr<storm::models::sparse::Model<ValueType>> buildExplicitDRNModel(
-    std::string const& drnFile, storm::parser::DirectEncodingParserOptions const& options = storm::parser::DirectEncodingParserOptions()) {
-    return storm::parser::DirectEncodingParser<ValueType>::parseModel(drnFile, options);
-}
-
-template<typename ValueType>
-std::shared_ptr<storm::models::sparse::Model<ValueType>> buildExplicitIMCAModel(std::string const&) {
-    STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Exact models with direct encoding are not supported.");
-}
-
-template<>
-inline std::shared_ptr<storm::models::sparse::Model<double>> buildExplicitIMCAModel(std::string const& imcaFile) {
-    return storm::parser::ImcaMarkovAutomatonParser<double>::parseImcaFile(imcaFile);
 }
 
 }  // namespace api

--- a/src/storm/modelchecker/abstraction/GameBasedMdpModelChecker.h
+++ b/src/storm/modelchecker/abstraction/GameBasedMdpModelChecker.h
@@ -20,8 +20,6 @@
 
 #include "storm/settings/modules/AbstractionSettings.h"
 
-#include "storm-parsers/parser/ExpressionParser.h"
-
 #include "storm/exceptions/InvalidArgumentException.h"
 #include "storm/utility/macros.h"
 


### PR DESCRIPTION
There were some `#include "storm-parsers/..."` in files located in `src/storm/` which is not valid since `storm-parsers` depends on the core `storm` library (and not the other way round). I removed spurious includes and moved API methods for building models from explicit files (e.g. from .drn)  from `storm` to `storm-parsers`.