### PR TITLE
Add check to only compile clipping tests if Z3 is installed

### DIFF
--- a/src/test/storm-pomdp/modelchecker/BeliefExplorationPomdpModelCheckerTest.cpp
+++ b/src/test/storm-pomdp/modelchecker/BeliefExplorationPomdpModelCheckerTest.cpp
@@ -329,24 +329,6 @@ TYPED_TEST(BeliefExplorationTest, simple_Pmax_SE) {
         << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
 }
 
-TYPED_TEST(BeliefExplorationTest, simple_Pmax_Clip) {
-    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
-        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
-    }
-    typedef typename TestFixture::ValueType ValueType;
-
-    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmax=? [F \"goal\" ]", "slippery=0");
-    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
-    auto result = checker.check(this->env(), *data.formula);
-
-    ValueType expected = this->parseNumber("7/10");
-    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
-    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-    EXPECT_LE(result.diff(), this->precision())
-        << "Result [" << result.lowerBound << ", " << result.upperBound
-        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
-}
-
 TYPED_TEST(BeliefExplorationTest, simple_Pmin) {
     typedef typename TestFixture::ValueType ValueType;
 
@@ -378,24 +360,6 @@ TYPED_TEST(BeliefExplorationTest, simple_Pmin_SE) {
         << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
 }
 
-TYPED_TEST(BeliefExplorationTest, simple_Pmin_Clip) {
-    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
-        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
-    }
-    typedef typename TestFixture::ValueType ValueType;
-
-    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmin=? [F \"goal\" ]", "slippery=0");
-    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
-    auto result = checker.check(this->env(), *data.formula);
-
-    ValueType expected = this->parseNumber("3/10");
-    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
-    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-    EXPECT_LE(result.diff(), this->precision())
-        << "Result [" << result.lowerBound << ", " << result.upperBound
-        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
-}
-
 TYPED_TEST(BeliefExplorationTest, simple_slippery_Pmax) {
     typedef typename TestFixture::ValueType ValueType;
 
@@ -417,24 +381,6 @@ TYPED_TEST(BeliefExplorationTest, simple_slippery_Pmax_SE) {
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmax=? [F \"goal\" ]", "slippery=0.4");
     storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model,
                                                                                                                     this->optionsWithStateElimination());
-    auto result = checker.check(this->env(), *data.formula);
-
-    ValueType expected = this->parseNumber("7/10");
-    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
-    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-    EXPECT_LE(result.diff(), this->precision())
-        << "Result [" << result.lowerBound << ", " << result.upperBound
-        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
-}
-
-TYPED_TEST(BeliefExplorationTest, simple_slippery_Pmax_Clip) {
-    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
-        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
-    }
-    typedef typename TestFixture::ValueType ValueType;
-
-    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmax=? [F \"goal\" ]", "slippery=0.4");
-    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
     auto result = checker.check(this->env(), *data.formula);
 
     ValueType expected = this->parseNumber("7/10");
@@ -492,32 +438,6 @@ TYPED_TEST(BeliefExplorationTest, simple_slippery_Pmin_SE) {
         << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
 }
 
