### PR TITLE
CI: explicitly set STORM_VERSION_COMMITS_AHEAD

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -28,7 +28,7 @@ jobs:
           - {name: "GMP exact; CLN rational functions; No Spot", buildType: "Debug", cmakeArgs: "-DSTORM_DEVELOPER=ON -DSTORM_PORTABLE=ON -DSTORM_USE_CLN_EA=OFF -DSTORM_USE_CLN_RF=ON -DSTORM_USE_SPOT_SHIPPED=OFF -DSTORM_COMPILE_WITH_ALL_SANITIZERS=ON"}
     steps:
       - name: Git clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Replace Dockerfile
         run: cp .github/workflows/Dockerfile.carl_implicit Dockerfile
       - name: Build storm from Dockerfile
@@ -64,7 +64,7 @@ jobs:
           - {name: "Clang", buildType: "Debug", cmakeArgs: "-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSTORM_DEVELOPER=ON -DSTORM_PORTABLE=ON -DSTORM_USE_SPOT_SHIPPED=ON", packages: "clang"}
     steps:
       - name: Git clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Replace Dockerfile
         run: cp .github/workflows/Dockerfile.archlinux Dockerfile
       - name: Build storm from Dockerfile
@@ -97,7 +97,7 @@ jobs:
         buildType: ["Release"]
     steps:
       - name: Git clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build storm from Dockerfile
         run: docker build -t movesrwth/storm:ci . --build-arg BASE_IMG=movesrwth/storm-basesystem:${{ matrix.distro }} --build-arg build_type="${{ matrix.buildType }}" --build-arg no_threads=${NR_JOBS}
       - name: Run Docker
@@ -129,9 +129,12 @@ jobs:
           - {name: "Release", dockerTag: "ci", cmakeArgs: "-DSTORM_DEVELOPER=OFF -DSTORM_PORTABLE=ON -DSTORM_USE_SPOT_SHIPPED=ON"}
     steps:
       - name: Git clone
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
+      - name: Git describe
+        id: ghd
+        uses: proudust/gh-describe@v1
+      - name: Set static Storm version
+        run: echo "set(STORM_VERSION_COMMITS_AHEAD ${{ steps.ghd.outputs.distance }})" >> version.cmake
       - name: Build storm from Dockerfile
         run: docker build -t movesrwth/storm:${{ matrix.buildType.dockerTag }} . --build-arg build_type="${{ matrix.buildType.name }}" --build-arg cmake_args="${{ matrix.buildType.cmakeArgs }}" --build-arg no_threads=${NR_JOBS}
       - name: Run Docker
@@ -171,8 +174,8 @@ jobs:
     # Only run in main repo and even if previous step failed
     if: github.repository_owner == 'moves-rwth' && always()
     steps:
-      - uses: technote-space/workflow-conclusion-action@v2
-      - uses: dawidd6/action-send-mail@v2
+      - uses: technote-space/workflow-conclusion-action@v3
+      - uses: dawidd6/action-send-mail@v3
         with:
           server_address: ${{ secrets.STORM_CI_MAIL_SERVER }}
           server_port: 587


### PR DESCRIPTION
Explicitly set `STORM_VERSION_COMMITS_AHEAD` in `version.cmake`. This ensures that the Storm version is correctly set in the Docker container even though no git information is available.

Also updated some Github actions to the latest version.