### PR TITLE
More efficient MEC and SCC Decompositions

### DIFF
--- a/src/storm-pomdp/analysis/FiniteBeliefMdpDetection.h
+++ b/src/storm-pomdp/analysis/FiniteBeliefMdpDetection.h
@@ -31,7 +31,7 @@ bool detectFiniteBeliefMdp(storm::models::sparse::Pomdp<ValueType> const& pomdp,
     storm::storage::BitVector relevantStates;
     if (targetStates) {
         relevantStates = ~targetStates.value();
-        options.subsystem(&relevantStates);
+        options.subsystem(relevantStates);
     }
     storm::storage::StronglyConnectedComponentDecomposition<ValueType> sccs(pomdp.getTransitionMatrix(), options);
 

--- a/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.cpp
+++ b/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.cpp
@@ -990,7 +990,7 @@ uint_fast64_t SparseDtmcEliminationModelChecker<SparseDtmcModelType>::treatScc(
         // Here, we further decompose the SCC into sub-SCCs.
         storm::storage::BitVector nonEntrySccStates = scc & ~entryStates;
         storm::storage::StronglyConnectedComponentDecomposition<ValueType> decomposition(
-            forwardTransitions, storm::storage::StronglyConnectedComponentDecompositionOptions().subsystem(&nonEntrySccStates));
+            forwardTransitions, storm::storage::StronglyConnectedComponentDecompositionOptions().subsystem(nonEntrySccStates));
         STORM_LOG_TRACE("Decomposed SCC into " << decomposition.size() << " sub-SCCs.");
 
         // Store a bit vector of remaining SCCs so we can be flexible when it comes to the order in which

--- a/src/storm/storage/MaximalEndComponent.cpp
+++ b/src/storm/storage/MaximalEndComponent.cpp
@@ -29,6 +29,10 @@ MaximalEndComponent& MaximalEndComponent::operator=(MaximalEndComponent&& other)
     return *this;
 }
 
+bool MaximalEndComponent::operator==(MaximalEndComponent const& other) {
+    return stateToChoicesMapping == other.stateToChoicesMapping;
+}
+
 void MaximalEndComponent::addState(uint_fast64_t state, set_type const& choices) {
     stateToChoicesMapping[state] = choices;
 }

--- a/src/storm/storage/MaximalEndComponent.cpp
+++ b/src/storm/storage/MaximalEndComponent.cpp
@@ -33,6 +33,10 @@ bool MaximalEndComponent::operator==(MaximalEndComponent const& other) {
     return stateToChoicesMapping == other.stateToChoicesMapping;
 }
 
+bool MaximalEndComponent::operator!=(MaximalEndComponent const& other) {
+    return stateToChoicesMapping != other.stateToChoicesMapping;
+}
+
 void MaximalEndComponent::addState(uint_fast64_t state, set_type const& choices) {
     stateToChoicesMapping[state] = choices;
 }