-TYPED_TEST(BeliefExplorationTest, simple_slippery_Pmin_Clip) {
-    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
-        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
-    }
-    typedef typename TestFixture::ValueType ValueType;
-
-    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmin=? [F \"goal\" ]", "slippery=0.4");
-    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
-    auto result = checker.check(this->env(), *data.formula);
-
-    ValueType expected = this->parseNumber("3/10");
-    if (this->isExact()) {
-        // This model's value can only be approximated arbitrarily close but never reached
-        // Exact arithmetics will thus not reach the value with absoulute precision either.
-        ValueType approxPrecision = storm::utility::convertNumber<ValueType>(1e-4);
-        EXPECT_LE(result.lowerBound, expected + approxPrecision);
-        EXPECT_GE(result.upperBound, expected - approxPrecision);
-    } else {
-        EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision() * 10);
-        EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision() * 10);
-    }
-    EXPECT_LE(result.diff(), this->precision())
-        << "Result [" << result.lowerBound << ", " << result.upperBound
-        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
-}
-
 TYPED_TEST(BeliefExplorationTest, simple_Rmax) {
     typedef typename TestFixture::ValueType ValueType;
 
@@ -539,24 +459,6 @@ TYPED_TEST(BeliefExplorationTest, simple_Rmax_SE) {
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmax=? [F s>4 ]", "slippery=0");
     storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model,
                                                                                                                     this->optionsWithStateElimination());
-    auto result = checker.check(this->env(), *data.formula);
-
-    ValueType expected = this->parseNumber("29/50");
-    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
-    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-    EXPECT_LE(result.diff(), this->precision())
-        << "Result [" << result.lowerBound << ", " << result.upperBound
-        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
-}
-
-TYPED_TEST(BeliefExplorationTest, simple_Rmax_Clip) {
-    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
-        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
-    }
-    typedef typename TestFixture::ValueType ValueType;
-
-    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmax=? [F s>4 ]", "slippery=0");
-    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
     auto result = checker.check(this->env(), *data.formula);
 
     ValueType expected = this->parseNumber("29/50");
@@ -598,24 +500,6 @@ TYPED_TEST(BeliefExplorationTest, simple_Rmin_SE) {
         << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
 }
 
-TYPED_TEST(BeliefExplorationTest, simple_Rmin_Clip) {
-    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
-        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
-    }
-    typedef typename TestFixture::ValueType ValueType;
-
-    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmin=? [F s>4 ]", "slippery=0");
-    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
-    auto result = checker.check(this->env(), *data.formula);
-
-    ValueType expected = this->parseNumber("19/50");
-    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
-    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-    EXPECT_LE(result.diff(), this->precision())
-        << "Result [" << result.lowerBound << ", " << result.upperBound
-        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
-}
-
 TYPED_TEST(BeliefExplorationTest, simple_slippery_Rmax) {
     typedef typename TestFixture::ValueType ValueType;
 
@@ -647,24 +531,6 @@ TYPED_TEST(BeliefExplorationTest, simple_slippery_Rmax_SE) {
         << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
 }
 
-TYPED_TEST(BeliefExplorationTest, simple_slippery_Rmax_Clip) {
-    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
-        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
-    }
-    typedef typename TestFixture::ValueType ValueType;
-
-    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmax=? [F s>4 ]", "slippery=0.4");
-    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
-    auto result = checker.check(this->env(), *data.formula);
-
-    ValueType expected = this->parseNumber("29/30");
-    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
-    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-    EXPECT_LE(result.diff(), this->precision())
-        << "Result [" << result.lowerBound << ", " << result.upperBound
-        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
-}
-
 TYPED_TEST(BeliefExplorationTest, simple_slippery_Rmin) {
     typedef typename TestFixture::ValueType ValueType;
 
@@ -686,24 +552,6 @@ TYPED_TEST(BeliefExplorationTest, simple_slippery_Rmin_SE) {
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmin=? [F s>4 ]", "slippery=0.4");
     storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model,
                                                                                                                     this->optionsWithStateElimination());
-    auto result = checker.check(this->env(), *data.formula);
-
-    ValueType expected = this->parseNumber("19/30");
-    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
-    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-    EXPECT_LE(result.diff(), this->precision())
-        << "Result [" << result.lowerBound << ", " << result.upperBound
-        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
-}
-
-TYPED_TEST(BeliefExplorationTest, simple_slippery_Rmin_Clip) {
-    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
-        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
-    }
-    typedef typename TestFixture::ValueType ValueType;
-
-    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmin=? [F s>4 ]", "slippery=0.4");
-    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
     auto result = checker.check(this->env(), *data.formula);
 
     ValueType expected = this->parseNumber("19/30");
@@ -747,25 +595,6 @@ TYPED_TEST(BeliefExplorationTest, maze2_Rmin_SE) {
         << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
 }
 
