### PR TITLE
Improved the behavior of OptionalRef

### DIFF
--- a/src/storm-pars-cli/solutionFunctions.h
+++ b/src/storm-pars-cli/solutionFunctions.h
@@ -41,16 +41,12 @@ void computeSolutionFunctionsWithSparseEngine(std::shared_ptr<storm::models::spa
                 auto dtmc = model->template as<storm::models::sparse::Dtmc<ValueType>>();
                 std::optional<ValueType> rationalFunction = result->asExplicitQuantitativeCheckResult<ValueType>()[*model->getInitialStates().begin()];
                 auto constraintCollector = storm::analysis::ConstraintCollector<ValueType>(*dtmc);
-                storm::api::exportParametricResultToFile(rationalFunction,
-                                                         storm::OptionalRef<storm::analysis::ConstraintCollector<ValueType> const>(constraintCollector),
-                                                         parametricSettings.exportResultPath());
+                storm::api::exportParametricResultToFile<ValueType>(rationalFunction, constraintCollector, parametricSettings.exportResultPath());
             } else if (parametricSettings.exportResultToFile() && model->isOfType(storm::models::ModelType::Ctmc)) {
                 auto ctmc = model->template as<storm::models::sparse::Ctmc<ValueType>>();
                 std::optional<ValueType> rationalFunction = result->asExplicitQuantitativeCheckResult<ValueType>()[*model->getInitialStates().begin()];
                 auto constraintCollector = storm::analysis::ConstraintCollector<ValueType>(*ctmc);
-                storm::api::exportParametricResultToFile(rationalFunction,
-                                                         storm::OptionalRef<storm::analysis::ConstraintCollector<ValueType> const>(constraintCollector),
-                                                         parametricSettings.exportResultPath());
+                storm::api::exportParametricResultToFile<ValueType>(rationalFunction, constraintCollector, parametricSettings.exportResultPath());
             }
         });
 }
@@ -73,9 +69,7 @@ void computeSolutionFunctionsWithSymbolicEngine(std::shared_ptr<storm::models::s
             if (parametricSettings.exportResultToFile() && model->isOfType(storm::models::ModelType::Dtmc)) {
                 STORM_LOG_WARN("For symbolic engines, we currently do not support collecting graph-preserving constraints.");
                 std::optional<ValueType> rationalFunction = result->asSymbolicQuantitativeCheckResult<DdType, ValueType>().sum();
-                storm::api::exportParametricResultToFile(rationalFunction,
-                                                         storm::OptionalRef<storm::analysis::ConstraintCollector<ValueType> const>(storm::NullRef),
-                                                         parametricSettings.exportResultPath());
+                storm::api::exportParametricResultToFile<ValueType>(rationalFunction, storm::NullRef, parametricSettings.exportResultPath());
             }
         });
 }

--- a/src/storm/utility/OptionalRef.h
+++ b/src/storm/utility/OptionalRef.h
@@ -8,10 +8,27 @@
 namespace storm {
 
 /*!
+ * Helper to prevent OptionalRef's to rvalue types
+ * @see https://en.cppreference.com/w/cpp/utility/functional/reference_wrapper#Possible_implementation
+ */
+
+namespace optionalref_detail {
+template<class T>
+constexpr T& FUN(T& t) noexcept {
+    return t;
+}
+template<class T>
+void FUN(T&&) = delete;
+}  // namespace optionalref_detail
+
+/*!
  * Auxiliary struct used to identify OptionalRefs that do not contain a reference.
+ * Inspired by std::nullopt, see https://en.cppreference.com/w/cpp/utility/optional/nullopt_t
  */
 struct NullRefType {
-} constexpr NullRef;
+    constexpr explicit NullRefType(int) {}
+};
+inline constexpr NullRefType NullRef{0};
 
 /*!
  * Helper class that optionally holds a reference to an object of type T.
@@ -50,8 +67,9 @@ class OptionalRef {
      * @note Exploits template argument deduction so that the class template can be derived from expressions like `OptionalRef(foo)` (even if foo is of type
      * e.g. T&)
      */
-    template<class U>
-    OptionalRef(U&& obj) : ptr(std::addressof(obj)) {}
+    template<class U, class = decltype(optionalref_detail::FUN<T>(std::declval<U>()), std::enable_if_t<!std::is_same_v<OptionalRef, std::remove_cvref_t<U>>>())>
+    constexpr OptionalRef(U&& u) noexcept(noexcept(optionalref_detail::FUN<T>(std::forward<U>(u))))
+        : ptr(std::addressof(optionalref_detail::FUN<T>(std::forward<U>(u)))) {}
 
     /*!
      * Creates a copy of the given OptionalRef. `this` and `other` will both reference the same object


### PR DESCRIPTION
- prevent construction from rvalue references (as this likely yields to unclear ownership)
- prevent implicit construction of a storm::NullRefType
- prevent nesting of OptionalRefs, i.e., storm::OptionalRef<storm::OptionalRef<T>>

I also made the usage in `storm-pars-cli/solutionFunctions.h` a bit more concise.