### PR TITLE
Introduce namespace storm::gbar

### DIFF
--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -1069,15 +1069,15 @@ template<storm::dd::DdType DdType, typename ValueType>
 void verifyWithAbstractionRefinementEngine(SymbolicInput const& input, ModelProcessingInformation const& mpi) {
     STORM_LOG_ASSERT(input.model, "Expected symbolic model description.");
     storm::settings::modules::AbstractionSettings const& abstractionSettings = storm::settings::getModule<storm::settings::modules::AbstractionSettings>();
-    storm::api::AbstractionRefinementOptions options(
+    storm::gbar::api::AbstractionRefinementOptions options(
         parseConstraints(input.model->getManager(), abstractionSettings.getConstraintString()),
         parseInjectedRefinementPredicates(input.model->getManager(), abstractionSettings.getInjectedRefinementPredicates()));
 
     verifyProperties<ValueType>(input, [&input, &options, &mpi](std::shared_ptr<storm::logic::Formula const> const& formula,
                                                                 std::shared_ptr<storm::logic::Formula const> const& states) {
         STORM_LOG_THROW(states->isInitialFormula(), storm::exceptions::NotSupportedException, "Abstraction-refinement can only filter initial states.");
-        return storm::api::verifyWithAbstractionRefinementEngine<DdType, ValueType>(mpi.env, input.model.get(),
-                                                                                    storm::api::createTask<ValueType>(formula, true), options);
+        return storm::gbar::api::verifyWithAbstractionRefinementEngine<DdType, ValueType>(mpi.env, input.model.get(),
+                                                                                          storm::api::createTask<ValueType>(formula, true), options);
     });
 }
 
@@ -1238,12 +1238,13 @@ void verifyWithDdEngine(std::shared_ptr<storm::models::ModelBase> const& model, 
 template<storm::dd::DdType DdType, typename ValueType>
 void verifyWithAbstractionRefinementEngine(std::shared_ptr<storm::models::ModelBase> const& model, SymbolicInput const& input,
                                            ModelProcessingInformation const& mpi) {
-    verifyProperties<ValueType>(input, [&model, &mpi](std::shared_ptr<storm::logic::Formula const> const& formula,
-                                                      std::shared_ptr<storm::logic::Formula const> const& states) {
-        STORM_LOG_THROW(states->isInitialFormula(), storm::exceptions::NotSupportedException, "Abstraction-refinement can only filter initial states.");
-        auto symbolicModel = model->as<storm::models::symbolic::Model<DdType, ValueType>>();
-        return storm::api::verifyWithAbstractionRefinementEngine<DdType, ValueType>(mpi.env, symbolicModel, storm::api::createTask<ValueType>(formula, true));
-    });
+    verifyProperties<ValueType>(
+        input, [&model, &mpi](std::shared_ptr<storm::logic::Formula const> const& formula, std::shared_ptr<storm::logic::Formula const> const& states) {
+            STORM_LOG_THROW(states->isInitialFormula(), storm::exceptions::NotSupportedException, "Abstraction-refinement can only filter initial states.");
+            auto symbolicModel = model->as<storm::models::symbolic::Model<DdType, ValueType>>();
+            return storm::gbar::api::verifyWithAbstractionRefinementEngine<DdType, ValueType>(mpi.env, symbolicModel,
+                                                                                              storm::api::createTask<ValueType>(formula, true));
+        });
 }
 
 template<storm::dd::DdType DdType, typename ValueType>

--- a/src/storm-gamebased-ar/abstraction/AbstractionInformation.cpp
+++ b/src/storm-gamebased-ar/abstraction/AbstractionInformation.cpp
@@ -10,7 +10,7 @@
 #include "storm/storage/expressions/Expression.h"
 #include "storm/storage/expressions/ExpressionManager.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType DdType>
@@ -624,4 +624,4 @@ template std::vector<std::map<uint_fast64_t, std::pair<storm::storage::BitVector
 AbstractionInformation<storm::dd::DdType::Sylvan>::decodeChoicesToUpdateSuccessorMapping(std::set<storm::expressions::Variable> const& player2Variables,
                                                                                          storm::dd::Bdd<storm::dd::DdType::Sylvan> const& choices) const;
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/AbstractionInformation.h
+++ b/src/storm-gamebased-ar/abstraction/AbstractionInformation.h
@@ -24,7 +24,9 @@ namespace dd {
 template<storm::dd::DdType DdType>
 class DdManager;
 }
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 
 struct AbstractionInformationOptions {
@@ -672,4 +674,4 @@ class AbstractionInformation {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/BottomStateResult.cpp
+++ b/src/storm-gamebased-ar/abstraction/BottomStateResult.cpp
@@ -1,7 +1,7 @@
 #include "storm-gamebased-ar/abstraction/BottomStateResult.h"
 #include "storm/storage/dd/sylvan/InternalSylvanBdd.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType DdType>
@@ -13,4 +13,4 @@ BottomStateResult<DdType>::BottomStateResult(storm::dd::Bdd<DdType> const& state
 template struct BottomStateResult<storm::dd::DdType::CUDD>;
 template struct BottomStateResult<storm::dd::DdType::Sylvan>;
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/BottomStateResult.h
+++ b/src/storm-gamebased-ar/abstraction/BottomStateResult.h
@@ -3,7 +3,7 @@
 #include "storm/storage/dd/Bdd.h"
 #include "storm/storage/dd/DdType.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType DdType>
@@ -16,4 +16,4 @@ struct BottomStateResult {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ExplicitQualitativeGameResult.cpp
+++ b/src/storm-gamebased-ar/abstraction/ExplicitQualitativeGameResult.cpp
@@ -1,6 +1,6 @@
 #include "storm-gamebased-ar/abstraction/ExplicitQualitativeGameResult.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 ExplicitQualitativeGameResult::ExplicitQualitativeGameResult(storm::utility::graph::ExplicitGameProb01Result const& prob01Result)
@@ -13,4 +13,4 @@ storm::storage::BitVector const& ExplicitQualitativeGameResult::getStates() cons
 }
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ExplicitQualitativeGameResult.h
+++ b/src/storm-gamebased-ar/abstraction/ExplicitQualitativeGameResult.h
@@ -3,7 +3,7 @@
 #include "storm-gamebased-ar/abstraction/ExplicitQualitativeResult.h"
 #include "storm/utility/graph.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 class ExplicitQualitativeGameResult : public storm::utility::graph::ExplicitGameProb01Result, public ExplicitQualitativeResult {
@@ -16,4 +16,4 @@ class ExplicitQualitativeGameResult : public storm::utility::graph::ExplicitGame
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ExplicitQualitativeGameResultMinMax.cpp
+++ b/src/storm-gamebased-ar/abstraction/ExplicitQualitativeGameResultMinMax.cpp
@@ -1,6 +1,6 @@
 #include "storm-gamebased-ar/abstraction/ExplicitQualitativeGameResultMinMax.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 ExplicitQualitativeGameResult const& ExplicitQualitativeGameResultMinMax::getProb0(storm::OptimizationDirection const& dir) const {
@@ -35,4 +35,4 @@ ExplicitQualitativeGameResult& ExplicitQualitativeGameResultMinMax::getProb1(sto
     }
 }
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ExplicitQualitativeGameResultMinMax.h
+++ b/src/storm-gamebased-ar/abstraction/ExplicitQualitativeGameResultMinMax.h
@@ -3,7 +3,7 @@
 #include "storm-gamebased-ar/abstraction/ExplicitQualitativeGameResult.h"
 #include "storm-gamebased-ar/abstraction/ExplicitQualitativeResultMinMax.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 class ExplicitQualitativeGameResultMinMax : public ExplicitQualitativeResultMinMax {
@@ -22,4 +22,4 @@ class ExplicitQualitativeGameResultMinMax : public ExplicitQualitativeResultMinM
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ExplicitQualitativeResult.cpp
+++ b/src/storm-gamebased-ar/abstraction/ExplicitQualitativeResult.cpp
@@ -2,7 +2,7 @@
 
 #include "storm-gamebased-ar/abstraction/ExplicitQualitativeGameResult.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 ExplicitQualitativeGameResult& ExplicitQualitativeResult::asExplicitQualitativeGameResult() {
@@ -14,4 +14,4 @@ ExplicitQualitativeGameResult const& ExplicitQualitativeResult::asExplicitQualit
 }
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ExplicitQualitativeResult.h
+++ b/src/storm-gamebased-ar/abstraction/ExplicitQualitativeResult.h
@@ -8,7 +8,9 @@ namespace storm {
 namespace storage {
 class BitVector;
 }
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 
 class ExplicitQualitativeGameResult;
@@ -24,4 +26,4 @@ class ExplicitQualitativeResult : public QualitativeResult {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ExplicitQualitativeResultMinMax.cpp
+++ b/src/storm-gamebased-ar/abstraction/ExplicitQualitativeResultMinMax.cpp
@@ -1,6 +1,6 @@
 #include "storm-gamebased-ar/abstraction/ExplicitQualitativeResultMinMax.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 bool ExplicitQualitativeResultMinMax::isExplicit() const {
@@ -40,4 +40,4 @@ ExplicitQualitativeResult& ExplicitQualitativeResultMinMax::getProb1Max() {
 }
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ExplicitQualitativeResultMinMax.h
+++ b/src/storm-gamebased-ar/abstraction/ExplicitQualitativeResultMinMax.h
@@ -4,7 +4,7 @@
 
 #include "storm-gamebased-ar/abstraction/QualitativeResultMinMax.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 class ExplicitQualitativeResult;
 class ExplicitQualitativeGameResultMinMax;
@@ -31,4 +31,4 @@ class ExplicitQualitativeResultMinMax : public QualitativeResultMinMax {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ExplicitQuantitativeResult.cpp
+++ b/src/storm-gamebased-ar/abstraction/ExplicitQuantitativeResult.cpp
@@ -7,7 +7,7 @@
 #include "storm/exceptions/InvalidArgumentException.h"
 #include "storm/utility/macros.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<typename ValueType>
@@ -59,4 +59,4 @@ std::pair<ValueType, ValueType> ExplicitQuantitativeResult<ValueType>::getRange(
 template class ExplicitQuantitativeResult<double>;
 template class ExplicitQuantitativeResult<storm::RationalNumber>;
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ExplicitQuantitativeResult.h
+++ b/src/storm-gamebased-ar/abstraction/ExplicitQuantitativeResult.h
@@ -7,7 +7,9 @@ namespace storm {
 namespace storage {
 class BitVector;
 }
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 
 template<typename ValueType>
@@ -28,4 +30,4 @@ class ExplicitQuantitativeResult {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ExplicitQuantitativeResultMinMax.cpp
+++ b/src/storm-gamebased-ar/abstraction/ExplicitQuantitativeResultMinMax.cpp
@@ -2,7 +2,7 @@
 
 #include "storm/adapters/RationalNumberAdapter.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<typename ValueType>
@@ -61,4 +61,4 @@ ExplicitQuantitativeResult<ValueType>& ExplicitQuantitativeResultMinMax<ValueTyp
 template class ExplicitQuantitativeResultMinMax<double>;
 template class ExplicitQuantitativeResultMinMax<storm::RationalNumber>;
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ExplicitQuantitativeResultMinMax.h
+++ b/src/storm-gamebased-ar/abstraction/ExplicitQuantitativeResultMinMax.h
@@ -4,7 +4,7 @@
 
 #include "storm/solver/OptimizationDirection.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<typename ValueType>
@@ -29,4 +29,4 @@ class ExplicitQuantitativeResultMinMax {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ExpressionTranslator.cpp
+++ b/src/storm-gamebased-ar/abstraction/ExpressionTranslator.cpp
@@ -10,7 +10,7 @@
 #include "storm/exceptions/NotSupportedException.h"
 #include "storm/utility/macros.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 using namespace storm::expressions;
@@ -238,4 +238,4 @@ template class ExpressionTranslator<storm::dd::DdType::CUDD>;
 template class ExpressionTranslator<storm::dd::DdType::Sylvan>;
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ExpressionTranslator.h
+++ b/src/storm-gamebased-ar/abstraction/ExpressionTranslator.h
@@ -17,7 +17,9 @@ class Bdd;
 namespace expressions {
 class Expression;
 }
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType DdType>
@@ -50,4 +52,4 @@ class ExpressionTranslator : public storm::expressions::ExpressionVisitor {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/GameBddResult.cpp
+++ b/src/storm-gamebased-ar/abstraction/GameBddResult.cpp
@@ -1,7 +1,7 @@
 #include "storm-gamebased-ar/abstraction/GameBddResult.h"
 #include "storm/storage/dd/sylvan/InternalSylvanBdd.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType DdType>
@@ -19,4 +19,4 @@ template struct GameBddResult<storm::dd::DdType::CUDD>;
 template struct GameBddResult<storm::dd::DdType::Sylvan>;
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/GameBddResult.h
+++ b/src/storm-gamebased-ar/abstraction/GameBddResult.h
@@ -2,7 +2,7 @@
 
 #include "storm/storage/dd/Bdd.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType DdType>
@@ -15,4 +15,4 @@ struct GameBddResult {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/LocalExpressionInformation.cpp
+++ b/src/storm-gamebased-ar/abstraction/LocalExpressionInformation.cpp
@@ -7,7 +7,7 @@
 
 #include "storm/utility/macros.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType DdType>
@@ -235,4 +235,4 @@ template class LocalExpressionInformation<storm::dd::DdType::Sylvan>;
 template std::ostream& operator<<(std::ostream& out, LocalExpressionInformation<storm::dd::DdType::CUDD> const& partition);
 template std::ostream& operator<<(std::ostream& out, LocalExpressionInformation<storm::dd::DdType::Sylvan> const& partition);
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/LocalExpressionInformation.h
+++ b/src/storm-gamebased-ar/abstraction/LocalExpressionInformation.h
@@ -10,7 +10,7 @@
 
 #include "storm/storage/dd/DdType.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType DdType>
@@ -173,4 +173,4 @@ template<storm::dd::DdType DdType>
 std::ostream& operator<<(std::ostream& out, LocalExpressionInformation<DdType> const& partition);
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/MenuGame.cpp
+++ b/src/storm-gamebased-ar/abstraction/MenuGame.cpp
@@ -12,7 +12,7 @@
 #include "storm-config.h"
 #include "storm/adapters/RationalFunctionAdapter.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type, typename ValueType>
@@ -91,4 +91,4 @@ template class MenuGame<storm::dd::DdType::Sylvan, double>;
 template class MenuGame<storm::dd::DdType::Sylvan, storm::RationalNumber>;
 #endif
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/MenuGame.h
+++ b/src/storm-gamebased-ar/abstraction/MenuGame.h
@@ -6,7 +6,7 @@
 
 #include "storm/utility/OsDetection.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 /*!
@@ -111,4 +111,4 @@ class MenuGame : public storm::models::symbolic::StochasticTwoPlayerGame<Type, V
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/MenuGameAbstractor.cpp
+++ b/src/storm-gamebased-ar/abstraction/MenuGameAbstractor.cpp
@@ -15,7 +15,7 @@
 #include "storm-config.h"
 #include "storm/adapters/RationalFunctionAdapter.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType DdType, typename ValueType>
@@ -72,7 +72,7 @@ bool MenuGameAbstractor<DdType, ValueType>::isRestrictToRelevantStatesSet() cons
 }
 
 template<storm::dd::DdType DdType, typename ValueType>
-void MenuGameAbstractor<DdType, ValueType>::exportToDot(storm::abstraction::MenuGame<DdType, ValueType> const& currentGame, std::string const& filename,
+void MenuGameAbstractor<DdType, ValueType>::exportToDot(storm::gbar::abstraction::MenuGame<DdType, ValueType> const& currentGame, std::string const& filename,
                                                         storm::dd::Bdd<DdType> const& highlightStatesBdd, storm::dd::Bdd<DdType> const& filter) const {
     std::ofstream out;
     storm::utility::openFile(filename, out);
@@ -199,4 +199,4 @@ template class MenuGameAbstractor<storm::dd::DdType::Sylvan, double>;
 template class MenuGameAbstractor<storm::dd::DdType::Sylvan, storm::RationalNumber>;
 #endif
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/MenuGameAbstractor.h
+++ b/src/storm-gamebased-ar/abstraction/MenuGameAbstractor.h
@@ -15,7 +15,9 @@ namespace dd {
 template<storm::dd::DdType DdType>
 class Bdd;
 }
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType DdType>
@@ -92,7 +94,7 @@ class MenuGameAbstractor {
    protected:
     bool isRestrictToRelevantStatesSet() const;
 
-    void exportToDot(storm::abstraction::MenuGame<DdType, ValueType> const& currentGame, std::string const& filename,
+    void exportToDot(storm::gbar::abstraction::MenuGame<DdType, ValueType> const& currentGame, std::string const& filename,
                      storm::dd::Bdd<DdType> const& highlightStatesBdd, storm::dd::Bdd<DdType> const& filter) const;
 
    private:
@@ -103,4 +105,4 @@ class MenuGameAbstractor {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/MenuGameRefiner.cpp
+++ b/src/storm-gamebased-ar/abstraction/MenuGameRefiner.cpp
@@ -25,7 +25,7 @@
 #include "storm-config.h"
 #include "storm/adapters/RationalFunctionAdapter.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 using storm::settings::modules::AbstractionSettings;
@@ -119,7 +119,7 @@ void MenuGameRefiner<Type, ValueType>::refine(std::vector<storm::expressions::Ex
 }
 
 template<storm::dd::DdType Type, typename ValueType>
-SymbolicMostProbablePathsResult<Type, ValueType> getMostProbablePathSpanningTree(storm::abstraction::MenuGame<Type, ValueType> const& game,
+SymbolicMostProbablePathsResult<Type, ValueType> getMostProbablePathSpanningTree(storm::gbar::abstraction::MenuGame<Type, ValueType> const& game,
                                                                                  storm::dd::Bdd<Type> const& transitionFilter) {
     storm::dd::Add<Type, ValueType> maxProbabilities = game.getInitialStates().template toAdd<ValueType>();
 
@@ -160,7 +160,7 @@ SymbolicMostProbablePathsResult<Type, ValueType> getMostProbablePathSpanningTree
 
 template<storm::dd::DdType Type, typename ValueType>
 SymbolicPivotStateResult<Type, ValueType> pickPivotState(AbstractionSettings::PivotSelectionHeuristic const& heuristic,
-                                                         storm::abstraction::MenuGame<Type, ValueType> const& game,
+                                                         storm::gbar::abstraction::MenuGame<Type, ValueType> const& game,
                                                          PivotStateCandidatesResult<Type> const& pivotStateCandidateResult,
                                                          boost::optional<SymbolicQualitativeGameResultMinMax<Type>> const& qualitativeResult,
                                                          boost::optional<SymbolicQuantitativeGameResultMinMax<Type, ValueType>> const& quantitativeResult) {
@@ -436,7 +436,7 @@ RefinementPredicates MenuGameRefiner<Type, ValueType>::derivePredicatesFromDiffe
 }
 
 template<storm::dd::DdType Type, typename ValueType>
-RefinementPredicates MenuGameRefiner<Type, ValueType>::derivePredicatesFromChoice(storm::abstraction::MenuGame<Type, ValueType> const& game,
+RefinementPredicates MenuGameRefiner<Type, ValueType>::derivePredicatesFromChoice(storm::gbar::abstraction::MenuGame<Type, ValueType> const& game,
                                                                                   storm::dd::Bdd<Type> const& pivotState,
                                                                                   storm::dd::Bdd<Type> const& player1Choice, storm::dd::Bdd<Type> const& choice,
                                                                                   storm::dd::Bdd<Type> const& choiceSuccessors) const {
@@ -529,9 +529,10 @@ RefinementPredicates MenuGameRefiner<Type, ValueType>::derivePredicatesFromChoic
 }
 
 template<storm::dd::DdType Type, typename ValueType>
-PivotStateCandidatesResult<Type> computePivotStates(storm::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& transitionMatrixBdd,
-                                                    storm::dd::Bdd<Type> const& minPlayer1Strategy, storm::dd::Bdd<Type> const& minPlayer2Strategy,
-                                                    storm::dd::Bdd<Type> const& maxPlayer1Strategy, storm::dd::Bdd<Type> const& maxPlayer2Strategy) {
+PivotStateCandidatesResult<Type> computePivotStates(storm::gbar::abstraction::MenuGame<Type, ValueType> const& game,
+                                                    storm::dd::Bdd<Type> const& transitionMatrixBdd, storm::dd::Bdd<Type> const& minPlayer1Strategy,
+                                                    storm::dd::Bdd<Type> const& minPlayer2Strategy, storm::dd::Bdd<Type> const& maxPlayer1Strategy,
+                                                    storm::dd::Bdd<Type> const& maxPlayer2Strategy) {
     PivotStateCandidatesResult<Type> result;
 
     // Build the fragment of transitions that is reachable by either the min or the max strategies.
@@ -563,7 +564,7 @@ PivotStateCandidatesResult<Type> computePivotStates(storm::abstraction::MenuGame
 
 template<storm::dd::DdType Type, typename ValueType>
 RefinementPredicates MenuGameRefiner<Type, ValueType>::derivePredicatesFromPivotState(
-    storm::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& pivotState, storm::dd::Bdd<Type> const& minPlayer1Strategy,
+    storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& pivotState, storm::dd::Bdd<Type> const& minPlayer1Strategy,
     storm::dd::Bdd<Type> const& minPlayer2Strategy, storm::dd::Bdd<Type> const& maxPlayer1Strategy, storm::dd::Bdd<Type> const& maxPlayer2Strategy) const {
     // Compute the lower and the upper choice for the pivot state.
     std::set<storm::expressions::Variable> variablesToAbstract = game.getNondeterminismVariables();
@@ -632,7 +633,7 @@ RefinementPredicates MenuGameRefiner<Type, ValueType>::derivePredicatesFromPivot
 template<storm::dd::DdType Type, typename ValueType>
 std::pair<std::vector<std::vector<storm::expressions::Expression>>, std::map<storm::expressions::Variable, storm::expressions::Expression>>
 MenuGameRefiner<Type, ValueType>::buildTrace(storm::expressions::ExpressionManager& expressionManager,
-                                             storm::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& spanningTree,
+                                             storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& spanningTree,
                                              storm::dd::Bdd<Type> const& pivotState) const {
     std::vector<std::vector<storm::expressions::Expression>> predicates;
 
@@ -999,7 +1000,7 @@ boost::optional<RefinementPredicates> MenuGameRefiner<Type, ValueType>::derivePr
 
 template<storm::dd::DdType Type, typename ValueType>
 boost::optional<RefinementPredicates> MenuGameRefiner<Type, ValueType>::derivePredicatesFromInterpolation(
-    storm::abstraction::MenuGame<Type, ValueType> const& game, SymbolicPivotStateResult<Type, ValueType> const& symbolicPivotStateResult,
+    storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, SymbolicPivotStateResult<Type, ValueType> const& symbolicPivotStateResult,
     storm::dd::Bdd<Type> const& minPlayer1Strategy, storm::dd::Bdd<Type> const& minPlayer2Strategy, storm::dd::Bdd<Type> const& maxPlayer1Strategy,
     storm::dd::Bdd<Type> const& maxPlayer2Strategy) const {
     // Compute the most probable path from any initial state to the pivot state.
@@ -1030,7 +1031,8 @@ boost::optional<RefinementPredicates> MenuGameRefiner<Type, ValueType>::derivePr
 
 template<storm::dd::DdType Type, typename ValueType>
 boost::optional<RefinementPredicates> MenuGameRefiner<Type, ValueType>::derivePredicatesFromInterpolation(
-    storm::abstraction::MenuGame<Type, ValueType> const& game, ExplicitPivotStateResult<ValueType> const& pivotStateResult, storm::dd::Odd const& odd) const {
+    storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, ExplicitPivotStateResult<ValueType> const& pivotStateResult,
+    storm::dd::Odd const& odd) const {
     // Create a new expression manager that we can use for the interpolation.
     AbstractionInformation<Type> const& abstractionInformation = abstractor.get().getAbstractionInformation();
     std::shared_ptr<storm::expressions::ExpressionManager> interpolationManager = abstractionInformation.getExpressionManager().clone();
@@ -1054,7 +1056,7 @@ boost::optional<RefinementPredicates> MenuGameRefiner<Type, ValueType>::derivePr
 }
 
 template<storm::dd::DdType Type, typename ValueType>
-bool MenuGameRefiner<Type, ValueType>::refine(storm::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& transitionMatrixBdd,
+bool MenuGameRefiner<Type, ValueType>::refine(storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& transitionMatrixBdd,
                                               SymbolicQualitativeGameResultMinMax<Type> const& qualitativeResult) const {
     STORM_LOG_TRACE("Trying refinement after qualitative check.");
     // Get all relevant strategies.
@@ -1485,7 +1487,7 @@ boost::optional<RefinementPredicates> MenuGameRefiner<Type, ValueType>::derivePr
 }
 
 template<storm::dd::DdType Type, typename ValueType>
-bool MenuGameRefiner<Type, ValueType>::refine(storm::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Odd const& odd,
+bool MenuGameRefiner<Type, ValueType>::refine(storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Odd const& odd,
                                               storm::storage::SparseMatrix<ValueType> const& transitionMatrix, std::vector<uint64_t> const& player1Grouping,
                                               std::vector<uint64_t> const& player1Labeling, std::vector<uint64_t> const& player2Labeling,
                                               storm::storage::BitVector const& initialStates, storm::storage::BitVector const& constraintStates,
@@ -1574,7 +1576,7 @@ bool MenuGameRefiner<Type, ValueType>::refine(storm::abstraction::MenuGame<Type,
 }
 
 template<storm::dd::DdType Type, typename ValueType>
-bool MenuGameRefiner<Type, ValueType>::refine(storm::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Odd const& odd,
+bool MenuGameRefiner<Type, ValueType>::refine(storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Odd const& odd,
                                               storm::storage::SparseMatrix<ValueType> const& transitionMatrix, std::vector<uint64_t> const& player1Grouping,
                                               std::vector<uint64_t> const& player1Labeling, std::vector<uint64_t> const& player2Labeling,
                                               storm::storage::BitVector const& initialStates, storm::storage::BitVector const& constraintStates,
@@ -1659,7 +1661,7 @@ bool MenuGameRefiner<Type, ValueType>::refine(storm::abstraction::MenuGame<Type,
 }
 
 template<storm::dd::DdType Type, typename ValueType>
-bool MenuGameRefiner<Type, ValueType>::refine(storm::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& transitionMatrixBdd,
+bool MenuGameRefiner<Type, ValueType>::refine(storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& transitionMatrixBdd,
                                               SymbolicQuantitativeGameResultMinMax<Type, ValueType> const& quantitativeResult) const {
     STORM_LOG_TRACE("Refining after quantitative check.");
     // Get all relevant strategies.
@@ -1848,4 +1850,4 @@ template class MenuGameRefiner<storm::dd::DdType::Sylvan, storm::RationalNumber>
 #endif
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/MenuGameRefiner.h
+++ b/src/storm-gamebased-ar/abstraction/MenuGameRefiner.h
@@ -29,7 +29,9 @@ namespace storage {
 class BitVector;
 class ExplicitGameStrategyPair;
 }  // namespace storage
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type, typename ValueType>
@@ -132,7 +134,7 @@ class MenuGameRefiner {
      *
      * @param True if predicates for refinement could be derived, false otherwise.
      */
-    bool refine(storm::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& transitionMatrixBdd,
+    bool refine(storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& transitionMatrixBdd,
                 SymbolicQualitativeGameResultMinMax<Type> const& qualitativeResult) const;
 
     /*!
@@ -140,7 +142,7 @@ class MenuGameRefiner {
      *
      * @param True if predicates for refinement could be derived, false otherwise.
      */
-    bool refine(storm::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Odd const& odd,
+    bool refine(storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Odd const& odd,
                 storm::storage::SparseMatrix<ValueType> const& transitionMatrix, std::vector<uint64_t> const& player1Grouping,
                 std::vector<uint64_t> const& player1Labeling, std::vector<uint64_t> const& player2Labeling, storm::storage::BitVector const& initialStates,
                 storm::storage::BitVector const& constraintStates, storm::storage::BitVector const& targetStates,
@@ -152,7 +154,7 @@ class MenuGameRefiner {
      *
      * @param True if predicates for refinement could be derived, false otherwise.
      */
-    bool refine(storm::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Odd const& odd,
+    bool refine(storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Odd const& odd,
                 storm::storage::SparseMatrix<ValueType> const& transitionMatrix, std::vector<uint64_t> const& player1Grouping,
                 std::vector<uint64_t> const& player1Labeling, std::vector<uint64_t> const& player2Labeling, storm::storage::BitVector const& initialStates,
                 storm::storage::BitVector const& constraintStates, storm::storage::BitVector const& targetStates,
@@ -164,7 +166,7 @@ class MenuGameRefiner {
      *
      * @param True if predicates for refinement could be derived, false otherwise.
      */
-    bool refine(storm::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& transitionMatrixBdd,
+    bool refine(storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& transitionMatrixBdd,
                 SymbolicQuantitativeGameResultMinMax<Type, ValueType> const& quantitativeResult) const;
 
     /*!
@@ -175,10 +177,10 @@ class MenuGameRefiner {
    private:
     RefinementPredicates derivePredicatesFromDifferingChoices(storm::dd::Bdd<Type> const& player1Choice, storm::dd::Bdd<Type> const& lowerChoice,
                                                               storm::dd::Bdd<Type> const& upperChoice) const;
-    RefinementPredicates derivePredicatesFromChoice(storm::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& pivotState,
+    RefinementPredicates derivePredicatesFromChoice(storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& pivotState,
                                                     storm::dd::Bdd<Type> const& player1Choice, storm::dd::Bdd<Type> const& choice,
                                                     storm::dd::Bdd<Type> const& choiceSuccessors) const;
-    RefinementPredicates derivePredicatesFromPivotState(storm::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& pivotState,
+    RefinementPredicates derivePredicatesFromPivotState(storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& pivotState,
                                                         storm::dd::Bdd<Type> const& minPlayer1Strategy, storm::dd::Bdd<Type> const& minPlayer2Strategy,
                                                         storm::dd::Bdd<Type> const& maxPlayer1Strategy, storm::dd::Bdd<Type> const& maxPlayer2Strategy) const;
 
@@ -197,14 +199,14 @@ class MenuGameRefiner {
         storm::expressions::ExpressionManager& interpolationManager, std::vector<std::vector<storm::expressions::Expression>> const& trace,
         std::map<storm::expressions::Variable, storm::expressions::Expression> const& variableSubstitution) const;
 
-    boost::optional<RefinementPredicates> derivePredicatesFromInterpolation(storm::abstraction::MenuGame<Type, ValueType> const& game,
+    boost::optional<RefinementPredicates> derivePredicatesFromInterpolation(storm::gbar::abstraction::MenuGame<Type, ValueType> const& game,
                                                                             SymbolicPivotStateResult<Type, ValueType> const& symbolicPivotStateResult,
                                                                             storm::dd::Bdd<Type> const& minPlayer1Strategy,
                                                                             storm::dd::Bdd<Type> const& minPlayer2Strategy,
                                                                             storm::dd::Bdd<Type> const& maxPlayer1Strategy,
                                                                             storm::dd::Bdd<Type> const& maxPlayer2Strategy) const;
     std::pair<std::vector<std::vector<storm::expressions::Expression>>, std::map<storm::expressions::Variable, storm::expressions::Expression>> buildTrace(
-        storm::expressions::ExpressionManager& expressionManager, storm::abstraction::MenuGame<Type, ValueType> const& game,
+        storm::expressions::ExpressionManager& expressionManager, storm::gbar::abstraction::MenuGame<Type, ValueType> const& game,
         storm::dd::Bdd<Type> const& spanningTree, storm::dd::Bdd<Type> const& pivotState) const;
 
     std::pair<std::vector<uint64_t>, std::vector<uint64_t>> buildReversedLabeledPath(ExplicitPivotStateResult<ValueType> const& pivotStateResult) const;
@@ -212,7 +214,7 @@ class MenuGameRefiner {
     buildTraceFromReversedLabeledPath(storm::expressions::ExpressionManager& expressionManager, std::vector<uint64_t> const& reversedPath,
                                       std::vector<uint64_t> const& reversedLabels, storm::dd::Odd const& odd,
                                       std::vector<uint64_t> const* stateToOffset = nullptr) const;
-    boost::optional<RefinementPredicates> derivePredicatesFromInterpolation(storm::abstraction::MenuGame<Type, ValueType> const& game,
+    boost::optional<RefinementPredicates> derivePredicatesFromInterpolation(storm::gbar::abstraction::MenuGame<Type, ValueType> const& game,
                                                                             ExplicitPivotStateResult<ValueType> const& pivotStateResult,
                                                                             storm::dd::Odd const& odd) const;
 
@@ -265,4 +267,4 @@ class MenuGameRefiner {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/QualitativeResult.cpp
+++ b/src/storm-gamebased-ar/abstraction/QualitativeResult.cpp
@@ -3,7 +3,7 @@
 #include "storm-gamebased-ar/abstraction/ExplicitQualitativeResult.h"
 #include "storm-gamebased-ar/abstraction/SymbolicQualitativeResult.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 bool QualitativeResult::isSymbolic() const {
@@ -33,4 +33,4 @@ ExplicitQualitativeResult const& QualitativeResult::asExplicitQualitativeResult(
 }
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/QualitativeResult.h
+++ b/src/storm-gamebased-ar/abstraction/QualitativeResult.h
@@ -2,7 +2,7 @@
 
 #include "storm/storage/dd/DdType.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type>
@@ -27,4 +27,4 @@ class QualitativeResult {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/QualitativeResultMinMax.cpp
+++ b/src/storm-gamebased-ar/abstraction/QualitativeResultMinMax.cpp
@@ -2,7 +2,7 @@
 
 #include "storm-gamebased-ar/abstraction/SymbolicQualitativeResultMinMax.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 bool QualitativeResultMinMax::isSymbolic() const {
@@ -29,4 +29,4 @@ template SymbolicQualitativeResultMinMax<storm::dd::DdType::Sylvan> const& Quali
 template SymbolicQualitativeResultMinMax<storm::dd::DdType::Sylvan>& QualitativeResultMinMax::asSymbolicQualitativeResultMinMax();
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/QualitativeResultMinMax.h
+++ b/src/storm-gamebased-ar/abstraction/QualitativeResultMinMax.h
@@ -2,7 +2,7 @@
 
 #include "storm/storage/dd/DdType.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type>
@@ -23,4 +23,4 @@ class QualitativeResultMinMax {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/RefinementCommand.cpp
+++ b/src/storm-gamebased-ar/abstraction/RefinementCommand.cpp
@@ -1,6 +1,6 @@
 #include "storm-gamebased-ar/abstraction/RefinementCommand.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 RefinementCommand::RefinementCommand(uint64_t referencedPlayer1Choice, std::vector<storm::expressions::Expression> const& predicates)
@@ -25,4 +25,4 @@ std::vector<storm::expressions::Expression> const& RefinementCommand::getPredica
 }
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/RefinementCommand.h
+++ b/src/storm-gamebased-ar/abstraction/RefinementCommand.h
@@ -7,7 +7,7 @@
 
 #include "storm/storage/expressions/Expression.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 class RefinementCommand {
@@ -33,4 +33,4 @@ class RefinementCommand {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/StateSet.cpp
+++ b/src/storm-gamebased-ar/abstraction/StateSet.cpp
@@ -2,7 +2,7 @@
 #include "storm-gamebased-ar/abstraction/SymbolicStateSet.h"
 #include "storm/storage/dd/sylvan/InternalSylvanBdd.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 bool StateSet::isSymbolic() const {
@@ -26,4 +26,4 @@ template SymbolicStateSet<storm::dd::DdType::Sylvan> const& StateSet::asSymbolic
 template SymbolicStateSet<storm::dd::DdType::Sylvan>& StateSet::asSymbolicStateSet();
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/StateSet.h
+++ b/src/storm-gamebased-ar/abstraction/StateSet.h
@@ -2,7 +2,7 @@
 
 #include "storm/storage/dd/DdType.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type>
@@ -22,4 +22,4 @@ class StateSet {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/StateSetAbstractor.cpp
+++ b/src/storm-gamebased-ar/abstraction/StateSetAbstractor.cpp
@@ -10,7 +10,7 @@
 #include "storm-config.h"
 #include "storm/adapters/RationalFunctionAdapter.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType DdType, typename ValueType>
@@ -179,4 +179,4 @@ template class StateSetAbstractor<storm::dd::DdType::Sylvan, double>;
 template class StateSetAbstractor<storm::dd::DdType::Sylvan, storm::RationalNumber>;
 #endif
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/StateSetAbstractor.h
+++ b/src/storm-gamebased-ar/abstraction/StateSetAbstractor.h
@@ -27,7 +27,9 @@ class Bdd;
 template<storm::dd::DdType DdType, typename ValueType>
 class Add;
 }  // namespace dd
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 template<storm::dd::DdType DdType>
 class AbstractionInformation;
@@ -158,4 +160,4 @@ class StateSetAbstractor {
     storm::dd::Bdd<DdType> constraint;
 };
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicQualitativeGameResult.cpp
+++ b/src/storm-gamebased-ar/abstraction/SymbolicQualitativeGameResult.cpp
@@ -1,7 +1,7 @@
 #include "storm-gamebased-ar/abstraction/SymbolicQualitativeGameResult.h"
 #include "storm/storage/dd/sylvan/InternalSylvanBdd.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type>
@@ -18,4 +18,4 @@ storm::dd::Bdd<Type> const& SymbolicQualitativeGameResult<Type>::getStates() con
 template class SymbolicQualitativeGameResult<storm::dd::DdType::CUDD>;
 template class SymbolicQualitativeGameResult<storm::dd::DdType::Sylvan>;
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicQualitativeGameResult.h
+++ b/src/storm-gamebased-ar/abstraction/SymbolicQualitativeGameResult.h
@@ -3,7 +3,7 @@
 #include "storm-gamebased-ar/abstraction/SymbolicQualitativeResult.h"
 #include "storm/utility/graph.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type>
@@ -17,4 +17,4 @@ class SymbolicQualitativeGameResult : public storm::utility::graph::SymbolicGame
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicQualitativeGameResultMinMax.cpp
+++ b/src/storm-gamebased-ar/abstraction/SymbolicQualitativeGameResultMinMax.cpp
@@ -1,6 +1,6 @@
 #include "storm-gamebased-ar/abstraction/SymbolicQualitativeGameResultMinMax.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type>
@@ -25,4 +25,4 @@ template class SymbolicQualitativeGameResultMinMax<storm::dd::DdType::CUDD>;
 template class SymbolicQualitativeGameResultMinMax<storm::dd::DdType::Sylvan>;
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicQualitativeGameResultMinMax.h
+++ b/src/storm-gamebased-ar/abstraction/SymbolicQualitativeGameResultMinMax.h
@@ -5,7 +5,7 @@
 #include "storm-gamebased-ar/abstraction/SymbolicQualitativeGameResult.h"
 #include "storm-gamebased-ar/abstraction/SymbolicQualitativeResultMinMax.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type>
@@ -23,4 +23,4 @@ class SymbolicQualitativeGameResultMinMax : public SymbolicQualitativeResultMinM
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicQualitativeMdpResult.cpp
+++ b/src/storm-gamebased-ar/abstraction/SymbolicQualitativeMdpResult.cpp
@@ -1,7 +1,7 @@
 #include "storm-gamebased-ar/abstraction/SymbolicQualitativeMdpResult.h"
 #include "storm/storage/dd/sylvan/InternalSylvanBdd.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type>
@@ -18,4 +18,4 @@ template class SymbolicQualitativeMdpResult<storm::dd::DdType::CUDD>;
 template class SymbolicQualitativeMdpResult<storm::dd::DdType::Sylvan>;
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicQualitativeMdpResult.h
+++ b/src/storm-gamebased-ar/abstraction/SymbolicQualitativeMdpResult.h
@@ -4,7 +4,7 @@
 
 #include "storm/storage/dd/Bdd.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type>
@@ -20,4 +20,4 @@ class SymbolicQualitativeMdpResult : public SymbolicQualitativeResult<Type> {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicQualitativeMdpResultMinMax.cpp
+++ b/src/storm-gamebased-ar/abstraction/SymbolicQualitativeMdpResultMinMax.cpp
@@ -1,7 +1,7 @@
 #include "storm-gamebased-ar/abstraction/SymbolicQualitativeMdpResultMinMax.h"
 #include "storm/storage/dd/sylvan/InternalSylvanBdd.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type>
@@ -26,4 +26,4 @@ template class SymbolicQualitativeMdpResultMinMax<storm::dd::DdType::CUDD>;
 template class SymbolicQualitativeMdpResultMinMax<storm::dd::DdType::Sylvan>;
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicQualitativeMdpResultMinMax.h
+++ b/src/storm-gamebased-ar/abstraction/SymbolicQualitativeMdpResultMinMax.h
@@ -5,7 +5,7 @@
 #include "storm-gamebased-ar/abstraction/SymbolicQualitativeMdpResult.h"
 #include "storm-gamebased-ar/abstraction/SymbolicQualitativeResultMinMax.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type>
@@ -23,4 +23,4 @@ class SymbolicQualitativeMdpResultMinMax : public SymbolicQualitativeResultMinMa
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicQualitativeResult.h
+++ b/src/storm-gamebased-ar/abstraction/SymbolicQualitativeResult.h
@@ -10,7 +10,9 @@ namespace dd {
 template<storm::dd::DdType Type>
 class Bdd;
 }
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type>
@@ -22,4 +24,4 @@ class SymbolicQualitativeResult : public QualitativeResult {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicQualitativeResultMinMax.cpp
+++ b/src/storm-gamebased-ar/abstraction/SymbolicQualitativeResultMinMax.cpp
@@ -3,7 +3,7 @@
 
 #include "storm-gamebased-ar/abstraction/QualitativeResult.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type>
@@ -35,4 +35,4 @@ template class SymbolicQualitativeResultMinMax<storm::dd::DdType::CUDD>;
 template class SymbolicQualitativeResultMinMax<storm::dd::DdType::Sylvan>;
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicQualitativeResultMinMax.h
+++ b/src/storm-gamebased-ar/abstraction/SymbolicQualitativeResultMinMax.h
@@ -11,7 +11,9 @@ namespace dd {
 template<storm::dd::DdType Type>
 class Bdd;
 }
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 template<storm::dd::DdType Type>
 class SymbolicQualitativeResult;
@@ -32,4 +34,4 @@ class SymbolicQualitativeResultMinMax : public QualitativeResultMinMax {
     virtual SymbolicQualitativeResult<Type> const& getProb1(storm::OptimizationDirection const& dir) const = 0;
 };
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicQuantitativeGameResult.cpp
+++ b/src/storm-gamebased-ar/abstraction/SymbolicQuantitativeGameResult.cpp
@@ -1,7 +1,7 @@
 #include "storm-gamebased-ar/abstraction/SymbolicQuantitativeGameResult.h"
 #include "storm/storage/dd/sylvan/InternalSylvanBdd.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type, typename ValueType>
@@ -63,4 +63,4 @@ template class SymbolicQuantitativeGameResult<storm::dd::DdType::Sylvan, double>
 template class SymbolicQuantitativeGameResult<storm::dd::DdType::Sylvan, storm::RationalNumber>;
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicQuantitativeGameResult.h
+++ b/src/storm-gamebased-ar/abstraction/SymbolicQuantitativeGameResult.h
@@ -5,7 +5,7 @@
 #include "storm/storage/dd/DdType.h"
 #include "storm/storage/dd/sylvan/InternalSylvanBdd.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type, typename ValueType>
@@ -40,4 +40,4 @@ class SymbolicQuantitativeGameResult {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicQuantitativeGameResultMinMax.cpp
+++ b/src/storm-gamebased-ar/abstraction/SymbolicQuantitativeGameResultMinMax.cpp
@@ -1,7 +1,7 @@
 #include "storm-gamebased-ar/abstraction/SymbolicQuantitativeGameResultMinMax.h"
 #include "storm/storage/dd/sylvan/InternalSylvanBdd.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type, typename ValueType>
@@ -12,4 +12,4 @@ SymbolicQuantitativeGameResultMinMax<Type, ValueType>::SymbolicQuantitativeGameR
 }
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicQuantitativeGameResultMinMax.h
+++ b/src/storm-gamebased-ar/abstraction/SymbolicQuantitativeGameResultMinMax.h
@@ -2,7 +2,7 @@
 
 #include "storm-gamebased-ar/abstraction/SymbolicQuantitativeGameResult.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type, typename ValueType>
@@ -18,4 +18,4 @@ class SymbolicQuantitativeGameResultMinMax {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicStateSet.cpp
+++ b/src/storm-gamebased-ar/abstraction/SymbolicStateSet.cpp
@@ -1,7 +1,7 @@
 #include "storm-gamebased-ar/abstraction/SymbolicStateSet.h"
 #include "storm/storage/dd/sylvan/InternalSylvanBdd.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type>
@@ -23,4 +23,4 @@ template class SymbolicStateSet<storm::dd::DdType::CUDD>;
 template class SymbolicStateSet<storm::dd::DdType::Sylvan>;
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/SymbolicStateSet.h
+++ b/src/storm-gamebased-ar/abstraction/SymbolicStateSet.h
@@ -5,7 +5,7 @@
 #include "storm/storage/dd/Bdd.h"
 #include "storm/storage/dd/DdType.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType Type>
@@ -22,4 +22,4 @@ class SymbolicStateSet : public StateSet {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ValidBlockAbstractor.cpp
+++ b/src/storm-gamebased-ar/abstraction/ValidBlockAbstractor.cpp
@@ -7,7 +7,7 @@
 #include "storm/utility/Stopwatch.h"
 #include "storm/utility/solver.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType DdType>
@@ -146,4 +146,4 @@ template class ValidBlockAbstractor<storm::dd::DdType::CUDD>;
 template class ValidBlockAbstractor<storm::dd::DdType::Sylvan>;
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/ValidBlockAbstractor.h
+++ b/src/storm-gamebased-ar/abstraction/ValidBlockAbstractor.h
@@ -18,7 +18,9 @@ namespace solver {
 class SmtSolverFactory;
 }
 }  // namespace utility
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 
 template<storm::dd::DdType DdType>
@@ -88,4 +90,4 @@ class ValidBlockAbstractor {
 };
 
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/jani/AutomatonAbstractor.cpp
+++ b/src/storm-gamebased-ar/abstraction/jani/AutomatonAbstractor.cpp
@@ -17,7 +17,7 @@
 
 #include "storm/utility/macros.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 namespace jani {
 
@@ -160,4 +160,4 @@ template class AutomatonAbstractor<storm::dd::DdType::Sylvan, storm::RationalNum
 #endif
 }  // namespace jani
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/jani/AutomatonAbstractor.h
+++ b/src/storm-gamebased-ar/abstraction/jani/AutomatonAbstractor.h
@@ -15,7 +15,9 @@ namespace jani {
 // Forward-declare concrete automaton class.
 class Automaton;
 }  // namespace jani
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 template<storm::dd::DdType DdType>
 class AbstractionInformation;
@@ -151,4 +153,4 @@ class AutomatonAbstractor {
 };
 }  // namespace jani
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/jani/EdgeAbstractor.cpp
+++ b/src/storm-gamebased-ar/abstraction/jani/EdgeAbstractor.cpp
@@ -19,7 +19,7 @@
 #include "storm-config.h"
 #include "storm/adapters/RationalFunctionAdapter.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 namespace jani {
 template<storm::dd::DdType DdType, typename ValueType>
@@ -809,4 +809,4 @@ template class EdgeAbstractor<storm::dd::DdType::Sylvan, storm::RationalNumber>;
 #endif
 }  // namespace jani
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/jani/EdgeAbstractor.h
+++ b/src/storm-gamebased-ar/abstraction/jani/EdgeAbstractor.h
@@ -37,7 +37,9 @@ class Edge;
 class Assignment;
 class OrderedAssignments;
 }  // namespace jani
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 template<storm::dd::DdType DdType>
 class AbstractionInformation;
@@ -278,4 +280,4 @@ class EdgeAbstractor {
 };
 }  // namespace jani
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/jani/JaniMenuGameAbstractor.cpp
+++ b/src/storm-gamebased-ar/abstraction/jani/JaniMenuGameAbstractor.cpp
@@ -28,7 +28,7 @@
 #include "storm-config.h"
 #include "storm/adapters/RationalFunctionAdapter.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 namespace jani {
 
@@ -172,8 +172,8 @@ storm::expressions::Expression JaniMenuGameAbstractor<DdType, ValueType>::getIni
 
 template<storm::dd::DdType DdType, typename ValueType>
 storm::dd::Bdd<DdType> JaniMenuGameAbstractor<DdType, ValueType>::getStates(storm::expressions::Expression const& expression) {
-    storm::abstraction::ExpressionTranslator<DdType> translator(abstractionInformation,
-                                                                smtSolverFactory->create(abstractionInformation.getExpressionManager()));
+    storm::gbar::abstraction::ExpressionTranslator<DdType> translator(abstractionInformation,
+                                                                      smtSolverFactory->create(abstractionInformation.getExpressionManager()));
     return translator.translate(expression);
 }
 
@@ -340,4 +340,4 @@ template class JaniMenuGameAbstractor<storm::dd::DdType::Sylvan, storm::Rational
 #endif
 }  // namespace jani
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/jani/JaniMenuGameAbstractor.h
+++ b/src/storm-gamebased-ar/abstraction/jani/JaniMenuGameAbstractor.h
@@ -33,7 +33,9 @@ namespace jani {
 // Forward-declare concrete Model class.
 class Model;
 }  // namespace jani
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 namespace jani {
 
@@ -185,4 +187,4 @@ class JaniMenuGameAbstractor : public MenuGameAbstractor<DdType, ValueType> {
 };
 }  // namespace jani
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/prism/CommandAbstractor.cpp
+++ b/src/storm-gamebased-ar/abstraction/prism/CommandAbstractor.cpp
@@ -19,7 +19,7 @@
 #include "storm-config.h"
 #include "storm/adapters/RationalFunctionAdapter.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 namespace prism {
 template<storm::dd::DdType DdType, typename ValueType>
@@ -793,4 +793,4 @@ template class CommandAbstractor<storm::dd::DdType::Sylvan, storm::RationalNumbe
 #endif
 }  // namespace prism
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/prism/CommandAbstractor.h
+++ b/src/storm-gamebased-ar/abstraction/prism/CommandAbstractor.h
@@ -36,7 +36,9 @@ namespace prism {
 class Command;
 class Assignment;
 }  // namespace prism
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 template<storm::dd::DdType DdType>
 class AbstractionInformation;
@@ -275,4 +277,4 @@ class CommandAbstractor {
 };
 }  // namespace prism
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/prism/ModuleAbstractor.cpp
+++ b/src/storm-gamebased-ar/abstraction/prism/ModuleAbstractor.cpp
@@ -16,7 +16,7 @@
 
 #include "storm/utility/macros.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 namespace prism {
 
@@ -136,4 +136,4 @@ template class ModuleAbstractor<storm::dd::DdType::Sylvan, storm::RationalNumber
 #endif
 }  // namespace prism
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/prism/ModuleAbstractor.h
+++ b/src/storm-gamebased-ar/abstraction/prism/ModuleAbstractor.h
@@ -15,7 +15,9 @@ namespace prism {
 // Forward-declare concrete module class.
 class Module;
 }  // namespace prism
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 template<storm::dd::DdType DdType>
 class AbstractionInformation;
@@ -139,4 +141,4 @@ class ModuleAbstractor {
 };
 }  // namespace prism
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/prism/PrismMenuGameAbstractor.cpp
+++ b/src/storm-gamebased-ar/abstraction/prism/PrismMenuGameAbstractor.cpp
@@ -26,7 +26,7 @@
 #include "storm-config.h"
 #include "storm/adapters/RationalFunctionAdapter.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
 namespace prism {
 
@@ -165,8 +165,8 @@ storm::expressions::Expression PrismMenuGameAbstractor<DdType, ValueType>::getIn
 
 template<storm::dd::DdType DdType, typename ValueType>
 storm::dd::Bdd<DdType> PrismMenuGameAbstractor<DdType, ValueType>::getStates(storm::expressions::Expression const& expression) {
-    storm::abstraction::ExpressionTranslator<DdType> translator(abstractionInformation,
-                                                                smtSolverFactory->create(abstractionInformation.getExpressionManager()));
+    storm::gbar::abstraction::ExpressionTranslator<DdType> translator(abstractionInformation,
+                                                                      smtSolverFactory->create(abstractionInformation.getExpressionManager()));
     return translator.translate(expression);
 }
 
@@ -330,4 +330,4 @@ template class PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, storm::Rationa
 #endif
 }  // namespace prism
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/abstraction/prism/PrismMenuGameAbstractor.h
+++ b/src/storm-gamebased-ar/abstraction/prism/PrismMenuGameAbstractor.h
@@ -33,7 +33,9 @@ namespace prism {
 // Forward-declare concrete Program class.
 class Program;
 }  // namespace prism
+}  // namespace storm
 
+namespace storm::gbar {
 namespace abstraction {
 namespace prism {
 
@@ -182,4 +184,4 @@ class PrismMenuGameAbstractor : public MenuGameAbstractor<DdType, ValueType> {
 };
 }  // namespace prism
 }  // namespace abstraction
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/api/verification.h
+++ b/src/storm-gamebased-ar/api/verification.h
@@ -5,7 +5,9 @@
 #include "storm-gamebased-ar/modelchecker/abstraction/BisimulationAbstractionRefinementModelChecker.h"
 #include "storm-gamebased-ar/modelchecker/abstraction/GameBasedMdpModelChecker.h"
 
-namespace storm::api {
+namespace storm::gbar {
+namespace api {
+
 //
 // Verifying with Abstraction Refinement engine
 //
@@ -26,16 +28,16 @@ typename std::enable_if<!std::is_same<ValueType, storm::RationalFunction>::value
 verifyWithAbstractionRefinementEngine(storm::Environment const& env, storm::storage::SymbolicModelDescription const& model,
                                       storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& task,
                                       AbstractionRefinementOptions const& options = AbstractionRefinementOptions()) {
-    storm::modelchecker::GameBasedMdpModelCheckerOptions modelCheckerOptions(options.constraints, options.injectedRefinementPredicates);
+    storm::gbar::modelchecker::GameBasedMdpModelCheckerOptions modelCheckerOptions(options.constraints, options.injectedRefinementPredicates);
 
     std::unique_ptr<storm::modelchecker::CheckResult> result;
     if (model.getModelType() == storm::storage::SymbolicModelDescription::ModelType::DTMC) {
-        storm::modelchecker::GameBasedMdpModelChecker<DdType, storm::models::symbolic::Dtmc<DdType, ValueType>> modelchecker(model, modelCheckerOptions);
+        storm::gbar::modelchecker::GameBasedMdpModelChecker<DdType, storm::models::symbolic::Dtmc<DdType, ValueType>> modelchecker(model, modelCheckerOptions);
         if (modelchecker.canHandle(task)) {
             result = modelchecker.check(env, task);
         }
     } else if (model.getModelType() == storm::storage::SymbolicModelDescription::ModelType::MDP) {
-        storm::modelchecker::GameBasedMdpModelChecker<DdType, storm::models::symbolic::Mdp<DdType, ValueType>> modelchecker(model, modelCheckerOptions);
+        storm::gbar::modelchecker::GameBasedMdpModelChecker<DdType, storm::models::symbolic::Mdp<DdType, ValueType>> modelchecker(model, modelCheckerOptions);
         if (modelchecker.canHandle(task)) {
             result = modelchecker.check(env, task);
         }
@@ -69,13 +71,13 @@ typename std::enable_if<std::is_same<ValueType, double>::value, std::unique_ptr<
     std::unique_ptr<storm::modelchecker::CheckResult> result;
     model->getManager().execute([&]() {
         if (model->getType() == storm::models::ModelType::Dtmc) {
-            storm::modelchecker::BisimulationAbstractionRefinementModelChecker<storm::models::symbolic::Dtmc<DdType, ValueType>> modelchecker(
+            storm::gbar::modelchecker::BisimulationAbstractionRefinementModelChecker<storm::models::symbolic::Dtmc<DdType, ValueType>> modelchecker(
                 *model->template as<storm::models::symbolic::Dtmc<DdType, double>>());
             if (modelchecker.canHandle(task)) {
                 result = modelchecker.check(env, task);
             }
         } else if (model->getType() == storm::models::ModelType::Mdp) {
-            storm::modelchecker::BisimulationAbstractionRefinementModelChecker<storm::models::symbolic::Mdp<DdType, ValueType>> modelchecker(
+            storm::gbar::modelchecker::BisimulationAbstractionRefinementModelChecker<storm::models::symbolic::Mdp<DdType, ValueType>> modelchecker(
                 *model->template as<storm::models::symbolic::Mdp<DdType, double>>());
             if (modelchecker.canHandle(task)) {
                 result = modelchecker.check(env, task);
@@ -103,4 +105,5 @@ std::unique_ptr<storm::modelchecker::CheckResult> verifyWithAbstractionRefinemen
     return verifyWithAbstractionRefinementEngine<DdType, ValueType>(env, model, task);
 }
 
-}  // namespace storm::api
+}  // namespace api
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/modelchecker/abstraction/BisimulationAbstractionRefinementModelChecker.cpp
+++ b/src/storm-gamebased-ar/modelchecker/abstraction/BisimulationAbstractionRefinementModelChecker.cpp
@@ -15,7 +15,7 @@
 #include "storm/exceptions/NotSupportedException.h"
 #include "storm/utility/macros.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace modelchecker {
 
 template<typename ModelType>
@@ -67,7 +67,7 @@ BisimulationAbstractionRefinementModelChecker<ModelType>::getAbstractModel() {
 }
 
 template<typename ModelType>
-std::pair<std::unique_ptr<storm::abstraction::StateSet>, std::unique_ptr<storm::abstraction::StateSet>>
+std::pair<std::unique_ptr<storm::gbar::abstraction::StateSet>, std::unique_ptr<storm::gbar::abstraction::StateSet>>
 BisimulationAbstractionRefinementModelChecker<ModelType>::getConstraintAndTargetStates(storm::models::Model<ValueType> const& abstractModel) {
     STORM_LOG_ASSERT(lastAbstractModel, "Expected abstract model.");
     std::pair<storm::dd::Bdd<DdType>, storm::dd::Bdd<DdType>> ddResult;
@@ -79,9 +79,9 @@ BisimulationAbstractionRefinementModelChecker<ModelType>::getConstraintAndTarget
         ddResult = this->getConstraintAndTargetStates(*lastAbstractModel->template as<storm::models::symbolic::StochasticTwoPlayerGame<DdType, ValueType>>());
     }
 
-    std::pair<std::unique_ptr<storm::abstraction::StateSet>, std::unique_ptr<storm::abstraction::StateSet>> result;
-    result.first = std::make_unique<storm::abstraction::SymbolicStateSet<DdType>>(ddResult.first);
-    result.second = std::make_unique<storm::abstraction::SymbolicStateSet<DdType>>(ddResult.second);
+    std::pair<std::unique_ptr<storm::gbar::abstraction::StateSet>, std::unique_ptr<storm::gbar::abstraction::StateSet>> result;
+    result.first = std::make_unique<storm::gbar::abstraction::SymbolicStateSet<DdType>>(ddResult.first);
+    result.second = std::make_unique<storm::gbar::abstraction::SymbolicStateSet<DdType>>(ddResult.second);
     return result;
 }
 
@@ -94,16 +94,16 @@ BisimulationAbstractionRefinementModelChecker<ModelType>::getConstraintAndTarget
 
     auto const& checkTask = this->getCheckTask();
 
-    SymbolicPropositionalModelChecker<QuotientModelType> checker(quotient);
+    storm::modelchecker::SymbolicPropositionalModelChecker<QuotientModelType> checker(quotient);
     if (checkTask.getFormula().isUntilFormula()) {
-        std::unique_ptr<CheckResult> subresult = checker.check(checkTask.getFormula().asUntilFormula().getLeftSubformula());
+        std::unique_ptr<storm::modelchecker::CheckResult> subresult = checker.check(checkTask.getFormula().asUntilFormula().getLeftSubformula());
         result.first = subresult->asSymbolicQualitativeCheckResult<DdType>().getTruthValuesVector();
         subresult = checker.check(checkTask.getFormula().asUntilFormula().getRightSubformula());
         result.second = subresult->asSymbolicQualitativeCheckResult<DdType>().getTruthValuesVector();
     } else if (checkTask.getFormula().isEventuallyFormula()) {
         storm::logic::EventuallyFormula const& eventuallyFormula = checkTask.getFormula().asEventuallyFormula();
         result.first = quotient.getReachableStates();
-        std::unique_ptr<CheckResult> subresult = checker.check(eventuallyFormula.getSubformula());
+        std::unique_ptr<storm::modelchecker::CheckResult> subresult = checker.check(eventuallyFormula.getSubformula());
         result.second = subresult->asSymbolicQualitativeCheckResult<DdType>().getTruthValuesVector();
     } else {
         STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "The given formula is not supported by this model checker.");
@@ -136,4 +136,4 @@ template class BisimulationAbstractionRefinementModelChecker<storm::models::symb
 template class BisimulationAbstractionRefinementModelChecker<storm::models::symbolic::Mdp<storm::dd::DdType::Sylvan, double>>;
 
 }  // namespace modelchecker
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/modelchecker/abstraction/BisimulationAbstractionRefinementModelChecker.h
+++ b/src/storm-gamebased-ar/modelchecker/abstraction/BisimulationAbstractionRefinementModelChecker.h
@@ -4,17 +4,17 @@
 
 #include "storm-gamebased-ar/modelchecker/abstraction/AbstractAbstractionRefinementModelChecker.h"
 
-namespace storm {
-namespace models {
+namespace storm::models {
 template<typename ValueType>
 class Model;
 }
 
-namespace dd {
+namespace storm::dd {
 template<storm::dd::DdType DdType, typename ValueType, typename ExportValueType>
 class BisimulationDecomposition;
 }
 
+namespace storm::gbar {
 namespace modelchecker {
 
 template<typename ModelType>
@@ -35,7 +35,7 @@ class BisimulationAbstractionRefinementModelChecker : public AbstractAbstraction
     virtual std::string const& getName() const override;
     virtual void initializeAbstractionRefinement() override;
     virtual std::shared_ptr<storm::models::Model<ValueType>> getAbstractModel() override;
-    virtual std::pair<std::unique_ptr<storm::abstraction::StateSet>, std::unique_ptr<storm::abstraction::StateSet>> getConstraintAndTargetStates(
+    virtual std::pair<std::unique_ptr<storm::gbar::abstraction::StateSet>, std::unique_ptr<storm::gbar::abstraction::StateSet>> getConstraintAndTargetStates(
         storm::models::Model<ValueType> const& abstractModel) override;
     virtual uint64_t getAbstractionPlayer() const override;
     virtual bool requiresSchedulerSynthesis() const override;
@@ -58,4 +58,4 @@ class BisimulationAbstractionRefinementModelChecker : public AbstractAbstraction
 };
 
 }  // namespace modelchecker
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/modelchecker/abstraction/GameBasedMdpModelChecker.cpp
+++ b/src/storm-gamebased-ar/modelchecker/abstraction/GameBasedMdpModelChecker.cpp
@@ -51,14 +51,14 @@
 
 #include "storm/modelchecker/results/CheckResult.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace modelchecker {
 
 using detail::PreviousExplicitResult;
-using storm::abstraction::ExplicitQuantitativeResult;
-using storm::abstraction::ExplicitQuantitativeResultMinMax;
-using storm::abstraction::SymbolicQuantitativeGameResult;
-using storm::abstraction::SymbolicQuantitativeGameResultMinMax;
+using storm::gbar::abstraction::ExplicitQuantitativeResult;
+using storm::gbar::abstraction::ExplicitQuantitativeResultMinMax;
+using storm::gbar::abstraction::SymbolicQuantitativeGameResult;
+using storm::gbar::abstraction::SymbolicQuantitativeGameResultMinMax;
 using storm::storage::ExplicitGameStrategyPair;
 
 template<storm::dd::DdType Type, typename ModelType>
@@ -125,15 +125,15 @@ GameBasedMdpModelChecker<Type, ModelType>::GameBasedMdpModelChecker(storm::stora
 }
 
 template<storm::dd::DdType Type, typename ModelType>
-bool GameBasedMdpModelChecker<Type, ModelType>::canHandle(CheckTask<storm::logic::Formula, ValueType> const& checkTask) const {
+bool GameBasedMdpModelChecker<Type, ModelType>::canHandle(storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& checkTask) const {
     storm::logic::Formula const& formula = checkTask.getFormula();
     storm::logic::FragmentSpecification fragment = storm::logic::reachability();
     return formula.isInFragment(fragment) && checkTask.isOnlyInitialStatesRelevantSet();
 }
 
 template<storm::dd::DdType Type, typename ModelType>
-std::unique_ptr<CheckResult> GameBasedMdpModelChecker<Type, ModelType>::computeUntilProbabilities(
-    Environment const& env, CheckTask<storm::logic::UntilFormula, ValueType> const& checkTask) {
+std::unique_ptr<storm::modelchecker::CheckResult> GameBasedMdpModelChecker<Type, ModelType>::computeUntilProbabilities(
+    Environment const& env, storm::modelchecker::CheckTask<storm::logic::UntilFormula, ValueType> const& checkTask) {
     storm::logic::UntilFormula const& pathFormula = checkTask.getFormula();
     std::map<std::string, storm::expressions::Expression> labelToExpressionMapping;
     if (preprocessedModel.isPrismProgram()) {
@@ -157,8 +157,8 @@ std::unique_ptr<CheckResult> GameBasedMdpModelChecker<Type, ModelType>::computeU
 }
 
 template<storm::dd::DdType Type, typename ModelType>
-std::unique_ptr<CheckResult> GameBasedMdpModelChecker<Type, ModelType>::computeReachabilityProbabilities(
-    Environment const& env, CheckTask<storm::logic::EventuallyFormula, ValueType> const& checkTask) {
+std::unique_ptr<storm::modelchecker::CheckResult> GameBasedMdpModelChecker<Type, ModelType>::computeReachabilityProbabilities(
+    Environment const& env, storm::modelchecker::CheckTask<storm::logic::EventuallyFormula, ValueType> const& checkTask) {
     storm::logic::EventuallyFormula const& pathFormula = checkTask.getFormula();
     std::map<std::string, storm::expressions::Expression> labelToExpressionMapping;
     if (preprocessedModel.isPrismProgram()) {
@@ -180,10 +180,10 @@ std::unique_ptr<CheckResult> GameBasedMdpModelChecker<Type, ModelType>::computeR
 }
 
 template<storm::dd::DdType Type, typename ValueType>
-std::unique_ptr<CheckResult> checkForResultAfterQualitativeCheck(CheckTask<storm::logic::Formula, ValueType> const& checkTask,
-                                                                 storm::OptimizationDirection player2Direction, storm::dd::Bdd<Type> const& initialStates,
-                                                                 storm::dd::Bdd<Type> const& prob0, storm::dd::Bdd<Type> const& prob1) {
-    std::unique_ptr<CheckResult> result;
+std::unique_ptr<storm::modelchecker::CheckResult> checkForResultAfterQualitativeCheck(
+    storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& checkTask, storm::OptimizationDirection player2Direction,
+    storm::dd::Bdd<Type> const& initialStates, storm::dd::Bdd<Type> const& prob0, storm::dd::Bdd<Type> const& prob1) {
+    std::unique_ptr<storm::modelchecker::CheckResult> result;
 
     if (checkTask.isBoundSet()) {
         // Despite having a bound, we create a quantitative result so that the next layer can perform the comparison.
@@ -227,11 +227,11 @@ std::unique_ptr<CheckResult> checkForResultAfterQualitativeCheck(CheckTask<storm
 }
 
 template<storm::dd::DdType Type, typename ValueType>
-std::unique_ptr<CheckResult> checkForResultAfterQualitativeCheck(CheckTask<storm::logic::Formula, ValueType> const& checkTask,
-                                                                 storm::dd::Bdd<Type> const& initialStates,
-                                                                 SymbolicQualitativeGameResultMinMax<Type> const& qualitativeResult) {
+std::unique_ptr<storm::modelchecker::CheckResult> checkForResultAfterQualitativeCheck(
+    storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& checkTask, storm::dd::Bdd<Type> const& initialStates,
+    SymbolicQualitativeGameResultMinMax<Type> const& qualitativeResult) {
     // Check whether we can already give the answer based on the current information.
-    std::unique_ptr<CheckResult> result =
+    std::unique_ptr<storm::modelchecker::CheckResult> result =
         checkForResultAfterQualitativeCheck<Type, ValueType>(checkTask, storm::OptimizationDirection::Minimize, initialStates,
                                                              qualitativeResult.prob0Min.getPlayer1States(), qualitativeResult.prob1Min.getPlayer1States());
     if (result) {
@@ -246,10 +246,10 @@ std::unique_ptr<CheckResult> checkForResultAfterQualitativeCheck(CheckTask<storm
 }
 
 template<typename ValueType>
-std::unique_ptr<CheckResult> checkForResultAfterQualitativeCheck(CheckTask<storm::logic::Formula, ValueType> const& checkTask,
-                                                                 storm::OptimizationDirection player2Direction, storm::storage::BitVector const& initialStates,
-                                                                 storm::storage::BitVector const& prob0, storm::storage::BitVector const& prob1) {
-    std::unique_ptr<CheckResult> result;
+std::unique_ptr<storm::modelchecker::CheckResult> checkForResultAfterQualitativeCheck(
+    storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& checkTask, storm::OptimizationDirection player2Direction,
+    storm::storage::BitVector const& initialStates, storm::storage::BitVector const& prob0, storm::storage::BitVector const& prob1) {
+    std::unique_ptr<storm::modelchecker::CheckResult> result;
 
     if (checkTask.isBoundSet()) {
         // Despite having a bound, we create a quantitative result so that the next layer can perform the comparison.
@@ -293,11 +293,11 @@ std::unique_ptr<CheckResult> checkForResultAfterQualitativeCheck(CheckTask<storm
 }
 
 template<typename ValueType>
-std::unique_ptr<CheckResult> checkForResultAfterQualitativeCheck(CheckTask<storm::logic::Formula, ValueType> const& checkTask,
-                                                                 storm::storage::BitVector const& initialStates,
-                                                                 ExplicitQualitativeGameResultMinMax const& qualitativeResult) {
+std::unique_ptr<storm::modelchecker::CheckResult> checkForResultAfterQualitativeCheck(
+    storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& checkTask, storm::storage::BitVector const& initialStates,
+    ExplicitQualitativeGameResultMinMax const& qualitativeResult) {
     // Check whether we can already give the answer based on the current information.
-    std::unique_ptr<CheckResult> result =
+    std::unique_ptr<storm::modelchecker::CheckResult> result =
         checkForResultAfterQualitativeCheck<ValueType>(checkTask, storm::OptimizationDirection::Minimize, initialStates,
                                                        qualitativeResult.prob0Min.getPlayer1States(), qualitativeResult.prob1Min.getPlayer1States());
     if (result) {
@@ -312,10 +312,10 @@ std::unique_ptr<CheckResult> checkForResultAfterQualitativeCheck(CheckTask<storm
 }
 
 template<typename ValueType>
-std::unique_ptr<CheckResult> checkForResultAfterQuantitativeCheck(CheckTask<storm::logic::Formula, ValueType> const& checkTask,
-                                                                  storm::OptimizationDirection const& player2Direction,
-                                                                  std::pair<ValueType, ValueType> const& initialValueRange) {
-    std::unique_ptr<CheckResult> result;
+std::unique_ptr<storm::modelchecker::CheckResult> checkForResultAfterQuantitativeCheck(
+    storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& checkTask, storm::OptimizationDirection const& player2Direction,
+    std::pair<ValueType, ValueType> const& initialValueRange) {
+    std::unique_ptr<storm::modelchecker::CheckResult> result;
 
     // If the minimum value exceeds an upper threshold or the maximum value is below a lower threshold, we can
     // return the value because the property will definitely hold. Vice versa, if the minimum value exceeds an
@@ -357,9 +357,9 @@ std::unique_ptr<CheckResult> checkForResultAfterQuantitativeCheck(CheckTask<stor
 }
 
 template<typename ValueType>
-std::unique_ptr<CheckResult> checkForResultAfterQuantitativeCheck(ValueType const& minValue, ValueType const& maxValue,
-                                                                  storm::utility::ConstantsComparator<ValueType> const& comparator) {
-    std::unique_ptr<CheckResult> result;
+std::unique_ptr<storm::modelchecker::CheckResult> checkForResultAfterQuantitativeCheck(ValueType const& minValue, ValueType const& maxValue,
+                                                                                       storm::utility::ConstantsComparator<ValueType> const& comparator) {
+    std::unique_ptr<storm::modelchecker::CheckResult> result;
 
     // If the lower and upper bounds are close enough, we can return the result.
     if (comparator.isEqual(minValue, maxValue)) {
@@ -373,7 +373,7 @@ std::unique_ptr<CheckResult> checkForResultAfterQuantitativeCheck(ValueType cons
 template<storm::dd::DdType Type, typename ValueType>
 SymbolicQuantitativeGameResult<Type, ValueType> solveMaybeStates(
     Environment const& env, storm::OptimizationDirection const& player1Direction, storm::OptimizationDirection const& player2Direction,
-    storm::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& maybeStates, storm::dd::Bdd<Type> const& prob1States,
+    storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::dd::Bdd<Type> const& maybeStates, storm::dd::Bdd<Type> const& prob1States,
     boost::optional<SymbolicQuantitativeGameResult<Type, ValueType>> const& startInfo = boost::none) {
     STORM_LOG_TRACE("Performing quantative solution step. Player 1: " << player1Direction << ", player 2: " << player2Direction << ".");
 
@@ -411,7 +411,7 @@ SymbolicQuantitativeGameResult<Type, ValueType> solveMaybeStates(
 template<storm::dd::DdType Type, typename ValueType>
 SymbolicQuantitativeGameResult<Type, ValueType> computeQuantitativeResult(
     Environment const& env, storm::OptimizationDirection player1Direction, storm::OptimizationDirection player2Direction,
-    storm::abstraction::MenuGame<Type, ValueType> const& game, SymbolicQualitativeGameResultMinMax<Type> const& qualitativeResult,
+    storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, SymbolicQualitativeGameResultMinMax<Type> const& qualitativeResult,
     storm::dd::Add<Type, ValueType> const& initialStatesAdd, storm::dd::Bdd<Type> const& maybeStates,
     boost::optional<SymbolicQuantitativeGameResult<Type, ValueType>> const& startInfo = boost::none) {
     bool min = player2Direction == storm::OptimizationDirection::Minimize;
@@ -625,9 +625,9 @@ ExplicitQuantitativeResult<ValueType> computeQuantitativeResult(
 }
 
 template<storm::dd::DdType Type, typename ModelType>
-std::unique_ptr<CheckResult> GameBasedMdpModelChecker<Type, ModelType>::performGameBasedAbstractionRefinement(
-    Environment const& env, CheckTask<storm::logic::Formula, ValueType> const& checkTask, storm::expressions::Expression const& constraintExpression,
-    storm::expressions::Expression const& targetStateExpression) {
+std::unique_ptr<storm::modelchecker::CheckResult> GameBasedMdpModelChecker<Type, ModelType>::performGameBasedAbstractionRefinement(
+    Environment const& env, storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& checkTask,
+    storm::expressions::Expression const& constraintExpression, storm::expressions::Expression const& targetStateExpression) {
     STORM_LOG_THROW(checkTask.isOnlyInitialStatesRelevantSet(), storm::exceptions::InvalidPropertyException,
                     "The game-based abstraction refinement model checker can only compute the result for the initial states.");
 
@@ -642,15 +642,15 @@ std::unique_ptr<CheckResult> GameBasedMdpModelChecker<Type, ModelType>::performG
     storm::OptimizationDirection player1Direction = getPlayer1Direction(checkTask);
 
     // Create the abstractor.
-    storm::abstraction::MenuGameAbstractorOptions abstractorOptions(std::move(options.constraints));
+    storm::gbar::abstraction::MenuGameAbstractorOptions abstractorOptions(std::move(options.constraints));
     if (preprocessedModel.isPrismProgram()) {
-        abstractor = std::make_shared<storm::abstraction::prism::PrismMenuGameAbstractor<Type, ValueType>>(preprocessedModel.asPrismProgram(), smtSolverFactory,
-                                                                                                           abstractorOptions);
+        abstractor = std::make_shared<storm::gbar::abstraction::prism::PrismMenuGameAbstractor<Type, ValueType>>(preprocessedModel.asPrismProgram(),
+                                                                                                                 smtSolverFactory, abstractorOptions);
     } else {
-        abstractor = std::make_shared<storm::abstraction::jani::JaniMenuGameAbstractor<Type, ValueType>>(preprocessedModel.asJaniModel(), smtSolverFactory,
-                                                                                                         abstractorOptions);
+        abstractor = std::make_shared<storm::gbar::abstraction::jani::JaniMenuGameAbstractor<Type, ValueType>>(preprocessedModel.asJaniModel(),
+                                                                                                               smtSolverFactory, abstractorOptions);
     }
-    std::unique_ptr<CheckResult> result;
+    std::unique_ptr<storm::modelchecker::CheckResult> result;
     abstractor->getDdManager().execute([&]() {
         if (!constraintExpression.isTrue()) {
             abstractor->addTerminalStates(!constraintExpression);
@@ -659,8 +659,9 @@ std::unique_ptr<CheckResult> GameBasedMdpModelChecker<Type, ModelType>::performG
         abstractor->setTargetStates(targetStateExpression);
 
         // Create a refiner that can be used to refine the abstraction when needed.
-        storm::abstraction::MenuGameRefinerOptions refinerOptions(std::move(options.injectedRefinementPredicates));
-        storm::abstraction::MenuGameRefiner<Type, ValueType> refiner(*abstractor, smtSolverFactory->create(preprocessedModel.getManager()), refinerOptions);
+        storm::gbar::abstraction::MenuGameRefinerOptions refinerOptions(std::move(options.injectedRefinementPredicates));
+        storm::gbar::abstraction::MenuGameRefiner<Type, ValueType> refiner(*abstractor, smtSolverFactory->create(preprocessedModel.getManager()),
+                                                                           refinerOptions);
         refiner.refine(initialPredicates, false);
 
         storm::dd::Bdd<Type> globalConstraintStates = abstractor->getStates(constraintExpression);
@@ -679,7 +680,7 @@ std::unique_ptr<CheckResult> GameBasedMdpModelChecker<Type, ModelType>::performG
 
             // (1) build the abstraction.
             storm::utility::Stopwatch abstractionWatch(true);
-            storm::abstraction::MenuGame<Type, ValueType> game = abstractor->abstract();
+            storm::gbar::abstraction::MenuGame<Type, ValueType> game = abstractor->abstract();
             abstractionWatch.stop();
             totalAbstractionWatch.add(abstractionWatch);
 
@@ -742,10 +743,11 @@ std::unique_ptr<CheckResult> GameBasedMdpModelChecker<Type, ModelType>::performG
 }
 
 template<storm::dd::DdType Type, typename ModelType>
-std::unique_ptr<CheckResult> GameBasedMdpModelChecker<Type, ModelType>::performSymbolicAbstractionSolutionStep(
-    Environment const& env, CheckTask<storm::logic::Formula, ValueType> const& checkTask, storm::abstraction::MenuGame<Type, ValueType> const& game,
-    storm::OptimizationDirection player1Direction, storm::dd::Bdd<Type> const& initialStates, storm::dd::Bdd<Type> const& constraintStates,
-    storm::dd::Bdd<Type> const& targetStates, storm::abstraction::MenuGameRefiner<Type, ValueType> const& refiner,
+std::unique_ptr<storm::modelchecker::CheckResult> GameBasedMdpModelChecker<Type, ModelType>::performSymbolicAbstractionSolutionStep(
+    Environment const& env, storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& checkTask,
+    storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::OptimizationDirection player1Direction, storm::dd::Bdd<Type> const& initialStates,
+    storm::dd::Bdd<Type> const& constraintStates, storm::dd::Bdd<Type> const& targetStates,
+    storm::gbar::abstraction::MenuGameRefiner<Type, ValueType> const& refiner,
     boost::optional<SymbolicQualitativeGameResultMinMax<Type>>& previousQualitativeResult,
     boost::optional<SymbolicQuantitativeGameResult<Type, ValueType>>& previousMinQuantitativeResult) {
     STORM_LOG_TRACE("Using dd-based solving.");
@@ -757,7 +759,8 @@ std::unique_ptr<CheckResult> GameBasedMdpModelChecker<Type, ModelType>::performS
     storm::utility::Stopwatch qualitativeWatch(true);
     SymbolicQualitativeGameResultMinMax<Type> qualitativeResult =
         computeProb01States(previousQualitativeResult, game, player1Direction, transitionMatrixBdd, constraintStates, targetStates);
-    std::unique_ptr<CheckResult> result = checkForResultAfterQualitativeCheck<Type, ValueType>(checkTask, initialStates, qualitativeResult);
+    std::unique_ptr<storm::modelchecker::CheckResult> result =
+        checkForResultAfterQualitativeCheck<Type, ValueType>(checkTask, initialStates, qualitativeResult);
     if (result) {
         return result;
     }
@@ -1354,11 +1357,11 @@ void postProcessStrategies(uint64_t iteration, storm::OptimizationDirection cons
 }
 
 template<storm::dd::DdType Type, typename ModelType>
-std::unique_ptr<CheckResult> GameBasedMdpModelChecker<Type, ModelType>::performExplicitAbstractionSolutionStep(
-    Environment const& env, CheckTask<storm::logic::Formula, ValueType> const& checkTask, storm::abstraction::MenuGame<Type, ValueType> const& game,
-    storm::OptimizationDirection player1Direction, storm::dd::Bdd<Type> const& initialStatesBdd, storm::dd::Bdd<Type> const& constraintStatesBdd,
-    storm::dd::Bdd<Type> const& targetStatesBdd, storm::abstraction::MenuGameRefiner<Type, ValueType> const& refiner,
-    boost::optional<PreviousExplicitResult<ValueType>>& previousResult) {
+std::unique_ptr<storm::modelchecker::CheckResult> GameBasedMdpModelChecker<Type, ModelType>::performExplicitAbstractionSolutionStep(
+    Environment const& env, storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& checkTask,
+    storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::OptimizationDirection player1Direction,
+    storm::dd::Bdd<Type> const& initialStatesBdd, storm::dd::Bdd<Type> const& constraintStatesBdd, storm::dd::Bdd<Type> const& targetStatesBdd,
+    storm::gbar::abstraction::MenuGameRefiner<Type, ValueType> const& refiner, boost::optional<PreviousExplicitResult<ValueType>>& previousResult) {
     STORM_LOG_TRACE("Using sparse solving.");
 
     // (0) Start by transforming the necessary symbolic elements to explicit ones.
@@ -1432,7 +1435,7 @@ std::unique_ptr<CheckResult> GameBasedMdpModelChecker<Type, ModelType>::performE
     totalSolutionWatch.add(qualitativeWatch);
     STORM_LOG_INFO("Qualitative computation completed in " << qualitativeWatch.getTimeInMilliseconds() << "ms.");
 
-    std::unique_ptr<CheckResult> result = checkForResultAfterQualitativeCheck<ValueType>(checkTask, initialStates, qualitativeResult);
+    std::unique_ptr<storm::modelchecker::CheckResult> result = checkForResultAfterQualitativeCheck<ValueType>(checkTask, initialStates, qualitativeResult);
     if (result) {
         return result;
     }
@@ -1595,7 +1598,8 @@ std::vector<storm::expressions::Expression> GameBasedMdpModelChecker<Type, Model
 }
 
 template<storm::dd::DdType Type, typename ModelType>
-storm::OptimizationDirection GameBasedMdpModelChecker<Type, ModelType>::getPlayer1Direction(CheckTask<storm::logic::Formula, ValueType> const& checkTask) {
+storm::OptimizationDirection GameBasedMdpModelChecker<Type, ModelType>::getPlayer1Direction(
+    storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& checkTask) {
     if (preprocessedModel.getModelType() == storm::storage::SymbolicModelDescription::ModelType::DTMC) {
         return storm::OptimizationDirection::Maximize;
     } else if (checkTask.isOptimizationDirectionSet()) {
@@ -1669,9 +1673,9 @@ ExplicitQualitativeGameResultMinMax GameBasedMdpModelChecker<Type, ModelType>::c
 
 template<storm::dd::DdType Type, typename ModelType>
 SymbolicQualitativeGameResultMinMax<Type> GameBasedMdpModelChecker<Type, ModelType>::computeProb01States(
-    boost::optional<SymbolicQualitativeGameResultMinMax<Type>> const& previousQualitativeResult, storm::abstraction::MenuGame<Type, ValueType> const& game,
-    storm::OptimizationDirection player1Direction, storm::dd::Bdd<Type> const& transitionMatrixBdd, storm::dd::Bdd<Type> const& constraintStates,
-    storm::dd::Bdd<Type> const& targetStates) {
+    boost::optional<SymbolicQualitativeGameResultMinMax<Type>> const& previousQualitativeResult,
+    storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::OptimizationDirection player1Direction,
+    storm::dd::Bdd<Type> const& transitionMatrixBdd, storm::dd::Bdd<Type> const& constraintStates, storm::dd::Bdd<Type> const& targetStates) {
     SymbolicQualitativeGameResultMinMax<Type> result;
 
     if (reuseQualitativeResults) {
@@ -1756,11 +1760,11 @@ SymbolicQualitativeGameResultMinMax<Type> GameBasedMdpModelChecker<Type, ModelTy
 }
 
 template<storm::dd::DdType Type, typename ModelType>
-void GameBasedMdpModelChecker<Type, ModelType>::printStatistics(storm::abstraction::MenuGameAbstractor<Type, ValueType> const& abstractor,
-                                                                storm::abstraction::MenuGame<Type, ValueType> const& game, uint64_t refinements,
+void GameBasedMdpModelChecker<Type, ModelType>::printStatistics(storm::gbar::abstraction::MenuGameAbstractor<Type, ValueType> const& abstractor,
+                                                                storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, uint64_t refinements,
                                                                 uint64_t peakPlayer1States, uint64_t peakTransitions) const {
     if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-        storm::abstraction::AbstractionInformation<Type> const& abstractionInformation = abstractor.getAbstractionInformation();
+        storm::gbar::abstraction::AbstractionInformation<Type> const& abstractionInformation = abstractor.getAbstractionInformation();
 
         std::streamsize originalPrecision = std::cout.precision();
         std::cout << std::fixed << std::setprecision(2);
@@ -1827,4 +1831,4 @@ template class GameBasedMdpModelChecker<storm::dd::DdType::Sylvan, storm::models
 template class GameBasedMdpModelChecker<storm::dd::DdType::Sylvan, storm::models::symbolic::Dtmc<storm::dd::DdType::Sylvan, storm::RationalNumber>>;
 template class GameBasedMdpModelChecker<storm::dd::DdType::Sylvan, storm::models::symbolic::Mdp<storm::dd::DdType::Sylvan, storm::RationalNumber>>;
 }  // namespace modelchecker
-}  // namespace storm
+}  // namespace storm::gbar

--- a/src/storm-gamebased-ar/modelchecker/abstraction/GameBasedMdpModelChecker.h
+++ b/src/storm-gamebased-ar/modelchecker/abstraction/GameBasedMdpModelChecker.h
@@ -28,8 +28,9 @@
 #include "storm/utility/graph.h"
 #include "storm/utility/solver.h"
 
-namespace storm {
+namespace storm::gbar {
 namespace abstraction {
+
 template<storm::dd::DdType Type, typename ValueType>
 class MenuGame;
 
@@ -57,12 +58,12 @@ class ExplicitGameStrategyPair;
 
 namespace modelchecker {
 
-using storm::abstraction::ExplicitQualitativeGameResult;
-using storm::abstraction::ExplicitQualitativeGameResultMinMax;
-using storm::abstraction::ExplicitQuantitativeResult;
-using storm::abstraction::ExplicitQuantitativeResultMinMax;
-using storm::abstraction::SymbolicQualitativeGameResult;
-using storm::abstraction::SymbolicQualitativeGameResultMinMax;
+using storm::gbar::abstraction::ExplicitQualitativeGameResult;
+using storm::gbar::abstraction::ExplicitQualitativeGameResultMinMax;
+using storm::gbar::abstraction::ExplicitQuantitativeResult;
+using storm::gbar::abstraction::ExplicitQuantitativeResultMinMax;
+using storm::gbar::abstraction::SymbolicQualitativeGameResult;
+using storm::gbar::abstraction::SymbolicQualitativeGameResultMinMax;
 
 namespace detail {
 template<typename ValueType>
@@ -90,7 +91,7 @@ struct GameBasedMdpModelCheckerOptions {
 };
 
 template<storm::dd::DdType Type, typename ModelType>
-class GameBasedMdpModelChecker : public AbstractModelChecker<ModelType> {
+class GameBasedMdpModelChecker : public storm::modelchecker::AbstractModelChecker<ModelType> {
    public:
     typedef typename ModelType::ValueType ValueType;
 
@@ -108,33 +109,32 @@ class GameBasedMdpModelChecker : public AbstractModelChecker<ModelType> {
                                           std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>());
 
     /// Overridden methods from super class.
-    virtual bool canHandle(CheckTask<storm::logic::Formula, ValueType> const& checkTask) const override;
-    virtual std::unique_ptr<CheckResult> computeUntilProbabilities(Environment const& env,
-                                                                   CheckTask<storm::logic::UntilFormula, ValueType> const& checkTask) override;
-    virtual std::unique_ptr<CheckResult> computeReachabilityProbabilities(Environment const& env,
-                                                                          CheckTask<storm::logic::EventuallyFormula, ValueType> const& checkTask) override;
+    virtual bool canHandle(storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& checkTask) const override;
+    virtual std::unique_ptr<storm::modelchecker::CheckResult> computeUntilProbabilities(
+        Environment const& env, storm::modelchecker::CheckTask<storm::logic::UntilFormula, ValueType> const& checkTask) override;
+    virtual std::unique_ptr<storm::modelchecker::CheckResult> computeReachabilityProbabilities(
+        Environment const& env, storm::modelchecker::CheckTask<storm::logic::EventuallyFormula, ValueType> const& checkTask) override;
 
    private:
     /*!
      * Performs the core part of the abstraction-refinement loop.
      */
-    std::unique_ptr<CheckResult> performGameBasedAbstractionRefinement(Environment const& env, CheckTask<storm::logic::Formula, ValueType> const& checkTask,
-                                                                       storm::expressions::Expression const& constraintExpression,
-                                                                       storm::expressions::Expression const& targetStateExpression);
+    std::unique_ptr<storm::modelchecker::CheckResult> performGameBasedAbstractionRefinement(
+        Environment const& env, storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& checkTask,
+        storm::expressions::Expression const& constraintExpression, storm::expressions::Expression const& targetStateExpression);
 
-    std::unique_ptr<CheckResult> performSymbolicAbstractionSolutionStep(
-        Environment const& env, CheckTask<storm::logic::Formula, ValueType> const& checkTask, storm::abstraction::MenuGame<Type, ValueType> const& game,
-        storm::OptimizationDirection player1Direction, storm::dd::Bdd<Type> const& initialStates, storm::dd::Bdd<Type> const& constraintStates,
-        storm::dd::Bdd<Type> const& targetStates, storm::abstraction::MenuGameRefiner<Type, ValueType> const& refiner,
+    std::unique_ptr<storm::modelchecker::CheckResult> performSymbolicAbstractionSolutionStep(
+        Environment const& env, storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& checkTask,
+        storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::OptimizationDirection player1Direction,
+        storm::dd::Bdd<Type> const& initialStates, storm::dd::Bdd<Type> const& constraintStates, storm::dd::Bdd<Type> const& targetStates,
+        storm::gbar::abstraction::MenuGameRefiner<Type, ValueType> const& refiner,
         boost::optional<SymbolicQualitativeGameResultMinMax<Type>>& previousQualitativeResult,
         boost::optional<abstraction::SymbolicQuantitativeGameResult<Type, ValueType>>& previousMinQuantitativeResult);
-    std::unique_ptr<CheckResult> performExplicitAbstractionSolutionStep(Environment const& env, CheckTask<storm::logic::Formula, ValueType> const& checkTask,
-                                                                        storm::abstraction::MenuGame<Type, ValueType> const& game,
-                                                                        storm::OptimizationDirection player1Direction,
-                                                                        storm::dd::Bdd<Type> const& initialStates, storm::dd::Bdd<Type> const& constraintStates,
-                                                                        storm::dd::Bdd<Type> const& targetStates,
-                                                                        storm::abstraction::MenuGameRefiner<Type, ValueType> const& refiner,
-                                                                        boost::optional<detail::PreviousExplicitResult<ValueType>>& previousResult);
+    std::unique_ptr<storm::modelchecker::CheckResult> performExplicitAbstractionSolutionStep(
+        Environment const& env, storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& checkTask,
+        storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, storm::OptimizationDirection player1Direction,
+        storm::dd::Bdd<Type> const& initialStates, storm::dd::Bdd<Type> const& constraintStates, storm::dd::Bdd<Type> const& targetStates,
+        storm::gbar::abstraction::MenuGameRefiner<Type, ValueType> const& refiner, boost::optional<detail::PreviousExplicitResult<ValueType>>& previousResult);
 
     /*!
      * Retrieves the initial predicates for the abstraction.
@@ -145,14 +145,14 @@ class GameBasedMdpModelChecker : public AbstractModelChecker<ModelType> {
     /*!
      * Derives the optimization direction of player 1.
      */
-    storm::OptimizationDirection getPlayer1Direction(CheckTask<storm::logic::Formula, ValueType> const& checkTask);
+    storm::OptimizationDirection getPlayer1Direction(storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& checkTask);
 
     /*!
      * Performs a qualitative check on the the given game to compute the (player 1) states that have probability
      * 0 or 1, respectively, to reach a target state and only visiting constraint states before.
      */
     SymbolicQualitativeGameResultMinMax<Type> computeProb01States(boost::optional<SymbolicQualitativeGameResultMinMax<Type>> const& previousQualitativeResult,
-                                                                  storm::abstraction::MenuGame<Type, ValueType> const& game,
+                                                                  storm::gbar::abstraction::MenuGame<Type, ValueType> const& game,
                                                                   storm::OptimizationDirection player1Direction,
                                                                   storm::dd::Bdd<Type> const& transitionMatrixBdd, storm::dd::Bdd<Type> const& constraintStates,
                                                                   storm::dd::Bdd<Type> const& targetStates);
@@ -164,8 +164,9 @@ class GameBasedMdpModelChecker : public AbstractModelChecker<ModelType> {
         std::vector<uint64_t> const& player2BackwardTransitions, storm::storage::BitVector const& constraintStates,
         storm::storage::BitVector const& targetStates, storage::ExplicitGameStrategyPair& minStrategyPair, storage::ExplicitGameStrategyPair& maxStrategyPair);
 
-    void printStatistics(storm::abstraction::MenuGameAbstractor<Type, ValueType> const& abstractor, storm::abstraction::MenuGame<Type, ValueType> const& game,
-                         uint64_t refinements, uint64_t peakPlayer1States, uint64_t peakTransitions) const;
+    void printStatistics(storm::gbar::abstraction::MenuGameAbstractor<Type, ValueType> const& abstractor,
+                         storm::gbar::abstraction::MenuGame<Type, ValueType> const& game, uint64_t refinements, uint64_t peakPlayer1States,
+                         uint64_t peakTransitions) const;
 
     /*
      * Retrieves the expression characterized by the formula. The formula needs to be propositional.
@@ -198,7 +199,7 @@ class GameBasedMdpModelChecker : public AbstractModelChecker<ModelType> {
     storm::settings::modules::AbstractionSettings::SolveMode solveMode;
 
     /// The currently used abstractor.
-    std::shared_ptr<storm::abstraction::MenuGameAbstractor<Type, ValueType>> abstractor;
+    std::shared_ptr<storm::gbar::abstraction::MenuGameAbstractor<Type, ValueType>> abstractor;
 
     /// The performed number of refinement iterations.
     uint64_t iteration;
@@ -222,6 +223,6 @@ class GameBasedMdpModelChecker : public AbstractModelChecker<ModelType> {
     storm::utility::Stopwatch totalWatch;
 };
 }  // namespace modelchecker
-}  // namespace storm
+}  // namespace storm::gbar
 
 #endif /* STORM_MODELCHECKER_GAMEBASEDMDPMODELCHECKER_H_ */

--- a/src/test/storm-gamebased-ar/abstraction/GraphTest.cpp
+++ b/src/test/storm-gamebased-ar/abstraction/GraphTest.cpp
@@ -34,11 +34,11 @@ TEST(GraphTestAR, SymbolicProb01StochasticGameDieSmall) {
     initialPredicates.push_back(manager.getVariableExpression("s") < manager.integer(3));
 
     auto smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     // The target states are those states where !(s < 3).
     storm::dd::Bdd<storm::dd::DdType::CUDD> targetStates = !abstractor.getStates(initialPredicates[0]) && game.getReachableStates();
@@ -194,11 +194,11 @@ TEST(GraphTestAR, SymbolicProb01StochasticGameTwoDice) {
     initialPredicates.push_back(manager.getVariableExpression("d2") == manager.integer(6));
 
     auto smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     // The target states are those states where s1 == 7 & s2 == 7 & d1 + d2 == 2.
     storm::dd::Bdd<storm::dd::DdType::CUDD> targetStates = abstractor.getStates(initialPredicates[7]) && abstractor.getStates(initialPredicates[22]) &&
@@ -381,11 +381,11 @@ TEST(GraphTestAR, SymbolicProb01StochasticGameWlan) {
     initialPredicates.push_back(manager.getVariableExpression("bc2") == manager.integer(1));
 
     auto smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     // The target states are those states where col == 2.
     storm::dd::Bdd<storm::dd::DdType::CUDD> targetStates = abstractor.getStates(initialPredicates[2]) && game.getReachableStates();

--- a/src/test/storm-gamebased-ar/abstraction/PrismMenuGameTest.cpp
+++ b/src/test/storm-gamebased-ar/abstraction/PrismMenuGameTest.cpp
@@ -35,11 +35,11 @@ TEST(PrismMenuGame, DieAbstractionTest_Cudd) {
     initialPredicates.push_back(manager.getVariableExpression("s") < manager.integer(3));
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     EXPECT_EQ(26ull, game.getNumberOfTransitions());
     EXPECT_EQ(4ull, game.getNumberOfStates());
@@ -62,11 +62,11 @@ TEST(PrismMenuGame, DieAbstractionTest_Sylvan) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
 
     EXPECT_EQ(26ull, game.getNumberOfTransitions());
     EXPECT_EQ(4ull, game.getNumberOfStates());
@@ -88,11 +88,11 @@ TEST(PrismMenuGame, DieAbstractionTest_Sylvan) {
 
 //    std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-//    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, storm::RationalFunction> abstractor(program, smtSolverFactory);
-//    storm::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, storm::RationalFunction> refiner(abstractor, smtSolverFactory->create(manager));
+//    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, storm::RationalFunction> abstractor(program, smtSolverFactory);
+//    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, storm::RationalFunction> refiner(abstractor, smtSolverFactory->create(manager));
 //    refiner.refine(initialPredicates);
 
-//    storm::abstraction::MenuGame<storm::dd::DdType::Sylvan, storm::RationalFunction> game = abstractor.abstract();
+//    storm::gbar::abstraction::MenuGame<storm::dd::DdType::Sylvan, storm::RationalFunction> game = abstractor.abstract();
 
 //    EXPECT_EQ(26, game.getNumberOfTransitions());
 //    EXPECT_EQ(4, game.getNumberOfStates());
@@ -114,13 +114,13 @@ TEST(PrismMenuGame, DieAbstractionAndRefinementTest_Cudd) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
     ASSERT_NO_THROW(refiner.refine({manager.getVariableExpression("s") == manager.integer(7)}));
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     EXPECT_EQ(24ull, game.getNumberOfTransitions());
     EXPECT_EQ(5ull, game.getNumberOfStates());
@@ -143,13 +143,13 @@ TEST(PrismMenuGame, DieAbstractionAndRefinementTest_Sylvan) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
     ASSERT_NO_THROW(refiner.refine({manager.getVariableExpression("s") == manager.integer(7)}));
 
-    storm::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
 
     EXPECT_EQ(24ull, game.getNumberOfTransitions());
     EXPECT_EQ(5ull, game.getNumberOfStates());
@@ -187,11 +187,11 @@ TEST(PrismMenuGame, DieFullAbstractionTest_Cudd) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     EXPECT_EQ(20ull, game.getNumberOfTransitions());
     EXPECT_EQ(13ull, game.getNumberOfStates());
@@ -229,11 +229,11 @@ TEST(PrismMenuGame, DieFullAbstractionTest_Sylvan) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
 
     EXPECT_EQ(20ull, game.getNumberOfTransitions());
     EXPECT_EQ(13ull, game.getNumberOfStates());
@@ -257,11 +257,11 @@ TEST(PrismMenuGame, CrowdsAbstractionTest_Cudd) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     EXPECT_EQ(31ull, game.getNumberOfTransitions());
     EXPECT_EQ(4ull, game.getNumberOfStates());
@@ -285,11 +285,11 @@ TEST(PrismMenuGame, CrowdsAbstractionTest_Sylvan) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
 
     EXPECT_EQ(31ull, game.getNumberOfTransitions());
     EXPECT_EQ(4ull, game.getNumberOfStates());
@@ -313,8 +313,8 @@ TEST(PrismMenuGame, CrowdsAbstractionAndRefinementTest_Cudd) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
     ASSERT_NO_THROW(
@@ -322,7 +322,7 @@ TEST(PrismMenuGame, CrowdsAbstractionAndRefinementTest_Cudd) {
                             manager.getVariableExpression("observe3") + manager.getVariableExpression("observe4") <=
                         manager.getVariableExpression("runCount")}));
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     EXPECT_EQ(68ull, game.getNumberOfTransitions());
     EXPECT_EQ(8ull, game.getNumberOfStates());
@@ -346,8 +346,8 @@ TEST(PrismMenuGame, CrowdsAbstractionAndRefinementTest_Sylvan) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
     ASSERT_NO_THROW(
@@ -355,7 +355,7 @@ TEST(PrismMenuGame, CrowdsAbstractionAndRefinementTest_Sylvan) {
                             manager.getVariableExpression("observe3") + manager.getVariableExpression("observe4") <=
                         manager.getVariableExpression("runCount")}));
 
-    storm::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
 
     EXPECT_EQ(68ull, game.getNumberOfTransitions());
     EXPECT_EQ(8ull, game.getNumberOfStates());
@@ -433,11 +433,11 @@ TEST(PrismMenuGame, CrowdsFullAbstractionTest_Cudd) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     EXPECT_EQ(15113ull, game.getNumberOfTransitions());
     EXPECT_EQ(8607ull, game.getNumberOfStates());
@@ -515,11 +515,11 @@ TEST(PrismMenuGame, CrowdsFullAbstractionTest_Sylvan) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
 
     EXPECT_EQ(15113ull, game.getNumberOfTransitions());
     EXPECT_EQ(8607ull, game.getNumberOfStates());
@@ -545,11 +545,11 @@ TEST(PrismMenuGame, TwoDiceAbstractionTest_Cudd) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     EXPECT_EQ(90ull, game.getNumberOfTransitions());
     EXPECT_EQ(8ull, game.getNumberOfStates());
@@ -575,11 +575,11 @@ TEST(PrismMenuGame, TwoDiceAbstractionTest_Sylvan) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
 
     EXPECT_EQ(90ull, game.getNumberOfTransitions());
     EXPECT_EQ(8ull, game.getNumberOfStates());
@@ -605,13 +605,13 @@ TEST(PrismMenuGame, TwoDiceAbstractionAndRefinementTest_Cudd) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
     ASSERT_NO_THROW(refiner.refine({manager.getVariableExpression("d1") + manager.getVariableExpression("d2") == manager.integer(7)}));
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     EXPECT_EQ(276ull, game.getNumberOfTransitions());
     EXPECT_EQ(16ull, game.getNumberOfStates());
@@ -637,13 +637,13 @@ TEST(PrismMenuGame, TwoDiceAbstractionAndRefinementTest_Sylvan) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
     ASSERT_NO_THROW(refiner.refine({manager.getVariableExpression("d1") + manager.getVariableExpression("d2") == manager.integer(7)}));
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     EXPECT_EQ(276ull, game.getNumberOfTransitions());
     EXPECT_EQ(16ull, game.getNumberOfStates());
@@ -700,11 +700,11 @@ TEST(PrismMenuGame, TwoDiceFullAbstractionTest_Cudd) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     EXPECT_EQ(436ull, game.getNumberOfTransitions());
     EXPECT_EQ(169ull, game.getNumberOfStates());
@@ -761,11 +761,11 @@ TEST(PrismMenuGame, TwoDiceFullAbstractionTest_Sylvan) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
 
     EXPECT_EQ(436ull, game.getNumberOfTransitions());
     EXPECT_EQ(169ull, game.getNumberOfStates());
@@ -792,11 +792,11 @@ TEST(PrismMenuGame, WlanAbstractionTest_Cudd) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     EXPECT_EQ(903ull, game.getNumberOfTransitions());
     EXPECT_EQ(8ull, game.getNumberOfStates());
@@ -823,11 +823,11 @@ TEST(PrismMenuGame, WlanAbstractionTest_Sylvan) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
 
     EXPECT_EQ(903ull, game.getNumberOfTransitions());
     EXPECT_EQ(8ull, game.getNumberOfStates());
@@ -854,13 +854,13 @@ TEST(PrismMenuGame, WlanAbstractionAndRefinementTest_Cudd) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
     ASSERT_NO_THROW(refiner.refine({manager.getVariableExpression("backoff1") < manager.integer(7)}));
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     EXPECT_EQ(1800ull, game.getNumberOfTransitions());
     EXPECT_EQ(16ull, game.getNumberOfStates());
@@ -887,13 +887,13 @@ TEST(PrismMenuGame, WlanAbstractionAndRefinementTest_Sylvan) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
     ASSERT_NO_THROW(refiner.refine({manager.getVariableExpression("backoff1") < manager.integer(7)}));
 
-    storm::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
 
     EXPECT_EQ(1800ull, game.getNumberOfTransitions());
     EXPECT_EQ(16ull, game.getNumberOfStates());
@@ -1018,11 +1018,11 @@ TEST(PrismMenuGame, WlanFullAbstractionTest_Cudd) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::CUDD, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::CUDD, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::CUDD, double> game = abstractor.abstract();
 
     EXPECT_EQ(9503ull, game.getNumberOfTransitions());
     EXPECT_EQ(5523ull, game.getNumberOfStates());
@@ -1147,11 +1147,11 @@ TEST(PrismMenuGame, WlanFullAbstractionTest_Sylvan) {
 
     std::shared_ptr<storm::utility::solver::SmtSolverFactory> smtSolverFactory = std::make_shared<storm::utility::solver::MathsatSmtSolverFactory>();
 
-    storm::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
-    storm::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
+    storm::gbar::abstraction::prism::PrismMenuGameAbstractor<storm::dd::DdType::Sylvan, double> abstractor(program, smtSolverFactory);
+    storm::gbar::abstraction::MenuGameRefiner<storm::dd::DdType::Sylvan, double> refiner(abstractor, smtSolverFactory->create(manager));
     refiner.refine(initialPredicates);
 
-    storm::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
+    storm::gbar::abstraction::MenuGame<storm::dd::DdType::Sylvan, double> game = abstractor.abstract();
 
     EXPECT_EQ(9503ull, game.getNumberOfTransitions());
     EXPECT_EQ(5523ull, game.getNumberOfStates());

--- a/src/test/storm-gamebased-ar/modelchecker/abstraction/GameBasedDtmcModelCheckerTest.cpp
+++ b/src/test/storm-gamebased-ar/modelchecker/abstraction/GameBasedDtmcModelCheckerTest.cpp
@@ -24,7 +24,7 @@ TEST(GameBasedDtmcModelCheckerTest, DISABLED_Die_Cudd) {
 #endif
     storm::prism::Program program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/die.pm");
     auto checker =
-        std::make_shared<storm::modelchecker::GameBasedMdpModelChecker<storm::dd::DdType::CUDD, storm::models::symbolic::Dtmc<storm::dd::DdType::CUDD>>>(
+        std::make_shared<storm::gbar::modelchecker::GameBasedMdpModelChecker<storm::dd::DdType::CUDD, storm::models::symbolic::Dtmc<storm::dd::DdType::CUDD>>>(
             program);
 
     // A parser that we use for conveniently constructing the formulas.
@@ -65,9 +65,8 @@ TEST(GameBasedDtmcModelCheckerTest, DISABLED_Die_Sylvan) {
     // A parser that we use for conveniently constructing the formulas.
     storm::parser::FormulaParser formulaParser;
 
-    auto checker =
-        std::make_shared<storm::modelchecker::GameBasedMdpModelChecker<storm::dd::DdType::Sylvan, storm::models::symbolic::Dtmc<storm::dd::DdType::Sylvan>>>(
-            program);
+    auto checker = std::make_shared<
+        storm::gbar::modelchecker::GameBasedMdpModelChecker<storm::dd::DdType::Sylvan, storm::models::symbolic::Dtmc<storm::dd::DdType::Sylvan>>>(program);
 
     std::shared_ptr<storm::logic::Formula const> formula = formulaParser.parseSingleFormulaFromString("P=? [F \"one\"]");
     storm::modelchecker::CheckTask<storm::logic::Formula, double> task(*formula, true);
@@ -106,7 +105,7 @@ TEST(GameBasedDtmcModelCheckerTest, DISABLED_SynchronousLeader_Cudd) {
     storm::parser::FormulaParser formulaParser;
 
     auto checker =
-        std::make_shared<storm::modelchecker::GameBasedMdpModelChecker<storm::dd::DdType::CUDD, storm::models::symbolic::Dtmc<storm::dd::DdType::CUDD>>>(
+        std::make_shared<storm::gbar::modelchecker::GameBasedMdpModelChecker<storm::dd::DdType::CUDD, storm::models::symbolic::Dtmc<storm::dd::DdType::CUDD>>>(
             program);
 
     std::shared_ptr<storm::logic::Formula const> formula = formulaParser.parseSingleFormulaFromString("P=? [F \"elected\"]");
@@ -129,9 +128,8 @@ TEST(GameBasedDtmcModelCheckerTest, DISABLED_SynchronousLeader_Sylvan) {
     // A parser that we use for conveniently constructing the formulas.
     storm::parser::FormulaParser formulaParser;
 
-    auto checker =
-        std::make_shared<storm::modelchecker::GameBasedMdpModelChecker<storm::dd::DdType::Sylvan, storm::models::symbolic::Dtmc<storm::dd::DdType::Sylvan>>>(
-            program);
+    auto checker = std::make_shared<
+        storm::gbar::modelchecker::GameBasedMdpModelChecker<storm::dd::DdType::Sylvan, storm::models::symbolic::Dtmc<storm::dd::DdType::Sylvan>>>(program);
 
     std::shared_ptr<storm::logic::Formula const> formula = formulaParser.parseSingleFormulaFromString("P=? [F \"elected\"]");
     storm::modelchecker::CheckTask<storm::logic::Formula, double> task(*formula, true);

--- a/src/test/storm-gamebased-ar/modelchecker/abstraction/GameBasedMdpModelCheckerTest.cpp
+++ b/src/test/storm-gamebased-ar/modelchecker/abstraction/GameBasedMdpModelCheckerTest.cpp
@@ -34,7 +34,7 @@ TEST(GameBasedMdpModelCheckerTest, DISABLED_Dice_Cudd) {
 
     std::shared_ptr<storm::models::symbolic::Mdp<storm::dd::DdType::CUDD>> mdp = model->as<storm::models::symbolic::Mdp<storm::dd::DdType::CUDD>>();
     auto mdpModelchecker =
-        std::make_shared<storm::modelchecker::GameBasedMdpModelChecker<storm::dd::DdType::CUDD, storm::models::symbolic::Mdp<storm::dd::DdType::CUDD>>>(
+        std::make_shared<storm::gbar::modelchecker::GameBasedMdpModelChecker<storm::dd::DdType::CUDD, storm::models::symbolic::Mdp<storm::dd::DdType::CUDD>>>(
             program);
 
     // A parser that we use for conveniently constructing the formulas.
@@ -113,9 +113,8 @@ TEST(GameBasedMdpModelCheckerTest, DISABLED_Dice_Sylvan) {
     ASSERT_EQ(model->getNumberOfTransitions(), 436ull);
 
     std::shared_ptr<storm::models::symbolic::Mdp<storm::dd::DdType::Sylvan>> mdp = model->as<storm::models::symbolic::Mdp<storm::dd::DdType::Sylvan>>();
-    auto mdpModelchecker =
-        std::make_shared<storm::modelchecker::GameBasedMdpModelChecker<storm::dd::DdType::Sylvan, storm::models::symbolic::Mdp<storm::dd::DdType::Sylvan>>>(
-            program);
+    auto mdpModelchecker = std::make_shared<
+        storm::gbar::modelchecker::GameBasedMdpModelChecker<storm::dd::DdType::Sylvan, storm::models::symbolic::Mdp<storm::dd::DdType::Sylvan>>>(program);
 
     // A parser that we use for conveniently constructing the formulas.
     storm::parser::FormulaParser formulaParser;


### PR DESCRIPTION
Introduces namespace `storm::gbar` for the gamebased abstraction.
Resolves https://github.com/moves-rwth/storm/issues/438