-TYPED_TEST(BeliefExplorationTest, maze2_Rmin_Clip) {
-    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
-        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
-    }
-    typedef typename TestFixture::ValueType ValueType;
-
-    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/maze2.prism", "R[exp]min=? [F \"goal\"]", "sl=0");
-    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
-    auto result = checker.check(this->env(), *data.formula);
-
-    ValueType expected = this->parseNumber("74/91");
-    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
-    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-    // Use relative difference of bounds for this one
-    EXPECT_LE(result.diff(), this->precision())
-        << "Result [" << result.lowerBound << ", " << result.upperBound
-        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
-}
-
 TYPED_TEST(BeliefExplorationTest, maze2_Rmax) {
     typedef typename TestFixture::ValueType ValueType;
 
@@ -783,20 +612,6 @@ TYPED_TEST(BeliefExplorationTest, maze2_Rmax_SE) {
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/maze2.prism", "R[exp]max=? [F \"goal\"]", "sl=0");
     storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model,
                                                                                                                     this->optionsWithStateElimination());
-    auto result = checker.check(this->env(), *data.formula);
-
-    EXPECT_TRUE(storm::utility::isInfinity(result.lowerBound));
-    EXPECT_TRUE(storm::utility::isInfinity(result.upperBound));
-}
-
-TYPED_TEST(BeliefExplorationTest, maze2_Rmax_Clip) {
-    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
-        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
-    }
-    typedef typename TestFixture::ValueType ValueType;
-
-    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/maze2.prism", "R[exp]max=? [F \"goal\"]", "sl=0");
-    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
     auto result = checker.check(this->env(), *data.formula);
 
     EXPECT_TRUE(storm::utility::isInfinity(result.lowerBound));
@@ -836,25 +651,6 @@ TYPED_TEST(BeliefExplorationTest, maze2_slippery_Rmin_SE) {
         << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
 }
 
-TYPED_TEST(BeliefExplorationTest, maze2_slippery_Rmin_Clip) {
-    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
-        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
-    }
-    typedef typename TestFixture::ValueType ValueType;
-
-    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/maze2.prism", "R[exp]min=? [F \"goal\"]", "sl=0.075");
-    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
-    auto result = checker.check(this->env(), *data.formula);
-
-    ValueType expected = this->parseNumber("80/91");
-    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
-    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-    // Use relative difference of bounds for this one
-    EXPECT_LE(result.diff(), this->precision())
-        << "Result [" << result.lowerBound << ", " << result.upperBound
-        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
-}
-
 TYPED_TEST(BeliefExplorationTest, maze2_slippery_Rmax) {
     typedef typename TestFixture::ValueType ValueType;
 
@@ -872,20 +668,6 @@ TYPED_TEST(BeliefExplorationTest, maze2_slippery_Rmax_SE) {
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/maze2.prism", "R[exp]max=? [F \"goal\"]", "sl=0.075");
     storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model,
                                                                                                                     this->optionsWithStateElimination());
-    auto result = checker.check(this->env(), *data.formula);
-
-    EXPECT_TRUE(storm::utility::isInfinity(result.lowerBound));
-    EXPECT_TRUE(storm::utility::isInfinity(result.upperBound));
-}
-
-TYPED_TEST(BeliefExplorationTest, maze2_slippery_Rmax_Clip) {
-    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
-        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
-    }
-    typedef typename TestFixture::ValueType ValueType;
-
-    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/maze2.prism", "R[exp]max=? [F \"goal\"]", "sl=0.075");
-    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
     auto result = checker.check(this->env(), *data.formula);
 
     EXPECT_TRUE(storm::utility::isInfinity(result.lowerBound));
@@ -914,25 +696,6 @@ TYPED_TEST(BeliefExplorationTest, refuel_Pmax_SE) {
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/refuel.prism", "Pmax=?[\"notbad\" U \"goal\"]", "N=4");
     storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model,
                                                                                                                     this->optionsWithStateElimination());
-    auto result = checker.check(this->env(), *data.formula);
-
-    ValueType expected = this->parseNumber("38/155");
-    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
-    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
-    // Use relative difference of bounds for this one
-    EXPECT_LE(result.diff(), this->precision())
-        << "Result [" << result.lowerBound << ", " << result.upperBound
-        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
-}
-
-TYPED_TEST(BeliefExplorationTest, refuel_Pmax_Clip) {
-    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
-        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
-    }
-    typedef typename TestFixture::ValueType ValueType;
-
-    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/refuel.prism", "Pmax=?[\"notbad\" U \"goal\"]", "N=4");
-    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
     auto result = checker.check(this->env(), *data.formula);
 
     ValueType expected = this->parseNumber("38/155");
