### PR TITLE
CI: force update in Archlinux Dockerfile

### DIFF
--- a/.github/workflows/Dockerfile.archlinux
+++ b/.github/workflows/Dockerfile.archlinux
@@ -20,7 +20,7 @@ ARG packages=""
 
 # Install dependencies
 ######################
-RUN pacman -Sy
+RUN pacman -Syu --noconfirm  # Updates needed as Archlinux is rolling release
 RUN pacman -S --noconfirm base-devel git cmake boost cln gmp ginac glpk hwloc z3 xerces-c eigen $packages
 
 

--- a/.github/workflows/Dockerfile.archlinux
+++ b/.github/workflows/Dockerfile.archlinux
@@ -46,7 +46,7 @@ RUN make resources -j $no_threads
 RUN make storm -j $no_threads
 
 # Build additional binaries of Storm
-# (This can be skipped or adapted dependending on custom needs)
+# (This can be skipped or adapted depending on custom needs)
 RUN make binaries -j $no_threads
 
 # Set path

--- a/.github/workflows/Dockerfile.carl_implicit
+++ b/.github/workflows/Dockerfile.carl_implicit
@@ -43,7 +43,7 @@ RUN make resources -j $no_threads
 RUN make storm -j $no_threads
 
 # Build additional binaries of Storm
-# (This can be skipped or adapted dependending on custom needs)
+# (This can be skipped or adapted depending on custom needs)
 RUN make binaries -j $no_threads
 
 # Set path

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN make resources -j $no_threads
 RUN make storm -j $no_threads
 
 # Build additional binaries of Storm
-# (This can be skipped or adapted dependending on custom needs)
+# (This can be skipped or adapted depending on custom needs)
 RUN make binaries -j $no_threads
 
 # Set path


### PR DESCRIPTION
Rolling release of Archlinux requires updates in the Dockerfile to prevent issues based on partial updates such as [this](https://github.com/moves-rwth/storm/actions/runs/5759073389/job/15612569262).