### PR TITLE
Fixed issue with out-of-bounds flag

### DIFF
--- a/src/storm/generator/JaniNextStateGenerator.cpp
+++ b/src/storm/generator/JaniNextStateGenerator.cpp
@@ -101,6 +101,7 @@ JaniNextStateGenerator<ValueType, StateType>::JaniNextStateGenerator(storm::jani
     this->variableInformation.registerArrayVariableReplacements(arrayEliminatorData);
     this->transientVariableInformation = TransientVariableInformation<ValueType>(this->model, this->parallelAutomata);
     this->transientVariableInformation.registerArrayVariableReplacements(arrayEliminatorData);
+    this->initializeSpecialStates();
 
     // Create a proper evaluator.
     this->evaluator = std::make_unique<storm::expressions::ExpressionEvaluator<ValueType>>(this->model.getManager());

--- a/src/storm/generator/NextStateGenerator.cpp
+++ b/src/storm/generator/NextStateGenerator.cpp
@@ -42,26 +42,14 @@ NextStateGenerator<ValueType, StateType>::NextStateGenerator(storm::expressions:
       evaluator(nullptr),
       state(nullptr),
       actionMask(mask) {
-    if (variableInformation.hasOutOfBoundsBit()) {
-        outOfBoundsState = createOutOfBoundsState(variableInformation);
-    }
-    if (options.isAddOverlappingGuardLabelSet()) {
-        overlappingGuardStates = std::vector<uint64_t>();
-    }
+    initializeSpecialStates();
 }
 
 template<typename ValueType, typename StateType>
 NextStateGenerator<ValueType, StateType>::NextStateGenerator(storm::expressions::ExpressionManager const& expressionManager,
                                                              NextStateGeneratorOptions const& options,
                                                              std::shared_ptr<ActionMask<ValueType, StateType>> const& mask)
-    : options(options), expressionManager(expressionManager.getSharedPointer()), variableInformation(), evaluator(nullptr), state(nullptr), actionMask(mask) {
-    if (variableInformation.hasOutOfBoundsBit()) {
-        outOfBoundsState = createOutOfBoundsState(variableInformation);
-    }
-    if (options.isAddOverlappingGuardLabelSet()) {
-        overlappingGuardStates = std::vector<uint64_t>();
-    }
-}
+    : options(options), expressionManager(expressionManager.getSharedPointer()), variableInformation(), evaluator(nullptr), state(nullptr), actionMask(mask) {}
 
 template<typename ValueType, typename StateType>
 NextStateGeneratorOptions const& NextStateGenerator<ValueType, StateType>::getOptions() const {
@@ -71,6 +59,16 @@ NextStateGeneratorOptions const& NextStateGenerator<ValueType, StateType>::getOp
 template<typename ValueType, typename StateType>
 uint64_t NextStateGenerator<ValueType, StateType>::getStateSize() const {
     return variableInformation.getTotalBitOffset(true);
+}
+
+template<typename ValueType, typename StateType>
+void NextStateGenerator<ValueType, StateType>::initializeSpecialStates() {
+    if (variableInformation.hasOutOfBoundsBit()) {
+        outOfBoundsState = createOutOfBoundsState(variableInformation);
+    }
+    if (options.isAddOverlappingGuardLabelSet()) {
+        overlappingGuardStates = std::vector<uint64_t>();
+    }
 }
 
 template<typename ValueType, typename StateType>

--- a/src/storm/generator/NextStateGenerator.h
+++ b/src/storm/generator/NextStateGenerator.h
@@ -93,6 +93,9 @@ class NextStateGenerator {
     virtual bool isPartiallyObservable() const = 0;
     virtual std::vector<StateType> getInitialStates(StateToIdCallback const& stateToIdCallback) = 0;
 
+    /// Initializes the out-of-bounds state and states with overlapping guards.
+    void initializeSpecialStates();
+
     /// Initializes a builder for state valuations by adding the appropriate variables.
     virtual storm::storage::sparse::StateValuationsBuilder initializeStateValuationsBuilder() const;
 

--- a/src/storm/generator/PrismNextStateGenerator.cpp
+++ b/src/storm/generator/PrismNextStateGenerator.cpp
@@ -45,8 +45,9 @@ PrismNextStateGenerator<ValueType, StateType>::PrismNextStateGenerator(storm::pr
     // Only after checking validity of the program, we initialize the variable information.
     this->checkValid();
     this->variableInformation = VariableInformation(program, options.getReservedBitsForUnboundedVariables(), options.isAddOutOfBoundsStateSet());
+    this->initializeSpecialStates();
 
-    // Create a proper evalator.
+    // Create a proper evaluator.
     this->evaluator = std::make_unique<storm::expressions::ExpressionEvaluator<ValueType>>(program.getManager());
 
     if (this->options.isBuildAllRewardModelsSet()) {


### PR DESCRIPTION
Raised in https://github.com/moves-rwth/stormpy/issues/136.

The issue was that initially an empty `VariableInformation` was created and only later replaced by the complete one in the `NextStateGenerator`. As a result information about out-of-bounds values was not considered. I fixed it by adding a new method `initializeSpecialStates` which needs to be explicitly called after creating the VariableInformation.