@@ -977,6 +740,245 @@ TYPED_TEST(BeliefExplorationTest, refuel_Pmin_SE) {
         << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
 }
 
+#if defined STORM_HAVE_Z3_OPTIMIZE
+
+TYPED_TEST(BeliefExplorationTest, simple_Pmax_Clip) {
+    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
+        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
+    }
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmax=? [F \"goal\" ]", "slippery=0");
+    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
+    auto result = checker.check(this->env(), *data.formula);
+
+    ValueType expected = this->parseNumber("7/10");
+    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+    EXPECT_LE(result.diff(), this->precision())
+        << "Result [" << result.lowerBound << ", " << result.upperBound
+        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
+}
+
+TYPED_TEST(BeliefExplorationTest, simple_Pmin_Clip) {
+    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
+        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
+    }
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmin=? [F \"goal\" ]", "slippery=0");
+    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
+    auto result = checker.check(this->env(), *data.formula);
+
+    ValueType expected = this->parseNumber("3/10");
+    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+    EXPECT_LE(result.diff(), this->precision())
+        << "Result [" << result.lowerBound << ", " << result.upperBound
+        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
+}
+
+TYPED_TEST(BeliefExplorationTest, simple_slippery_Pmax_Clip) {
+    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
+        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
+    }
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmax=? [F \"goal\" ]", "slippery=0.4");
+    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
+    auto result = checker.check(this->env(), *data.formula);
+
+    ValueType expected = this->parseNumber("7/10");
+    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+    EXPECT_LE(result.diff(), this->precision())
+        << "Result [" << result.lowerBound << ", " << result.upperBound
+        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
+}
+
+TYPED_TEST(BeliefExplorationTest, simple_slippery_Pmin_Clip) {
+    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
+        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
+    }
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmin=? [F \"goal\" ]", "slippery=0.4");
+    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
+    auto result = checker.check(this->env(), *data.formula);
+
+    ValueType expected = this->parseNumber("3/10");
+    if (this->isExact()) {
+        // This model's value can only be approximated arbitrarily close but never reached
+        // Exact arithmetics will thus not reach the value with absoulute precision either.
+        ValueType approxPrecision = storm::utility::convertNumber<ValueType>(1e-4);
+        EXPECT_LE(result.lowerBound, expected + approxPrecision);
+        EXPECT_GE(result.upperBound, expected - approxPrecision);
+    } else {
+        EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision() * 10);
+        EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision() * 10);
+    }
+    EXPECT_LE(result.diff(), this->precision())
+        << "Result [" << result.lowerBound << ", " << result.upperBound
+        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
+}
+
+TYPED_TEST(BeliefExplorationTest, simple_Rmax_Clip) {
+    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
+        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
+    }
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmax=? [F s>4 ]", "slippery=0");
+    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
+    auto result = checker.check(this->env(), *data.formula);
+
+    ValueType expected = this->parseNumber("29/50");
+    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+    EXPECT_LE(result.diff(), this->precision())
+        << "Result [" << result.lowerBound << ", " << result.upperBound
+        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
+}
+
+TYPED_TEST(BeliefExplorationTest, simple_Rmin_Clip) {
+    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
+        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
+    }
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmin=? [F s>4 ]", "slippery=0");
+    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
+    auto result = checker.check(this->env(), *data.formula);
+
+    ValueType expected = this->parseNumber("19/50");
+    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+    EXPECT_LE(result.diff(), this->precision())
+        << "Result [" << result.lowerBound << ", " << result.upperBound
+        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
+}
+
+TYPED_TEST(BeliefExplorationTest, simple_slippery_Rmax_Clip) {
+    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
+        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
+    }
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmax=? [F s>4 ]", "slippery=0.4");
+    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
+    auto result = checker.check(this->env(), *data.formula);
+
+    ValueType expected = this->parseNumber("29/30");
+    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+    EXPECT_LE(result.diff(), this->precision())
+        << "Result [" << result.lowerBound << ", " << result.upperBound
+        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
+}
+
+TYPED_TEST(BeliefExplorationTest, simple_slippery_Rmin_Clip) {
+    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
+        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
+    }
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmin=? [F s>4 ]", "slippery=0.4");
+    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
+    auto result = checker.check(this->env(), *data.formula);
+
+    ValueType expected = this->parseNumber("19/30");
+    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+    EXPECT_LE(result.diff(), this->precision())
+        << "Result [" << result.lowerBound << ", " << result.upperBound
+        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
+}
+
+TYPED_TEST(BeliefExplorationTest, maze2_Rmin_Clip) {
+    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
+        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
+    }
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/maze2.prism", "R[exp]min=? [F \"goal\"]", "sl=0");
+    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
+    auto result = checker.check(this->env(), *data.formula);
+
+    ValueType expected = this->parseNumber("74/91");
+    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+    // Use relative difference of bounds for this one
+    EXPECT_LE(result.diff(), this->precision())
+        << "Result [" << result.lowerBound << ", " << result.upperBound
+        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
+}
+
+TYPED_TEST(BeliefExplorationTest, maze2_Rmax_Clip) {
+    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
+        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
+    }
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/maze2.prism", "R[exp]max=? [F \"goal\"]", "sl=0");
+    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
+    auto result = checker.check(this->env(), *data.formula);
+
+    EXPECT_TRUE(storm::utility::isInfinity(result.lowerBound));
+    EXPECT_TRUE(storm::utility::isInfinity(result.upperBound));
+}
+
+TYPED_TEST(BeliefExplorationTest, maze2_slippery_Rmin_Clip) {
+    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
+        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
+    }
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/maze2.prism", "R[exp]min=? [F \"goal\"]", "sl=0.075");
+    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
+    auto result = checker.check(this->env(), *data.formula);
+
+    ValueType expected = this->parseNumber("80/91");
+    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+    // Use relative difference of bounds for this one
+    EXPECT_LE(result.diff(), this->precision())
+        << "Result [" << result.lowerBound << ", " << result.upperBound
+        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
+}
+
+TYPED_TEST(BeliefExplorationTest, maze2_slippery_Rmax_Clip) {
+    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
+        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
+    }
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/maze2.prism", "R[exp]max=? [F \"goal\"]", "sl=0.075");
+    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
+    auto result = checker.check(this->env(), *data.formula);
+
+    EXPECT_TRUE(storm::utility::isInfinity(result.lowerBound));
+    EXPECT_TRUE(storm::utility::isInfinity(result.upperBound));
+}
+
+TYPED_TEST(BeliefExplorationTest, refuel_Pmax_Clip) {
+    if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
+        GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
+    }
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/refuel.prism", "Pmax=?[\"notbad\" U \"goal\"]", "N=4");
+    storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> checker(data.model, this->optionsWithClipping());
+    auto result = checker.check(this->env(), *data.formula);
+
+    ValueType expected = this->parseNumber("38/155");
+    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+    // Use relative difference of bounds for this one
+    EXPECT_LE(result.diff(), this->precision())
+        << "Result [" << result.lowerBound << ", " << result.upperBound
+        << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
+}
+
 TYPED_TEST(BeliefExplorationTest, refuel_Pmin_Clip) {
     if (!storm::test::z3AtLeastVersion(4, 8, 5)) {
         GTEST_SKIP() << "Test disabled since it triggers a bug in the installed version of z3.";
@@ -995,5 +997,6 @@ TYPED_TEST(BeliefExplorationTest, refuel_Pmin_Clip) {
         << "Result [" << result.lowerBound << ", " << result.upperBound
         << "] is not precise enough. If (only) this fails, the result bounds are still correct, but they might be unexpectedly imprecise.\n";
 }
+#endif  // defined STORM_HAVE_Z3_OPTIMIZE
 
 }  // namespace


### PR DESCRIPTION
Add check to only compile clipping tests if Z3 is installed.

Fixes #408 