--- a/src/storm/storage/MaximalEndComponent.h
+++ b/src/storm/storage/MaximalEndComponent.h
@@ -55,6 +55,11 @@ class MaximalEndComponent {
     MaximalEndComponent& operator=(MaximalEndComponent&& other);
 
     /*!
+     * @return true iff this is the same MEC as other
+     */
+    bool operator==(MaximalEndComponent const& other);
+
+    /*!
      * Adds the given state and the given choices to the MEC.
      *
      * @param state The state for which to add the choices.

--- a/src/storm/storage/MaximalEndComponent.h
+++ b/src/storm/storage/MaximalEndComponent.h
@@ -60,6 +60,11 @@ class MaximalEndComponent {
     bool operator==(MaximalEndComponent const& other);
 
     /*!
+     * @return true iff this is a different MEC as other
+     */
+    bool operator!=(MaximalEndComponent const& other);
+
+    /*!
      * Adds the given state and the given choices to the MEC.
      *
      * @param state The state for which to add the choices.

--- a/src/storm/storage/MaximalEndComponentDecomposition.cpp
+++ b/src/storm/storage/MaximalEndComponentDecomposition.cpp
@@ -79,7 +79,7 @@ void MaximalEndComponentDecomposition<ValueType>::performMaximalEndComponentDeco
                                                                                           storm::OptionalRef<storm::storage::BitVector const> states,
                                                                                           storm::OptionalRef<storm::storage::BitVector const> choices) {
     // Get some data for convenient access.
-    std::vector<uint_fast64_t> const& nondeterministicChoiceIndices = transitionMatrix.getRowGroupIndices();
+    auto const& nondeterministicChoiceIndices = transitionMatrix.getRowGroupIndices();
 
     storm::storage::BitVector remainingEcCandidates, ecChoices;
     SccDecompositionResult sccDecRes;

--- a/src/storm/storage/MaximalEndComponentDecomposition.cpp
+++ b/src/storm/storage/MaximalEndComponentDecomposition.cpp
@@ -7,6 +7,7 @@
 #include "storm/adapters/RationalFunctionAdapter.h"
 #include "storm/storage/MaximalEndComponentDecomposition.h"
 #include "storm/storage/StronglyConnectedComponentDecomposition.h"
+#include "storm/utility/graph.h"
 
 namespace storm {
 namespace storage {
@@ -74,161 +75,92 @@ MaximalEndComponentDecomposition<ValueType>& MaximalEndComponentDecomposition<Va
 
 template<typename ValueType>
 void MaximalEndComponentDecomposition<ValueType>::performMaximalEndComponentDecomposition(storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-                                                                                          storm::storage::SparseMatrix<ValueType> backwardTransitions,
+                                                                                          storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                                           storm::storage::BitVector const* states,
                                                                                           storm::storage::BitVector const* choices) {
     // Get some data for convenient access.
-    uint_fast64_t numberOfStates = transitionMatrix.getRowGroupCount();
     std::vector<uint_fast64_t> const& nondeterministicChoiceIndices = transitionMatrix.getRowGroupIndices();
 
-    // Initialize the maximal end component list to be the full state space.
-    std::list<StateBlock> endComponentStateSets;
+    storm::storage::BitVector remainingEcCandidates, ecChoices;
+    SccDecompositionResult sccDecRes;
+    SccDecompositionMemoryCache sccDecCache;
+    StronglyConnectedComponentDecompositionOptions sccDecOptions;
+    sccDecOptions.dropNaiveSccs();
     if (states) {
-        endComponentStateSets.emplace_back(states->begin(), states->end(), true);
-    } else {
-        std::vector<storm::storage::sparse::state_type> allStates;
-        allStates.resize(transitionMatrix.getRowGroupCount());
-        std::iota(allStates.begin(), allStates.end(), 0);
-        endComponentStateSets.emplace_back(allStates.begin(), allStates.end(), true);
+        sccDecOptions.subsystem(states);
     }
-    storm::storage::BitVector statesToCheck(numberOfStates);
-    storm::storage::BitVector includedChoices;
     if (choices) {
-        includedChoices = *choices;
-        if (states) {
-            // Exclude choices that originate from or lead to states that are not considered.
-            includedChoices &= transitionMatrix.getRowFilter(*states, *states);
-        }
-    } else if (states) {
-        // Exclude choices that originate from or lead to states that are not considered.
-        includedChoices = transitionMatrix.getRowFilter(*states, *states);
+        ecChoices = *choices;
+        sccDecOptions.choices(&ecChoices);
     } else {
-        includedChoices = storm::storage::BitVector(transitionMatrix.getRowCount(), true);
+        ecChoices.resize(transitionMatrix.getRowCount(), true);
     }
-    storm::storage::BitVector currMecAsBitVector(transitionMatrix.getRowGroupCount());
 
-    for (std::list<StateBlock>::const_iterator mecIterator = endComponentStateSets.begin(); mecIterator != endComponentStateSets.end();) {
-        StateBlock const& mec = *mecIterator;
-        currMecAsBitVector.clear();
-        currMecAsBitVector.set(mec.begin(), mec.end(), true);
-        // Keep track of whether the MEC changed during this iteration.
-        bool mecChanged = false;
+    while (true) {
+        performSccDecomposition(transitionMatrix, sccDecOptions, sccDecRes, sccDecCache);
 
-        // Get an SCC decomposition of the current MEC candidate.
-
-        StronglyConnectedComponentDecomposition<ValueType> sccs(
-            transitionMatrix, StronglyConnectedComponentDecompositionOptions().subsystem(&currMecAsBitVector).choices(&includedChoices).dropNaiveSccs());
-
-        // We need to do another iteration in case we have either more than once SCC or the SCC is smaller than
-        // the MEC canditate itself.
-        mecChanged |= sccs.size() != 1 || (sccs.size() > 0 && sccs[0].size() < mec.size());
-
-        // Check for each of the SCCs whether there is at least one action for each state that does not leave the SCC.
-        for (auto& scc : sccs) {
-            statesToCheck.set(scc.begin(), scc.end());
-
-            while (!statesToCheck.empty()) {
-                storm::storage::BitVector statesToRemove(numberOfStates);
-
-                for (auto state : statesToCheck) {
-                    bool keepStateInMEC = false;
-
-                    for (uint_fast64_t choice = nondeterministicChoiceIndices[state]; choice < nondeterministicChoiceIndices[state + 1]; ++choice) {
-                        // If the choice is not part of our subsystem, skip it.
-                        if (choices && !choices->get(choice)) {
-                            continue;
-                        }
-
-                        // If the choice is not included any more, skip it.
-                        if (!includedChoices.get(choice)) {
-                            continue;
-                        }
-
-                        bool choiceContainedInMEC = true;
-                        for (auto const& entry : transitionMatrix.getRow(choice)) {
-                            if (storm::utility::isZero(entry.getValue())) {
-                                continue;
-                            }
-
-                            if (!scc.containsState(entry.getColumn())) {
-                                includedChoices.set(choice, false);
-                                choiceContainedInMEC = false;
-                                break;
-                            }
-                        }
-
-                        // If there is at least one choice whose successor states are fully contained in the MEC, we can leave the state in the MEC.
-                        if (choiceContainedInMEC) {
-                            keepStateInMEC = true;
-                        }
-                    }
-
-                    if (!keepStateInMEC) {
-                        statesToRemove.set(state, true);
-                    }
-                }
-
-                // Now erase the states that have no option to stay inside the MEC with all successors.
-                mecChanged |= !statesToRemove.empty();
-                for (uint_fast64_t state : statesToRemove) {
-                    scc.erase(state);
-                }
-
-                // Now check which states should be reconsidered, because successors of them were removed.
-                statesToCheck.clear();
-                for (auto state : statesToRemove) {
-                    for (auto const& entry : backwardTransitions.getRow(state)) {
-                        if (scc.containsState(entry.getColumn())) {
-                            statesToCheck.set(entry.getColumn());
-                        }
-                    }
-                }
-            }
-        }
-
-        // If the MEC changed, we delete it from the list of MECs and append the possible new MEC candidates to
-        // the list instead.
-        if (mecChanged) {
-            for (StronglyConnectedComponent& scc : sccs) {
-                if (!scc.empty()) {
-                    endComponentStateSets.push_back(std::move(scc));
-                }
-            }
-
-            std::list<StateBlock>::const_iterator eraseIterator(mecIterator);
-            ++mecIterator;
-            endComponentStateSets.erase(eraseIterator);
-        } else {
-            // Otherwise, we proceed with the next MEC candidate.
-            ++mecIterator;
-        }
-
-    }  // End of loop over all MEC candidates.
-
-    // Now that we computed the underlying state sets of the MECs, we need to properly identify the choices
-    // contained in the MEC and store them as actual MECs.
-    this->blocks.reserve(endComponentStateSets.size());
-    for (auto const& mecStateSet : endComponentStateSets) {
-        MaximalEndComponent newMec;
-
-        for (auto state : mecStateSet) {
-            MaximalEndComponent::set_type containedChoices;
-            for (uint_fast64_t choice = nondeterministicChoiceIndices[state]; choice < nondeterministicChoiceIndices[state + 1]; ++choice) {
-                // Skip the choice if it is not part of our subsystem.
-                if (choices && !choices->get(choice)) {
+        remainingEcCandidates = sccDecRes.nonTrivialStates;
+        storm::storage::BitVector ecSccIndices(sccDecRes.sccCount, true);
+        storm::storage::BitVector nonTrivSccIndices(sccDecRes.sccCount, false);
+        // find the choices that do not stay in their SCC
+        for (auto state : remainingEcCandidates) {
+            auto const sccIndex = sccDecRes.stateToSccMapping[state];
+            nonTrivSccIndices.set(sccIndex, true);
+            bool stateCanStayInScc = false;
+            for (auto const choice : transitionMatrix.getRowGroupIndices(state)) {
+                if (!ecChoices.get(choice)) {
                     continue;
                 }
-
-                if (includedChoices.get(choice)) {
-                    containedChoices.insert(choice);
+                auto row = transitionMatrix.getRow(choice);
+                if (std::any_of(row.begin(), row.end(), [&sccIndex, &sccDecRes](auto const& entry) {
+                        return sccIndex != sccDecRes.stateToSccMapping[entry.getColumn()] && !storm::utility::isZero(entry.getValue());
+                    })) {
+                    ecChoices.set(choice, false);       // The choice leaves the SCC
+                    ecSccIndices.set(sccIndex, false);  // This SCC is not 'stable' yet
+                } else {
+                    stateCanStayInScc = true;  // The choice stays in the SCC
                 }
             }
-
-            STORM_LOG_ASSERT(!containedChoices.empty(), "The contained choices of any state in an MEC must be non-empty.");
-            newMec.addState(state, std::move(containedChoices));
+            if (!stateCanStayInScc) {
+                remainingEcCandidates.set(state, false);  // This state is not in an EC
+            }
         }
 
-        this->blocks.emplace_back(std::move(newMec));
+        // process the MECs that we've found, i.e. SCCs where every state can stay inside the SCC
+        ecSccIndices &= nonTrivSccIndices;
+        for (auto sccIndex : ecSccIndices) {
+            MaximalEndComponent newMec;
+            for (auto state : remainingEcCandidates) {
+                // skip states from different SCCs
+                if (sccDecRes.stateToSccMapping[state] != sccIndex) {
+                    continue;
+                }
+                // This is no longer a candidate
+                remainingEcCandidates.set(state, false);
+                // Add choices to the MEC
+                MaximalEndComponent::set_type containedChoices;
+                for (auto ecChoiceIt = ecChoices.begin(nondeterministicChoiceIndices[state]); *ecChoiceIt < nondeterministicChoiceIndices[state + 1];
+                     ++ecChoiceIt) {
+                    containedChoices.insert(*ecChoiceIt);
+                }
+                STORM_LOG_ASSERT(!containedChoices.empty(), "The contained choices of any state in an MEC must be non-empty.");
+                newMec.addState(state, std::move(containedChoices));
+            }
+            this->blocks.emplace_back(std::move(newMec));
+        }
+
+        if (nonTrivSccIndices == ecSccIndices) {
+            // All non trivial SCCs are MECs, nothing left to do!
+            break;
+        }
+
+        // prepare next iteration.
+        // It suffices to keep the candidates that have the possibility to always stay in the candidate set
+        remainingEcCandidates = storm::utility::graph::performProbGreater0A(transitionMatrix, nondeterministicChoiceIndices, backwardTransitions,
+                                                                            remainingEcCandidates, ~remainingEcCandidates, false, 0, ecChoices);
+        remainingEcCandidates.complement();
+        sccDecOptions.subsystem(&remainingEcCandidates);
+        sccDecOptions.choices(&ecChoices);
     }
 
     STORM_LOG_DEBUG("MEC decomposition found " << this->size() << " MEC(s).");

--- a/src/storm/storage/MaximalEndComponentDecomposition.cpp
+++ b/src/storm/storage/MaximalEndComponentDecomposition.cpp
@@ -118,7 +118,7 @@ void MaximalEndComponentDecomposition<ValueType>::performMaximalEndComponentDeco
                     ecChoices.set(choice, false);       // The choice leaves the SCC
                     ecSccIndices.set(sccIndex, false);  // This SCC is not 'stable' yet
                 } else {
-                    stateCanStayInScc = true;           // The choice stays in the SCC
+                    stateCanStayInScc = true;  // The choice stays in the SCC
                 }
             }
             if (!stateCanStayInScc) {

--- a/src/storm/storage/MaximalEndComponentDecomposition.h
+++ b/src/storm/storage/MaximalEndComponentDecomposition.h
@@ -38,6 +38,7 @@ class MaximalEndComponentDecomposition : public Decomposition<MaximalEndComponen
 
     /*
      * Creates an MEC decomposition of the given subsystem of given model (represented by a row-grouped matrix).
+     * If a state-action pair (aka choice) has a transition that leaves the subsystem, the entire state-action pair is ignored.
      *
      * @param transitionMatrix The transition relation of model to decompose into MECs.
      * @param backwardTransition The reversed transition relation.
@@ -48,6 +49,8 @@ class MaximalEndComponentDecomposition : public Decomposition<MaximalEndComponen
 
     /*
      * Creates an MEC decomposition of the given subsystem of given model (represented by a row-grouped matrix).
+     * If a state-action pair (aka choice) has a transition that leaves the subsystem, the entire state-action pair is ignored, independent of how the given
+     * 'choices' vector is set for that choice.
      *
      * @param transitionMatrix The transition relation of model to decompose into MECs.
      * @param backwardTransition The reversed transition relation.
@@ -105,8 +108,8 @@ class MaximalEndComponentDecomposition : public Decomposition<MaximalEndComponen
      * @param choices The choices of the subsystem to decompose.
      */
     void performMaximalEndComponentDecomposition(storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-                                                 storm::storage::SparseMatrix<ValueType> backwardTransitions, storm::storage::BitVector const* states = nullptr,
-                                                 storm::storage::BitVector const* choices = nullptr);
+                                                 storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
+                                                 storm::storage::BitVector const* states = nullptr, storm::storage::BitVector const* choices = nullptr);
 };
 }  // namespace storage
 }  // namespace storm

