### PR TITLE
remove one more header include of JsonAdapter

### DIFF
--- a/src/storm/adapters/JsonAdapter.h
+++ b/src/storm/adapters/JsonAdapter.h
@@ -3,24 +3,3 @@
 // Modernjson JSON parser
 #include "nlohmann/json.hpp"
 #include "storm/adapters/JsonForward.h"
-
-namespace storm {
-
-/*!
- * @pre j.is_number_float() must be true
- * @param j json object, must be of float type
- * @return true iff
- */
-template<typename ValueType>
-bool isJsonNumberExportAccurate(storm::json<ValueType> const& j);
-
-/*!
- * Dumps the given json object, producing a String.
- * If the ValueType is exact, a warning is printed if one or more number values can not be exported (dumped) with full accuracy (e.g. there is no float for 1/3)
- * @param j The JSON object
- * @param compact indicates whether the export should be done in compact mode (no unnecessary whitespace)
- */
-template<typename ValueType>
-std::string dumpJson(storm::json<ValueType> const& j, bool compact = false);
-
-}  // namespace storm

--- a/src/storm/adapters/JsonForward.h
+++ b/src/storm/adapters/JsonForward.h
@@ -8,4 +8,22 @@ namespace storm {
 
 template<typename ValueType>
 using json = nlohmann::basic_json<std::map, std::vector, std::string, bool, int64_t, uint64_t, ValueType>;
-}
+
+/*!
+ * @pre j.is_number_float() must be true
+ * @param j json object, must be of float type
+ * @return true iff
+ */
+template<typename ValueType>
+bool isJsonNumberExportAccurate(storm::json<ValueType> const& j);
+
+/*!
+ * Dumps the given json object, producing a String.
+ * If the ValueType is exact, a warning is printed if one or more number values can not be exported (dumped) with full accuracy (e.g. there is no float for 1/3)
+ * @param j The JSON object
+ * @param compact indicates whether the export should be done in compact mode (no unnecessary whitespace)
+ */
+template<typename ValueType>
+std::string dumpJson(storm::json<ValueType> const& j, bool compact = false);
+
+}  // namespace storm

--- a/src/storm/api/export.h
+++ b/src/storm/api/export.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "storm/adapters/JsonAdapter.h"
+#include "storm/adapters/JsonForward.h"
 #include "storm/exceptions/NotSupportedException.h"
 #include "storm/io/DDEncodingExporter.h"
 #include "storm/io/DirectEncodingExporter.h"


### PR DESCRIPTION
Three occurrences of the json adapter in a header remain (notice that this is bad for compile times). 