### PR TITLE
Enable code formatting for storm-pars

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,3 +1,2 @@
-./src/storm-pars/*
-./src/storm-pars-cli/*
-./src/test/storm-pars/*
+# Contains file path patterns that clang-format should ignore.
+# Currently intentionally left empty.


### PR DESCRIPTION
As usual, the `check-code-format` action is expected to fail.