--- a/src/storm/storage/MaximalEndComponentDecomposition.h
+++ b/src/storm/storage/MaximalEndComponentDecomposition.h
@@ -1,12 +1,11 @@
-#ifndef STORM_STORAGE_MAXIMALENDCOMPONENTDECOMPOSITION_H_
-#define STORM_STORAGE_MAXIMALENDCOMPONENTDECOMPOSITION_H_
+#pragma once
 
 #include "storm/models/sparse/NondeterministicModel.h"
 #include "storm/storage/Decomposition.h"
 #include "storm/storage/MaximalEndComponent.h"
+#include "storm/utility/OptionalRef.h"
 
-namespace storm {
-namespace storage {
+namespace storm::storage {
 
 /*!
  * This class represents the decomposition of a nondeterministic model into its maximal end components.
@@ -109,9 +108,7 @@ class MaximalEndComponentDecomposition : public Decomposition<MaximalEndComponen
      */
     void performMaximalEndComponentDecomposition(storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                  storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                 storm::storage::BitVector const* states = nullptr, storm::storage::BitVector const* choices = nullptr);
+                                                 storm::OptionalRef<storm::storage::BitVector const> states = storm::NullRef,
+                                                 storm::OptionalRef<storm::storage::BitVector const> choices = storm::NullRef);
 };
-}  // namespace storage
-}  // namespace storm
-
-#endif /* STORM_STORAGE_MAXIMALENDCOMPONENTDECOMPOSITION_H_ */
+}  // namespace storm::storage

