### PR TITLE
Add helper class to store optional references.

### DIFF
--- a/src/storm/utility/OptionalRef.h
+++ b/src/storm/utility/OptionalRef.h
@@ -1,0 +1,182 @@
+#pragma once
+
+#include <memory>
+#include <type_traits>
+
+#include "storm/utility/macros.h"
+
+namespace storm {
+
+/*!
+ * Auxiliary struct used to identify OptionalRefs that do not contain a reference.
+ */
+struct NullRefType {
+} constexpr NullRef;
+
+/*!
+ * Helper class that optionally holds a reference to an object of type T.
+ * This mimics the interface of std::optional, except that an OptionalRef never takes ownership of an object.
+ *
+ * @warning An OptionalRef becomes invalid if the lifetime of the referenced object ends prematurely.
+ *
+ * @note A possible use case is the implementation of optional function arguments, where std::optional would trigger a deep copy of the object.
+ *       For example, `foo(storm::OptionalRef<T const> bar = storm::NullRef)` instead of `foo(T const& bar)`
+ *
+ * @note This class does not provide an operator= as this is prone to errors: should this re-bind the reference or call T::operator= ?
+ *       Instead, the `reset` method can be used.
+ *
+ * @tparam T The type of the referenced object
+ */
+template<class T>
+class OptionalRef {
+    static_assert(!std::is_reference_v<T>, "Type of OptionalRef should not be a reference type itself.");
+
+   public:
+    using type = T;
+
+    /*!
+     * Creates a non-initialized reference.
+     */
+    OptionalRef() : ptr(nullptr) {}
+
+    /*!
+     * Creates a non-initialized reference
+     */
+    OptionalRef(NullRefType /*NullRef*/) : ptr(nullptr) {}
+
+    /*!
+     * Creates a reference to the provided object
+     * @param obj the object this will be a reference to
+     * @note Exploits template argument deduction so that the class template can be derived from expressions like `OptionalRef(foo)` (even if foo is of type
+     * e.g. T&)
+     */
+    template<class U>
+    OptionalRef(U&& obj) : ptr(std::addressof(obj)) {}
+
+    /*!
+     * Creates a copy of the given OptionalRef. `this` and `other` will both reference the same object
+     */
+    OptionalRef(OptionalRef<T> const& other) = default;
+
+    /*!
+     * Move constructs this OptionalRef from another one.
+     */
+    OptionalRef(OptionalRef<T>&& other) = default;
+
+    /*!
+     * Deleted assignment operator (see class description)
+     */
+    OptionalRef& operator=(OptionalRef const& other) = delete;
+
+    /*!
+     * Yields true iff this contains a reference
+     */
+    operator bool() const {
+        return ptr != nullptr;
+    }
+
+    /*!
+     * Yields true iff this contains a reference
+     */
+    bool has_value() const {
+        return ptr != nullptr;
+    }
+
+    /*!
+     * Accesses the contained reference (if any)
+     * @pre this must contain a reference.
+     */
+    T& operator*() {
+        STORM_LOG_ASSERT(has_value(), "OptionalRef operator* called but no object is referenced by this.");
+        return *ptr;
+    }
+
+    /*!
+     * Accesses the contained reference (if any)
+     * @pre this must contain a reference.
+     */
+    T const& operator*() const {
+        STORM_LOG_ASSERT(has_value(), "OptionalRef operator* called but no object is referenced by this.");
+        return *ptr;
+    }
+
+    /*!
+     * Accesses the contained reference (if any)
+     * @pre this must contain a reference.
+     */
+    T& value() {
+        STORM_LOG_ASSERT(has_value(), "OptionalRef value() called but no object is referenced by this.");
+        return *ptr;
+    }
+
+    /*!
+     * Accesses the contained reference (if any)
+     * @pre this must contain a reference.
+     */
+    T const& value() const {
+        STORM_LOG_ASSERT(has_value(), "OptionalRef value called but no object is referenced by this.");
+        return *ptr;
+    }
+
+    /*!
+     * Returns the contained reference (if any). Otherwise, the provided default value is returned.
+     */
+    T& value_or(T& defaultValue) {
+        return has_value() ? value() : defaultValue;
+    }
+
+    /*!
+     * Returns the contained reference (if any). Otherwise, the provided default value is returned.
+     */
+    T const& value_or(T const& defaultValue) const {
+        return has_value() ? value() : defaultValue;
+    }
+
+    /*!
+     * Yields a pointer to the referenced object (if any)
+     * @pre this must contain a reference.
+     */
+    T* operator->() {
+        STORM_LOG_ASSERT(has_value(), "OptionalRef operator-> called but no object is referenced by this.");
+        return ptr;
+    }
+
+    /*!
+     * Yields a pointer to the referenced object (if any)
+     * @pre this must contain a reference.
+     */
+    T const* operator->() const {
+        STORM_LOG_ASSERT(has_value(), "OptionalRef operator-> called but no object is referenced by this.");
+        return ptr;
+    }
+
+    /*!
+     * Unsets the reference. `has_value()` yields false after calling this.
+     */
+    void reset() {
+        ptr = nullptr;
+    }
+
+    /*!
+     * Unsets the reference. `has_value()` yields false after calling this.
+     */
+    void reset(NullRefType const&) {
+        ptr = nullptr;
+    }
+
+    /*!
+     * Rebinds the reference. `has_value()' yields true after calling this.
+     */
+    void reset(T& t) {
+        ptr = std::addressof(t);
+    }
+
+   private:
+    T* ptr;  /// A pointer to the referenced object. Nullptr if no object is referenced.
+};
+
+/// deduction guides
+template<class T>
+OptionalRef(T&) -> OptionalRef<T>;
+
+}  // namespace storm


### PR DESCRIPTION
 Adds `storm::OptionalRef`, a helper class that optionally holds a reference to an object.
 This mimics the interface of std::optional, except that an OptionalRef never takes ownership of an object.

A possible use case is the implementation of optional function arguments, where std::optional would trigger a deep copy of the object.  For example, `foo(storm::OptionalRef<T const> bar = storm::NullRef)` instead of `foo(T const& bar)`.
 
## Why?
This seems to be the best option for providing optional arguments:

- We use void `foo(std::optional<A const> const& a) {...}`  a lot, but it's imo very implicit that e.g.  in `foo(bar);`  a copy of `bar` is created when it is of type  `A`  or `A const&` .
- Sometimes, we use a raw pointer like `void foo(A const* a) {...}`  which avoids a copy but it's not very explicit about the fact that `a` is optional and it makes ownership unclear.
- `std::optional<A const&>` is not allowed by the CPP standard.
- We could use `void foo(std::optional<std::reference_wrapper<A>> const& a) { ... }`  but it becomes a bit annoying  since in the body of `foo` we'd have to deal with both, the optional and the reference_wrapper, e.g.  `A const& a_ref = a.value().get()`
- Function overloading (i.e. have both a  `foo()` and a `foo(A const& a)` is not always feasible (code duplications, dealing with multiple optional arguments, ...)