### PR TITLE
Extended fix of PR#321 to all Boost version >= 1.81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ The releases of major and minor versions contain an overview of changes since th
 
 Version 1.8.x
 -------------
+## Version 1.8.1
+- Workaround for issue with Boost >= 1.81
 
-## Version 1.8.0
+## Version 1.8.0 (2023/05)
 - Revised implementation of value iteration algorithms and its variants, fixing a bug in the optimistic value iteration heuristic.
 - Experimental support for compiling on Apple Silicon
 - Added SoPlex as a possible LP solver
@@ -20,7 +22,7 @@ Version 1.8.x
 - `storm-pomdp`: streamlined implementation for quantitative analysis
 - `storm-pomdp`: added clipping for POMDP under-approximation
 - `storm-pomdp`: added API for interactive exploration of belief MDPs
-- Developer: Introduced forward declarations (in their own headers), in particular for storm::RationalNumber, storm::RationalFunction, and storm::json
+- Developer: Introduced forward declarations (in their own headers), in particular for `storm::RationalNumber`, `storm::RationalFunction`, and `storm::json`
 - Developer: LpSolver interface now supports RawMode (to avoid overhead of `storm::expression`) and indicator constraints
 
 

--- a/resources/3rdparty/CMakeLists.txt
+++ b/resources/3rdparty/CMakeLists.txt
@@ -112,8 +112,8 @@ if ((NOT Boost_LIBRARY_DIRS) OR ("${Boost_LIBRARY_DIRS}" STREQUAL ""))
     set(Boost_LIBRARY_DIRS "${Boost_INCLUDE_DIRS}/stage/lib")
 endif ()
 
-if ("${Boost_VERSION}" STREQUAL "108100")
-    message(STATUS "Storm - Using workaround for Boost 1.81")
+if ((${Boost_MAJOR_VERSION} EQUAL 1) AND (${Boost_MINOR_VERSION} GREATER_EQUAL 81))
+    message(STATUS "Storm - Using workaround for Boost >= 1.81")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_PHOENIX_STL_TUPLE_H_")
 endif()
 


### PR DESCRIPTION
- previous fix (#321) was limited to only version 1.81.
- fixes https://github.com/moves-rwth/homebrew-storm/issues/8
- Boost version comparison is a bit complicated because the value of `Boost_VERSION` [changes starting with CMake version 3.15](https://cmake.org/cmake/help/latest/policy/CMP0093.html#policy:CMP0093)