### PR TITLE
Fix not detecting terminal states when Boolean literals are present

### DIFF
--- a/src/storm/builder/TerminalStatesGetter.cpp
+++ b/src/storm/builder/TerminalStatesGetter.cpp
@@ -9,7 +9,7 @@ namespace builder {
 void getTerminalStatesFromFormula(storm::logic::Formula const& formula,
                                   std::function<void(storm::expressions::Expression const&, bool)> const& terminalExpressionCallback,
                                   std::function<void(std::string const&, bool)> const& terminalLabelCallback) {
-    auto isAtomic = [](auto const& f) { return f.isAtomicExpressionFormula() || f.isAtomicLabelFormula(); };
+    auto isAtomic = [](auto const& f) { return f.isAtomicExpressionFormula() || f.isAtomicLabelFormula() || f.isBooleanLiteralFormula(); };
     if (formula.isAtomicExpressionFormula()) {
         terminalExpressionCallback(formula.asAtomicExpressionFormula().getExpression(), true);
     } else if (formula.isAtomicLabelFormula()) {


### PR DESCRIPTION
PR #422 introduced an error where for formulas like, e.g., `P=? [true U "a"]` the `"a"` was no longer detected as terminal label.