--- a/src/storm/storage/MaximalEndComponentDecomposition.h
+++ b/src/storm/storage/MaximalEndComponentDecomposition.h
@@ -98,13 +98,13 @@ class MaximalEndComponentDecomposition : public Decomposition<MaximalEndComponen
 
    private:
     /*!
-     * Performs the actual decomposition of the given subsystem in the given model into MECs. As a side-effect
-     * this stores the MECs found in the current decomposition.
+     * Performs the actual decomposition of the given subsystem in the given model into MECs. Stores the MECs found in the current decomposition.
      *
      * @param transitionMatrix The transition matrix representing the system whose subsystem to decompose into MECs.
      * @param backwardTransitions The reversed transition relation.
-     * @param states The states of the subsystem to decompose.
-     * @param choices The choices of the subsystem to decompose.
+     * @param states The states of the subsystem to decompose. If not given, all states are considered.
+     * @param choices The choices of the subsystem to decompose. If not given, all choices are considered.
+     *
      */
     void performMaximalEndComponentDecomposition(storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                  storm::storage::SparseMatrix<ValueType> const& backwardTransitions,

--- a/src/storm/storage/StronglyConnectedComponentDecomposition.cpp
+++ b/src/storm/storage/StronglyConnectedComponentDecomposition.cpp
@@ -1,15 +1,76 @@
 #include "storm/storage/StronglyConnectedComponentDecomposition.h"
-#include <storm/utility/vector.h>
+
 #include "storm/adapters/RationalFunctionAdapter.h"
-#include "storm/models/sparse/Model.h"
-#include "storm/models/sparse/StandardRewardModel.h"
-#include "storm/utility/Stopwatch.h"
+#include "storm/storage/SparseMatrix.h"
+#include "storm/utility/constants.h"
 #include "storm/utility/macros.h"
+#include "storm/utility/vector.h"
 
 #include "storm/exceptions/UnexpectedException.h"
 
-namespace storm {
-namespace storage {
+namespace storm::storage {
+
+StronglyConnectedComponentDecompositionOptions& StronglyConnectedComponentDecompositionOptions::subsystem(storm::storage::BitVector const* subsystem) {
+    subsystemPtr = subsystem;
+    return *this;
+}
+
+StronglyConnectedComponentDecompositionOptions& StronglyConnectedComponentDecompositionOptions::choices(storm::storage::BitVector const* choices) {
+    choicesPtr = choices;
+    return *this;
+}
+
+StronglyConnectedComponentDecompositionOptions& StronglyConnectedComponentDecompositionOptions::dropNaiveSccs(bool value) {
+    areNaiveSccsDropped = value;
+    return *this;
+}
+
+StronglyConnectedComponentDecompositionOptions& StronglyConnectedComponentDecompositionOptions::onlyBottomSccs(bool value) {
+    areOnlyBottomSccsConsidered = value;
+    return *this;
+}
+
+StronglyConnectedComponentDecompositionOptions& StronglyConnectedComponentDecompositionOptions::forceTopologicalSort(bool value) {
+    isTopologicalSortForced = value;
+    return *this;
+}
+
+StronglyConnectedComponentDecompositionOptions& StronglyConnectedComponentDecompositionOptions::computeSccDepths(bool value) {
+    isComputeSccDepthsSet = value;
+    return *this;
+}
+
+void SccDecompositionMemoryCache::initialize(uint64_t numStates) {
+    preorderNumbers.assign(numStates, std::numeric_limits<uint64_t>::max());
+    recursionStateStack.clear();
+    s.clear();
+    p.clear();
+}
+
+bool SccDecompositionMemoryCache::hasPreorderNumber(uint64_t stateIndex) const {
+    return preorderNumbers[stateIndex] != std::numeric_limits<uint64_t>::max();
+}
+
+void SccDecompositionResult::initialize(uint64_t numStates, bool computeSccDepths) {
+    sccCount = 0;
+    stateToSccMapping.assign(numStates, std::numeric_limits<uint64_t>::max());
+    nonTrivialStates.clear();
+    nonTrivialStates.resize(numStates, false);
+    if (computeSccDepths) {
+        if (sccDepths) {
+            sccDepths->clear();
+        } else {
+            sccDepths.emplace();
+        }
+    } else {
+        sccDepths = std::nullopt;
+    }
+}
+
+bool SccDecompositionResult::stateHasScc(uint64_t stateIndex) const {
+    return stateToSccMapping[stateIndex] != std::numeric_limits<uint64_t>::max();
+}
+
 template<typename ValueType>
 StronglyConnectedComponentDecomposition<ValueType>::StronglyConnectedComponentDecomposition() : Decomposition() {
     // Intentionally left empty.
@@ -71,29 +132,26 @@ StronglyConnectedComponentDecomposition<ValueType>& StronglyConnectedComponentDe
  * is increased.
  */
 template<typename ValueType>
-void performSccDecompositionGCM(storm::storage::SparseMatrix<ValueType> const& transitionMatrix, uint_fast64_t startState,
-                                storm::storage::BitVector& nonTrivialStates, storm::storage::BitVector const* subsystem,
-                                storm::storage::BitVector const* choices, uint_fast64_t& currentIndex, storm::storage::BitVector& hasPreorderNumber,
-                                std::vector<uint_fast64_t>& preorderNumbers, std::vector<uint_fast64_t>& recursionStateStack, std::vector<uint_fast64_t>& s,
-                                std::vector<uint_fast64_t>& p, storm::storage::BitVector& stateHasScc, std::vector<uint_fast64_t>& stateToSccMapping,
-                                uint_fast64_t& sccCount, bool /*forceTopologicalSort*/, std::vector<uint_fast64_t>* sccDepths) {
+void performSccDecompositionGCM(storm::storage::SparseMatrix<ValueType> const& transitionMatrix, storm::storage::BitVector const* subsystem,
+                                storm::storage::BitVector const* choices, bool /*forceTopologicalSort*/, uint64_t startState, uint64_t& currentIndex,
+                                SccDecompositionResult& result, SccDecompositionMemoryCache& cache) {
     // The forceTopologicalSort flag can be ignored as this method always generates a topological sort.
 
     // Prepare the stack used for turning the recursive procedure into an iterative one.
-    STORM_LOG_ASSERT(recursionStateStack.empty(), "Expected an empty recursion stack.");
-    recursionStateStack.push_back(startState);
+    STORM_LOG_ASSERT(cache.recursionStateStack.empty(), "Expected an empty recursion stack.");
+    cache.recursionStateStack.push_back(startState);
 
-    while (!recursionStateStack.empty()) {
+    while (!cache.recursionStateStack.empty()) {
         // Peek at the topmost state in the stack, but leave it on there for now.
-        uint_fast64_t currentState = recursionStateStack.back();
+        uint64_t currentState = cache.recursionStateStack.back();
+        assert(!subsystem || subsystem->get(currentState));
 
         // If the state has not yet been seen, we need to assign it a preorder number and iterate over its successors.
-        if (!hasPreorderNumber.get(currentState)) {
-            preorderNumbers[currentState] = currentIndex++;
-            hasPreorderNumber.set(currentState, true);
+        if (!cache.hasPreorderNumber(currentState)) {
+            cache.preorderNumbers[currentState] = currentIndex++;
 
-            s.push_back(currentState);
-            p.push_back(currentState);
+            cache.s.push_back(currentState);
+            cache.p.push_back(currentState);
 
             for (uint64_t row = transitionMatrix.getRowGroupIndices()[currentState], rowEnd = transitionMatrix.getRowGroupIndices()[currentState + 1];
                  row != rowEnd; ++row) {
@@ -104,17 +162,17 @@ void performSccDecompositionGCM(storm::storage::SparseMatrix<ValueType> const& t
                 for (auto const& successor : transitionMatrix.getRow(row)) {
                     if ((!subsystem || subsystem->get(successor.getColumn())) && successor.getValue() != storm::utility::zero<ValueType>()) {
                         if (currentState == successor.getColumn()) {
-                            nonTrivialStates.set(currentState, true);
+                            result.nonTrivialStates.set(currentState, true);
                         }
 
-                        if (!hasPreorderNumber.get(successor.getColumn())) {
+                        if (!cache.hasPreorderNumber(successor.getColumn())) {
                             // In this case, we must recursively visit the successor. We therefore push the state
                             // onto the recursion stack.
-                            recursionStateStack.push_back(successor.getColumn());
+                            cache.recursionStateStack.push_back(successor.getColumn());
                         } else {
-                            if (!stateHasScc.get(successor.getColumn())) {
-                                while (preorderNumbers[p.back()] > preorderNumbers[successor.getColumn()]) {
-                                    p.pop_back();
+                            if (!result.stateHasScc(successor.getColumn())) {
+                                while (cache.preorderNumbers[cache.p.back()] > cache.preorderNumbers[successor.getColumn()]) {
+                                    cache.p.pop_back();
                                 }
                             }
                         }
@@ -124,12 +182,12 @@ void performSccDecompositionGCM(storm::storage::SparseMatrix<ValueType> const& t
         } else {
             // In this case, we have searched all successors of the current state and can exit the "recursion"
             // on the current state.
-            if (currentState == p.back()) {
-                p.pop_back();
-                if (sccDepths) {
-                    uint_fast64_t sccDepth = 0;
+            if (currentState == cache.p.back()) {
+                cache.p.pop_back();
+                if (result.sccDepths) {
+                    uint64_t sccDepth = 0;
                     // Find the largest depth over successor SCCs.
-                    auto stateIt = s.end();
+                    auto stateIt = cache.s.end();
                     do {
                         --stateIt;
                         for (uint64_t row = transitionMatrix.getRowGroupIndices()[*stateIt], rowEnd = transitionMatrix.getRowGroupIndices()[*stateIt + 1];
@@ -139,29 +197,28 @@ void performSccDecompositionGCM(storm::storage::SparseMatrix<ValueType> const& t
                             }
                             for (auto const& successor : transitionMatrix.getRow(row)) {
                                 if ((!subsystem || subsystem->get(successor.getColumn())) && successor.getValue() != storm::utility::zero<ValueType>() &&
-                                    stateHasScc.get(successor.getColumn())) {
-                                    sccDepth = std::max(sccDepth, (*sccDepths)[stateToSccMapping[successor.getColumn()]] + 1);
+                                    result.stateHasScc(successor.getColumn())) {
+                                    sccDepth = std::max(sccDepth, (*result.sccDepths)[result.stateToSccMapping[successor.getColumn()]] + 1);
                                 }
                             }
                         }
                     } while (*stateIt != currentState);
-                    sccDepths->push_back(sccDepth);
+                    result.sccDepths->push_back(sccDepth);
                 }
-                bool nonSingletonScc = s.back() != currentState;
-                uint_fast64_t poppedState = 0;
+                bool nonSingletonScc = cache.s.back() != currentState;
+                uint64_t poppedState = 0;
                 do {
-                    poppedState = s.back();
-                    s.pop_back();
-                    stateToSccMapping[poppedState] = sccCount;
-                    stateHasScc.set(poppedState);
+                    poppedState = cache.s.back();
+                    cache.s.pop_back();
+                    result.stateToSccMapping[poppedState] = result.sccCount;
                     if (nonSingletonScc) {
-                        nonTrivialStates.set(poppedState, true);
+                        result.nonTrivialStates.set(poppedState, true);
                     }
                 } while (poppedState != currentState);
-                ++sccCount;
+                ++result.sccCount;
             }
 
-            recursionStateStack.pop_back();
+            cache.recursionStateStack.pop_back();
         }
     }
 }
@@ -169,70 +226,24 @@ void performSccDecompositionGCM(storm::storage::SparseMatrix<ValueType> const& t
 template<typename ValueType>
 void StronglyConnectedComponentDecomposition<ValueType>::performSccDecomposition(storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                                                  StronglyConnectedComponentDecompositionOptions const& options) {
-    STORM_LOG_ASSERT(!options.choicesPtr || options.subsystemPtr, "Expecting subsystem if choices are given.");
+    SccDecompositionResult result;
+    storm::storage::performSccDecomposition(transitionMatrix, options, result);
 
-    uint_fast64_t numberOfStates = transitionMatrix.getRowGroupCount();
-    uint_fast64_t sccCount = 0;
-
-    // We need to keep of trivial states (singleton SCCs without selfloop).
-    storm::storage::BitVector nonTrivialStates(numberOfStates, false);
-
-    // Obtain a mapping from states to the SCC it belongs to
-    std::vector<uint_fast64_t> stateToSccMapping(numberOfStates);
-    {
-        // Set up the environment of the algorithm.
-        // Start with the two stacks it maintains.
-        // This is to reduce memory (re-)allocations
-        std::vector<uint_fast64_t> s;
-        s.reserve(numberOfStates);
-        std::vector<uint_fast64_t> p;
-        p.reserve(numberOfStates);
-        std::vector<uint_fast64_t> recursionStateStack;
-        recursionStateStack.reserve(numberOfStates);
-
-        // We also need to store the preorder numbers of states and which states have been assigned to which SCC.
-        std::vector<uint_fast64_t> preorderNumbers(numberOfStates);
-        storm::storage::BitVector hasPreorderNumber(numberOfStates);
-        storm::storage::BitVector stateHasScc(numberOfStates);
-
-        // Store scc depths if requested
-        std::vector<uint_fast64_t>* sccDepthsPtr = nullptr;
-        sccDepths = boost::none;
-        if (options.isComputeSccDepthsSet || options.areOnlyBottomSccsConsidered) {
-            sccDepths = std::vector<uint_fast64_t>();
-            sccDepthsPtr = &sccDepths.get();
-        }
-
-        // Start the search for SCCs from every state in the block.
-        uint_fast64_t currentIndex = 0;
-        if (options.subsystemPtr) {
-            for (auto state : *options.subsystemPtr) {
-                if (!hasPreorderNumber.get(state)) {
-                    performSccDecompositionGCM(transitionMatrix, state, nonTrivialStates, options.subsystemPtr, options.choicesPtr, currentIndex,
-                                               hasPreorderNumber, preorderNumbers, recursionStateStack, s, p, stateHasScc, stateToSccMapping, sccCount,
-                                               options.isTopologicalSortForced, sccDepthsPtr);
-                }
-            }
-        } else {
-            for (uint64_t state = 0; state < transitionMatrix.getRowGroupCount(); ++state) {
-                if (!hasPreorderNumber.get(state)) {
-                    performSccDecompositionGCM(transitionMatrix, state, nonTrivialStates, options.subsystemPtr, options.choicesPtr, currentIndex,
-                                               hasPreorderNumber, preorderNumbers, recursionStateStack, s, p, stateHasScc, stateToSccMapping, sccCount,
-                                               options.isTopologicalSortForced, sccDepthsPtr);
-                }
-            }
-        }
+    STORM_LOG_ASSERT(!options.areOnlyBottomSccsConsidered || result.sccDepths.has_value(), "Scc depths not computed but needed.");
+    if (result.sccDepths) {
+        this->sccDepths = std::move(*result.sccDepths);
     }
+
     // After we obtained the state-to-SCC mapping, we build the actual blocks.
-    this->blocks.resize(sccCount);
+    this->blocks.resize(result.sccCount);
     for (uint64_t state = 0; state < transitionMatrix.getRowGroupCount(); ++state) {
         // Check if this state (and is SCC) should be considered in this decomposition.
         if ((!options.subsystemPtr || options.subsystemPtr->get(state))) {
-            if (!options.areNaiveSccsDropped || nonTrivialStates.get(state)) {
-                uint_fast64_t sccIndex = stateToSccMapping[state];
-                if (!options.areOnlyBottomSccsConsidered || sccDepths.get()[sccIndex] == 0) {
+            if (!options.areNaiveSccsDropped || result.nonTrivialStates.get(state)) {
+                uint64_t sccIndex = result.stateToSccMapping[state];
+                if (!options.areOnlyBottomSccsConsidered || sccDepths.value()[sccIndex] == 0) {
                     this->blocks[sccIndex].insert(state);
-                    if (!nonTrivialStates.get(state)) {
+                    if (!result.nonTrivialStates.get(state)) {
                         this->blocks[sccIndex].setIsTrivial(true);
                         STORM_LOG_ASSERT(this->blocks[sccIndex].size() == 1, "Unexpected number of states in a trivial SCC.");
                     }
@@ -243,8 +254,8 @@ void StronglyConnectedComponentDecomposition<ValueType>::performSccDecomposition
 
     // If requested, we need to delete all naive SCCs.
     if (options.areOnlyBottomSccsConsidered || options.areNaiveSccsDropped) {
-        storm::storage::BitVector blocksToDrop(sccCount);
-        for (uint_fast64_t sccIndex = 0; sccIndex < sccCount; ++sccIndex) {
+        storm::storage::BitVector blocksToDrop(result.sccCount);
+        for (uint64_t sccIndex = 0; sccIndex < result.sccCount; ++sccIndex) {
             if (this->blocks[sccIndex].empty()) {
                 blocksToDrop.set(sccIndex, true);
             }
@@ -252,36 +263,83 @@ void StronglyConnectedComponentDecomposition<ValueType>::performSccDecomposition
         // Create the new set of blocks by moving all the blocks we need to keep into it.
         storm::utility::vector::filterVectorInPlace(this->blocks, ~blocksToDrop);
         if (this->sccDepths) {
-            storm::utility::vector::filterVectorInPlace(this->sccDepths.get(), ~blocksToDrop);
+            storm::utility::vector::filterVectorInPlace(this->sccDepths.value(), ~blocksToDrop);
+        }
+    }
+}
+
+template<typename ValueType>
+void performSccDecomposition(storm::storage::SparseMatrix<ValueType> const& transitionMatrix, StronglyConnectedComponentDecompositionOptions const& options,
+                             SccDecompositionResult& result) {
+    SccDecompositionMemoryCache cache;
+    performSccDecomposition(transitionMatrix, options, result, cache);
+}
+
+template<typename ValueType>
+void performSccDecomposition(storm::storage::SparseMatrix<ValueType> const& transitionMatrix, StronglyConnectedComponentDecompositionOptions const& options,
+                             SccDecompositionResult& result, SccDecompositionMemoryCache& cache) {
+    STORM_LOG_ASSERT(!options.choicesPtr || options.subsystemPtr, "Expecting subsystem if choices are given.");
+
+    uint64_t numberOfStates = transitionMatrix.getRowGroupCount();
+    result.initialize(numberOfStates, options.isComputeSccDepthsSet || options.areOnlyBottomSccsConsidered);
+    cache.initialize(numberOfStates);
+
+    // Start the search for SCCs from every state in the block.
+    uint64_t currentIndex = 0;
+    auto performSccDecompFromState = [&](uint64_t startState) {
+        if (!cache.hasPreorderNumber(startState)) {
+            performSccDecompositionGCM(transitionMatrix, options.subsystemPtr, options.choicesPtr, options.isTopologicalSortForced, startState, currentIndex,
+                                       result, cache);
+        }
+    };
+
+    if (options.subsystemPtr) {
+        for (auto state : *options.subsystemPtr) {
+            performSccDecompFromState(state);
+        }
+    } else {
+        for (uint64_t state = 0; state < numberOfStates; ++state) {
+            performSccDecompFromState(state);
         }
     }
 }
 
 template<typename ValueType>
 bool StronglyConnectedComponentDecomposition<ValueType>::hasSccDepth() const {
-    return sccDepths.is_initialized();
+    return sccDepths.has_value();
 }
 
 template<typename ValueType>
-uint_fast64_t StronglyConnectedComponentDecomposition<ValueType>::getSccDepth(uint_fast64_t const& sccIndex) const {
-    STORM_LOG_THROW(sccDepths.is_initialized(), storm::exceptions::InvalidOperationException,
+uint64_t StronglyConnectedComponentDecomposition<ValueType>::getSccDepth(uint64_t const& sccIndex) const {
+    STORM_LOG_THROW(sccDepths.has_value(), storm::exceptions::InvalidOperationException,
                     "Tried to get the SCC depth but SCC depths were not computed upon construction.");
     STORM_LOG_ASSERT(sccIndex < sccDepths->size(), "SCC index " << sccIndex << " is out of range (" << sccDepths->size() << ")");
-    return sccDepths.get()[sccIndex];
+    return sccDepths.value()[sccIndex];
 }
 
 template<typename ValueType>
-uint_fast64_t StronglyConnectedComponentDecomposition<ValueType>::getMaxSccDepth() const {
-    STORM_LOG_THROW(sccDepths.is_initialized(), storm::exceptions::InvalidOperationException,
+uint64_t StronglyConnectedComponentDecomposition<ValueType>::getMaxSccDepth() const {
+    STORM_LOG_THROW(sccDepths.has_value(), storm::exceptions::InvalidOperationException,
                     "Tried to get the maximum SCC depth but SCC depths were not computed upon construction.");
     STORM_LOG_THROW(!sccDepths->empty(), storm::exceptions::InvalidOperationException,
                     "Tried to get the maximum SCC depth but this SCC decomposition seems to be empty.");
     return *std::max_element(sccDepths->begin(), sccDepths->end());
 }
 
-// Explicitly instantiate the SCC decomposition.
+template<typename ValueType>
+std::vector<uint64_t> StronglyConnectedComponentDecomposition<ValueType>::computeStateToSccIndexMap(uint64_t numberOfStates) const {
+    std::vector<uint64_t> result(numberOfStates, std::numeric_limits<uint64_t>::max());
+    uint64_t sccIndex = 0;
+    for (auto const& scc : *this) {
+        for (auto const& state : scc) {
+            result[state] = sccIndex;
+        }
+        ++sccIndex;
+    }
+    return result;
+}
+
 template class StronglyConnectedComponentDecomposition<double>;
 template class StronglyConnectedComponentDecomposition<storm::RationalNumber>;
 template class StronglyConnectedComponentDecomposition<storm::RationalFunction>;
-}  // namespace storage
-}  // namespace storm
+}  // namespace storm::storage

--- a/src/storm/storage/StronglyConnectedComponentDecomposition.h
+++ b/src/storm/storage/StronglyConnectedComponentDecomposition.h
@@ -6,6 +6,7 @@
 #include "storm/storage/BitVector.h"
 #include "storm/storage/Decomposition.h"
 #include "storm/storage/StronglyConnectedComponent.h"
+#include "storm/utility/OptionalRef.h"
 namespace storm {
 
 namespace storage {
@@ -15,10 +16,10 @@ class SparseMatrix;
 
 struct StronglyConnectedComponentDecompositionOptions {
     /// Sets a bit vector indicating which subsystem to consider for the decomposition into SCCs.
-    StronglyConnectedComponentDecompositionOptions& subsystem(storm::storage::BitVector const* subsystem);
+    StronglyConnectedComponentDecompositionOptions& subsystem(storm::storage::BitVector const& subsystem);
 
     /// Sets a bit vector indicating which choices of the states are contained in the subsystem.
-    StronglyConnectedComponentDecompositionOptions& choices(storm::storage::BitVector const* choices);
+    StronglyConnectedComponentDecompositionOptions& choices(storm::storage::BitVector const& choices);
 
     /// Sets if trivial SCCs (i.e. SCCs consisting of just one state without a self-loop) are to be kept in the decomposition.
     StronglyConnectedComponentDecompositionOptions& dropNaiveSccs(bool value = true);
@@ -32,8 +33,8 @@ struct StronglyConnectedComponentDecompositionOptions {
     /// Sets if scc depths can be retrieved.
     StronglyConnectedComponentDecompositionOptions& computeSccDepths(bool value = true);
 
-    storm::storage::BitVector const* subsystemPtr = nullptr;
-    storm::storage::BitVector const* choicesPtr = nullptr;
+    storm::OptionalRef<storm::storage::BitVector const> optSubsystem;
+    storm::OptionalRef<storm::storage::BitVector const> optChoices;
     bool areNaiveSccsDropped = false;
     bool areOnlyBottomSccsConsidered = false;
     bool isTopologicalSortForced = false;

--- a/src/storm/storage/StronglyConnectedComponentDecomposition.h
+++ b/src/storm/storage/StronglyConnectedComponentDecomposition.h
@@ -1,54 +1,36 @@
-#ifndef STORM_STORAGE_STRONGLYCONNECTEDCOMPONENTDECOMPOSITION_H_
-#define STORM_STORAGE_STRONGLYCONNECTEDCOMPONENTDECOMPOSITION_H_
+#pragma once
 
-#include <boost/optional.hpp>
+#include <optional>
+#include <vector>
+
 #include "storm/storage/BitVector.h"
 #include "storm/storage/Decomposition.h"
-#include "storm/storage/SparseMatrix.h"
 #include "storm/storage/StronglyConnectedComponent.h"
-#include "storm/utility/constants.h"
 namespace storm {
-namespace models {
-namespace sparse {
-// Forward declare the model class.
-template<typename ValueType, typename RewardModelType>
-class Model;
-}  // namespace sparse
-}  // namespace models
 
 namespace storage {
 
+template<typename ValueType>
+class SparseMatrix;
+
 struct StronglyConnectedComponentDecompositionOptions {
     /// Sets a bit vector indicating which subsystem to consider for the decomposition into SCCs.
-    StronglyConnectedComponentDecompositionOptions& subsystem(storm::storage::BitVector const* subsystem) {
-        subsystemPtr = subsystem;
-        return *this;
-    }
+    StronglyConnectedComponentDecompositionOptions& subsystem(storm::storage::BitVector const* subsystem);
+
     /// Sets a bit vector indicating which choices of the states are contained in the subsystem.
-    StronglyConnectedComponentDecompositionOptions& choices(storm::storage::BitVector const* choices) {
-        choicesPtr = choices;
-        return *this;
-    }
+    StronglyConnectedComponentDecompositionOptions& choices(storm::storage::BitVector const* choices);
+
     /// Sets if trivial SCCs (i.e. SCCs consisting of just one state without a self-loop) are to be kept in the decomposition.
-    StronglyConnectedComponentDecompositionOptions& dropNaiveSccs(bool value = true) {
-        areNaiveSccsDropped = value;
-        return *this;
-    }
+    StronglyConnectedComponentDecompositionOptions& dropNaiveSccs(bool value = true);
+
     /// Sets if only bottom SCCs, i.e. SCCs in which all states have no way of leaving the SCC), are kept.
-    StronglyConnectedComponentDecompositionOptions& onlyBottomSccs(bool value = true) {
-        areOnlyBottomSccsConsidered = value;
-        return *this;
-    }
+    StronglyConnectedComponentDecompositionOptions& onlyBottomSccs(bool value = true);
+
     /// Enforces that the returned SCCs are sorted in a topological order.
-    StronglyConnectedComponentDecompositionOptions& forceTopologicalSort(bool value = true) {
-        isTopologicalSortForced = value;
-        return *this;
-    }
+    StronglyConnectedComponentDecompositionOptions& forceTopologicalSort(bool value = true);
+
     /// Sets if scc depths can be retrieved.
-    StronglyConnectedComponentDecompositionOptions& computeSccDepths(bool value = true) {
-        isComputeSccDepthsSet = value;
-        return *this;
-    }
+    StronglyConnectedComponentDecompositionOptions& computeSccDepths(bool value = true);
 
     storm::storage::BitVector const* subsystemPtr = nullptr;
     storm::storage::BitVector const* choicesPtr = nullptr;
@@ -59,17 +41,69 @@ struct StronglyConnectedComponentDecompositionOptions {
 };
 
 /*!
+ * Holds temporary computation data used during the SCC decomposition algorithm.
+ * Can be kept in memory to avoid re-allocations, which is useful if multiple SCC decompositions are computed (e.g. as part of an end component decomposition
+ * algorithm).
+ */
+struct SccDecompositionMemoryCache {
+    void initialize(uint64_t numStates);
+    bool hasPreorderNumber(uint64_t stateIndex) const;
+    std::vector<uint64_t> preorderNumbers, recursionStateStack, s, p;
+};
+
+/*!
+ * Holds the result data of the implemented SCC decomposition algorithm.
+ */
+struct SccDecompositionResult {
+    void initialize(uint64_t numStates, bool computeSccDepths);
+    bool stateHasScc(uint64_t stateIndex) const;     /// True if an SCC is associated to the given state
+    uint64_t sccCount;                               /// Number of found SCCs
+    std::vector<uint64_t> stateToSccMapping;         /// Mapping from states to the SCC it belongs to
+    storm::storage::BitVector nonTrivialStates;      /// Keep track of trivial states (singleton SCCs without selfloop).
+    std::optional<std::vector<uint64_t>> sccDepths;  /// Holds SCC depths if requested. @see getSccDepth()
+};
+
+/*!
+ * Computes an SCC decomposition for the given matrix and options.
+ *
+ * @note This method does initialize the given result data. This means that if multiple SCC decompositions (e.g. with different options) are computed, the
+ * result memory can be re-used to avoid expensive reallocations.
+ *
+ * @param transitionMatrix transition matrix of the model
+ * @param options options for the decomposition
+ * @param result The resulting information will be stored into this struct.
+ */
+template<typename ValueType>
+void performSccDecomposition(storm::storage::SparseMatrix<ValueType> const& transitionMatrix, StronglyConnectedComponentDecompositionOptions const& options,
+                             SccDecompositionResult& result);
+
+/*!
+ * Computes an SCC decomposition for the given matrix and options.
+ *
+ * @note This method does initialize the given result and cache data. This means that if multiple SCC decompositions (e.g. with different options) are computed,
+ * the result and cache memory can be re-used to avoid expensive reallocations.
+ *
+ * @param transitionMatrix transition matrix of the model
+ * @param options options for the decomposition
+ * @param result The resulting information will be stored into this struct.
+ * @param cache memory used by the underlying algorithm
+ */
+template<typename ValueType>
+void performSccDecomposition(storm::storage::SparseMatrix<ValueType> const& transitionMatrix, StronglyConnectedComponentDecompositionOptions const& options,
+                             SccDecompositionResult& result, SccDecompositionMemoryCache& cache);
+
+/*!
  * This class represents the decomposition of a graph-like structure into its strongly connected components.
  */
 template<typename ValueType>
 class StronglyConnectedComponentDecomposition : public Decomposition<StronglyConnectedComponent> {
    public:
-    /*
+    /*!
      * Creates an empty SCC decomposition.
      */
     StronglyConnectedComponentDecomposition();
 
-    /*
+    /*!
      * Creates an SCC decomposition of the given subsystem in the given system (whose transition relation is
      * given by a sparse matrix).
      *
@@ -126,6 +160,14 @@ class StronglyConnectedComponentDecomposition : public Decomposition<StronglyCon
      */
     uint_fast64_t getMaxSccDepth() const;
 
+    /*!
+     * Computes a vector that for each state has the index of the scc of that state in it.
+     * If a state has no SCC in this decomposition (e.g. because we considered a subsystem), they will get SCC index std::numeric_limits<uint64_t>::max()
+     *
+     * @param numberOfStates the total number of states
+     */
+    std::vector<uint64_t> computeStateToSccIndexMap(uint64_t numberOfStates) const;
+
    private:
     /*
      * Performs the SCC decomposition of the given block in the given model. As a side-effect this fills
@@ -136,9 +178,7 @@ class StronglyConnectedComponentDecomposition : public Decomposition<StronglyCon
     void performSccDecomposition(storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                  StronglyConnectedComponentDecompositionOptions const& options);
 
-    boost::optional<std::vector<uint_fast64_t>> sccDepths;
+    std::optional<std::vector<uint_fast64_t>> sccDepths;
 };
 }  // namespace storage
 }  // namespace storm
-
-#endif /* STORM_STORAGE_STRONGLYCONNECTEDCOMPONENTDECOMPOSITION_H_ */


### PR DESCRIPTION
- option to cache data used during SCC decomposition algorithm, avoiding reallocations
- option to get an SCC decomposition in a more raw format
- rewrite of MEC decomposition algorithm using cache and raw MEC decomposition results