### PR TITLE
Revised LP Encoding for Multi-objective verification under simple strategies 

### DIFF
--- a/resources/cmake/find_modules/FindGUROBI.cmake
+++ b/resources/cmake/find_modules/FindGUROBI.cmake
@@ -18,6 +18,7 @@ else (GUROBI_INCLUDE_DIR)
 find_path(GUROBI_INCLUDE_DIR 
           NAMES gurobi_c++.h
           PATHS "$ENV{GUROBI_HOME}/include"
+                    "/Library/gurobi1100/macos_universal2/include"
                     "/Library/gurobi1000/macos_universal2/include"
                     "/Library/gurobi951/macos_universal2/include"
                     "/Library/gurobi950/mac64/include"
@@ -40,6 +41,7 @@ find_path(GUROBI_INCLUDE_DIR
 
 find_library( GUROBI_LIBRARY 
               NAMES gurobi
+        gurobi110
         gurobi100
         gurobi95
         gurobi91
@@ -58,6 +60,7 @@ find_library( GUROBI_LIBRARY
         gurobi46
         gurobi45
               PATHS "$ENV{GUROBI_HOME}/lib"
+                    "/Library/gurobi1100/macos_universal2/lib"
                     "/Library/gurobi1000/macos_universal2/lib"
                     "/Library/gurobi951/macos_universal2/lib"
                     "/Library/gurobi950/mac64/lib"
@@ -81,7 +84,7 @@ find_library( GUROBI_LIBRARY
 find_library( GUROBI_CXX_LIBRARY 
               NAMES gurobi_c++
               PATHS "$ENV{GUROBI_HOME}/lib"
-                    "/Library/gurobi1000/macos_universal2/lib"
+                    "/Library/gurobi1100/macos_universal2/lib"
                     "/Library/gurobi951/macos_universal2/lib"
                     "/Library/gurobi950/mac64/lib"
                     "/Library/gurobi912/mac64/lib"

--- a/resources/examples/testfiles/mdp/multiobj_infrew.nm
+++ b/resources/examples/testfiles/mdp/multiobj_infrew.nm
@@ -1,0 +1,19 @@
+mdp
+module main
+	
+	x : [0..2];
+	[a] x=0 -> (x'=1);
+	[b] x=0 -> (x'=2);
+	[c] x=1 -> (x'=1);
+	[d] x=1 -> (x'=2);
+	[e] x=2 -> (x'=1);
+endmodule
+
+rewards "one"
+	[b] true : 10;
+	[c] true : 1;
+endrewards
+
+rewards "two"
+    [e] true : 1;
+endrewards

--- a/src/storm/environment/modelchecker/MultiObjectiveModelCheckerEnvironment.cpp
+++ b/src/storm/environment/modelchecker/MultiObjectiveModelCheckerEnvironment.cpp
@@ -33,6 +33,12 @@ MultiObjectiveModelCheckerEnvironment::MultiObjectiveModelCheckerEnvironment() {
     } else if (multiobjectiveSettings.isFlowEncodingSet()) {
         encodingType = EncodingType::Flow;
     }
+    STORM_LOG_ASSERT(multiobjectiveSettings.isBsccDetectionViaOrderConstraintsSet() || multiobjectiveSettings.isBsccDetectionViaFlowConstraintsSet(),
+                     "unexpected settings");
+    bsccOrderEncoding = multiobjectiveSettings.isBsccDetectionViaOrderConstraintsSet();
+    STORM_LOG_ASSERT(multiobjectiveSettings.isIndicatorConstraintsSet() || multiobjectiveSettings.isBigMConstraintsSet(), "unexpected settings");
+    indicatorConstraints = multiobjectiveSettings.isIndicatorConstraintsSet();
+    redundantBsccConstraints = multiobjectiveSettings.isRedundantBsccConstraintsSet();
 
     if (multiobjectiveSettings.isMaxStepsSet()) {
         maxSteps = multiobjectiveSettings.getMaxSteps();
@@ -119,6 +125,28 @@ typename MultiObjectiveModelCheckerEnvironment::EncodingType const& MultiObjecti
 
 void MultiObjectiveModelCheckerEnvironment::setEncodingType(EncodingType const& value) {
     encodingType = value;
+}
+
+bool MultiObjectiveModelCheckerEnvironment::getUseIndicatorConstraints() const {
+    return indicatorConstraints;
+}
+void MultiObjectiveModelCheckerEnvironment::setUseIndicatorConstraints(bool value) {
+    indicatorConstraints = value;
+}
+
+bool MultiObjectiveModelCheckerEnvironment::getUseBsccOrderEncoding() const {
+    return bsccOrderEncoding;
+}
+void MultiObjectiveModelCheckerEnvironment::setUseBsccOrderEncoding(bool value) {
+    bsccOrderEncoding = value;
+}
+
+bool MultiObjectiveModelCheckerEnvironment::getUseRedundantBsccConstraints() const {
+    return redundantBsccConstraints;
+}
+
+void MultiObjectiveModelCheckerEnvironment::setUseRedundantBsccConstraints(bool value) {
+    redundantBsccConstraints = value;
 }
 
 bool MultiObjectiveModelCheckerEnvironment::isMaxStepsSet() const {

--- a/src/storm/environment/modelchecker/MultiObjectiveModelCheckerEnvironment.h
+++ b/src/storm/environment/modelchecker/MultiObjectiveModelCheckerEnvironment.h
@@ -47,6 +47,15 @@ class MultiObjectiveModelCheckerEnvironment {
     EncodingType const& getEncodingType() const;
     void setEncodingType(EncodingType const& value);
 
+    bool getUseIndicatorConstraints() const;
+    void setUseIndicatorConstraints(bool value);
+
+    bool getUseBsccOrderEncoding() const;
+    void setUseBsccOrderEncoding(bool value);
+
+    bool getUseRedundantBsccConstraints() const;
+    void setUseRedundantBsccConstraints(bool value);
+
     bool isMaxStepsSet() const;
     uint64_t const& getMaxSteps() const;
     void setMaxSteps(uint64_t const& value);
@@ -69,6 +78,9 @@ class MultiObjectiveModelCheckerEnvironment {
     storm::RationalNumber precision;
     PrecisionType precisionType;
     EncodingType encodingType;
+    bool indicatorConstraints;
+    bool bsccOrderEncoding;
+    bool redundantBsccConstraints;
     boost::optional<uint64_t> maxSteps;
     boost::optional<storm::storage::SchedulerClass> schedulerRestriction;
     bool printResults;

--- a/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsAchievabilityChecker.cpp
+++ b/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsAchievabilityChecker.cpp
@@ -1,0 +1,90 @@
+#include "storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsAchievabilityChecker.h"
+
+#include "storm/environment/modelchecker/MultiObjectiveModelCheckerEnvironment.h"
+#include "storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsLpChecker.h"
+#include "storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsObjectiveHelper.h"
+#include "storm/modelchecker/multiobjective/preprocessing/SparseMultiObjectivePreprocessorResult.h"
+#include "storm/modelchecker/results/ExplicitQualitativeCheckResult.h"
+#include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
+#include "storm/models/sparse/MarkovAutomaton.h"
+#include "storm/models/sparse/Mdp.h"
+#include "storm/models/sparse/StandardRewardModel.h"
+
+namespace storm::modelchecker::multiobjective {
+
+template<class SparseModelType, typename GeometryValueType>
+DeterministicSchedsAchievabilityChecker<SparseModelType, GeometryValueType>::DeterministicSchedsAchievabilityChecker(
+    preprocessing::SparseMultiObjectivePreprocessorResult<SparseModelType>& preprocessorResult)
+    : model(preprocessorResult.preprocessedModel), originalModelInitialState(*preprocessorResult.originalModel.getInitialStates().begin()) {
+    for (auto const& obj : preprocessorResult.objectives) {
+        objectiveHelper.emplace_back(*model, obj);
+        if (!objectiveHelper.back().hasThreshold()) {
+            STORM_LOG_ASSERT(!optimizingObjectiveIndex.has_value(),
+                             "Unexpected input: got a (quantitative) achievability query but there are more than one objectives without a threshold.");
+            optimizingObjectiveIndex = objectiveHelper.size() - 1;
+        }
+    }
+    lpChecker = std::make_shared<DeterministicSchedsLpChecker<SparseModelType, GeometryValueType>>(*model, objectiveHelper);
+}
+
+template<class SparseModelType, typename GeometryValueType>
+std::unique_ptr<CheckResult> DeterministicSchedsAchievabilityChecker<SparseModelType, GeometryValueType>::check(Environment const& env) {
+    using Point = typename std::vector<GeometryValueType>;
+    uint64_t const numObj = objectiveHelper.size();
+    // Create a polytope that contains all the points that would certify achievability of the point induced by the objective threshold
+    std::vector<storm::storage::geometry::Halfspace<GeometryValueType>> thresholdHalfspaces;
+    std::vector<GeometryValueType> objVector;
+    for (uint64_t objIndex = 0; objIndex < numObj; ++objIndex) {
+        auto& obj = objectiveHelper[objIndex];
+        obj.computeLowerUpperBounds(env);
+        if (!optimizingObjectiveIndex.has_value() || *optimizingObjectiveIndex != objIndex) {
+            objVector.assign(numObj, storm::utility::zero<GeometryValueType>());
+            objVector[objIndex] = -storm::utility::one<GeometryValueType>();
+            thresholdHalfspaces.emplace_back(objVector, storm::utility::convertNumber<GeometryValueType, ModelValueType>(-obj.getThreshold()));
+        }
+    }
+    auto thresholdPolytope = storm::storage::geometry::Polytope<GeometryValueType>::create(std::move(thresholdHalfspaces));
+
+    // Set objective weights (none if this is a qualitative achievability query)
+    objVector.assign(numObj, storm::utility::zero<GeometryValueType>());
+    auto eps = objVector;
+    if (optimizingObjectiveIndex.has_value()) {
+        objVector[*optimizingObjectiveIndex] = storm::utility::one<GeometryValueType>();
+        eps[*optimizingObjectiveIndex] = env.modelchecker().multi().getPrecision() * storm::utility::convertNumber<GeometryValueType, uint64_t>(2u);
+        if (env.modelchecker().multi().getPrecisionType() == MultiObjectiveModelCheckerEnvironment::PrecisionType::RelativeToDiff) {
+            eps[*optimizingObjectiveIndex] *= storm::utility::convertNumber<GeometryValueType, ModelValueType>(
+                objectiveHelper[*optimizingObjectiveIndex].getUpperValueBoundAtState(originalModelInitialState) -
+                objectiveHelper[*optimizingObjectiveIndex].getLowerValueBoundAtState(originalModelInitialState));
+        }
+        STORM_LOG_INFO("Computing quantitative achievability value with precision " << eps[*optimizingObjectiveIndex] << ".");
+    }
+    lpChecker->setCurrentWeightVector(env, objVector);
+
+    // Search achieving point
+    auto achievingPoint = lpChecker->check(env, thresholdPolytope, eps);
+    bool const isAchievable = achievingPoint.has_value();
+    if (isAchievable) {
+        STORM_LOG_INFO(
+            "Found achievable point: " << storm::utility::vector::toString(achievingPoint->first) << " ( approx. "
+                                       << storm::utility::vector::toString(storm::utility::vector::convertNumericVector<double>(achievingPoint->first))
+                                       << " ).");
+        if (optimizingObjectiveIndex.has_value()) {
+            using ValueType = typename SparseModelType::ValueType;
+            // Average between obtained lower- and upper bounds
+            auto result =
+                storm::utility::convertNumber<ValueType, GeometryValueType>(achievingPoint->first[*optimizingObjectiveIndex] + achievingPoint->second);
+            result /= storm::utility::convertNumber<ValueType, uint64_t>(2u);
+            if (objectiveHelper[*optimizingObjectiveIndex].minimizing()) {
+                result *= -storm::utility::one<ValueType>();
+            }
+            return std::make_unique<storm::modelchecker::ExplicitQuantitativeCheckResult<ValueType>>(originalModelInitialState, result);
+        }
+    }
+    return std::make_unique<storm::modelchecker::ExplicitQualitativeCheckResult>(originalModelInitialState, isAchievable);
+}
+
+template class DeterministicSchedsAchievabilityChecker<storm::models::sparse::Mdp<double>, storm::RationalNumber>;
+template class DeterministicSchedsAchievabilityChecker<storm::models::sparse::Mdp<storm::RationalNumber>, storm::RationalNumber>;
+template class DeterministicSchedsAchievabilityChecker<storm::models::sparse::MarkovAutomaton<double>, storm::RationalNumber>;
+template class DeterministicSchedsAchievabilityChecker<storm::models::sparse::MarkovAutomaton<storm::RationalNumber>, storm::RationalNumber>;
+}  // namespace storm::modelchecker::multiobjective

--- a/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsAchievabilityChecker.h
+++ b/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsAchievabilityChecker.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace storm {
+class Environment;
+
+namespace modelchecker {
+
+class CheckResult;
+
+namespace multiobjective {
+template<typename SparseModelType, typename GeometryValueType>
+class DeterministicSchedsLpChecker;
+
+template<typename SparseModelType>
+class DeterministicSchedsObjectiveHelper;
+
+namespace preprocessing {
+template<typename SparseModelType>
+class SparseMultiObjectivePreprocessorResult;
+}
+
+template<class SparseModelType, typename GeometryValueType>
+class DeterministicSchedsAchievabilityChecker {
+   public:
+    typedef typename SparseModelType::ValueType ModelValueType;
+
+    DeterministicSchedsAchievabilityChecker(preprocessing::SparseMultiObjectivePreprocessorResult<SparseModelType>& preprocessorResult);
+
+    virtual std::unique_ptr<CheckResult> check(Environment const& env);
+
+   private:
+    std::shared_ptr<DeterministicSchedsLpChecker<SparseModelType, GeometryValueType>> lpChecker;
+    std::vector<DeterministicSchedsObjectiveHelper<SparseModelType>> objectiveHelper;
+
+    std::shared_ptr<SparseModelType> model;
+    uint64_t const originalModelInitialState;
+    std::optional<uint64_t> optimizingObjectiveIndex;
+};
+
+}  // namespace multiobjective
+}  // namespace modelchecker
+}  // namespace storm

--- a/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsObjectiveHelper.cpp
+++ b/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsObjectiveHelper.cpp
@@ -1,39 +1,36 @@
 #include "storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsObjectiveHelper.h"
 
 #include "storm/environment/solver/MinMaxSolverEnvironment.h"
-#include "storm/logic/CloneVisitor.h"
 #include "storm/logic/Formulas.h"
-#include "storm/modelchecker/csl/SparseMarkovAutomatonCslModelChecker.h"
-#include "storm/modelchecker/prctl/SparseMdpPrctlModelChecker.h"
+#include "storm/modelchecker/multiobjective/deterministicScheds/VisitingTimesHelper.h"
 #include "storm/modelchecker/prctl/helper/BaierUpperRewardBoundsComputer.h"
+#include "storm/modelchecker/prctl/helper/DsMpiUpperRewardBoundsComputer.h"
 #include "storm/modelchecker/propositional/SparsePropositionalModelChecker.h"
 #include "storm/modelchecker/results/ExplicitQualitativeCheckResult.h"
-#include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
 #include "storm/models/sparse/MarkovAutomaton.h"
 #include "storm/models/sparse/Mdp.h"
 #include "storm/models/sparse/StandardRewardModel.h"
-#include "storm/solver/GurobiLpSolver.h"
-#include "storm/solver/LpSolver.h"
-#include "storm/solver/SmtSolver.h"
+#include "storm/solver/LinearEquationSolver.h"
+#include "storm/solver/MinMaxLinearEquationSolver.h"
 #include "storm/storage/BitVector.h"
 #include "storm/storage/MaximalEndComponentDecomposition.h"
-#include "storm/storage/expressions/Expressions.h"
+#include "storm/storage/StronglyConnectedComponentDecomposition.h"
 #include "storm/transformer/EndComponentEliminator.h"
+#include "storm/utility/Extremum.h"
 #include "storm/utility/FilteredRewardModel.h"
 #include "storm/utility/graph.h"
-#include "storm/utility/solver.h"
 #include "storm/utility/vector.h"
 
+#include "storm/exceptions/UncheckedRequirementException.h"
 #include "storm/exceptions/UnexpectedException.h"
-namespace storm {
-namespace modelchecker {
-namespace multiobjective {
+
+namespace storm::modelchecker::multiobjective {
 
 template<typename ModelType>
 DeterministicSchedsObjectiveHelper<ModelType>::DeterministicSchedsObjectiveHelper(ModelType const& model,
                                                                                   storm::modelchecker::multiobjective::Objective<ValueType> const& objective)
     : model(model), objective(objective) {
-    // Intentionally left empty
+    initialize();
 }
 
 template<typename ModelType>
@@ -47,215 +44,227 @@ storm::storage::BitVector evaluatePropositionalFormula(ModelType const& model, s
 
 template<typename ValueType>
 std::vector<ValueType> getTotalRewardVector(storm::models::sparse::MarkovAutomaton<ValueType> const& model, storm::logic::Formula const& formula) {
-    boost::optional<std::string> rewardModelName = formula.asRewardOperatorFormula().getOptionalRewardModelName();
-    typename storm::models::sparse::MarkovAutomaton<ValueType>::RewardModelType const& rewardModel =
-        rewardModelName.is_initialized() ? model.getRewardModel(rewardModelName.get()) : model.getUniqueRewardModel();
+    if (formula.isRewardOperatorFormula()) {
+        boost::optional<std::string> rewardModelName = formula.asRewardOperatorFormula().getOptionalRewardModelName();
+        typename storm::models::sparse::MarkovAutomaton<ValueType>::RewardModelType const& rewardModel =
+            rewardModelName.is_initialized() ? model.getRewardModel(rewardModelName.get()) : model.getUniqueRewardModel();
 
-    // Get a reward model where the state rewards are scaled accordingly
-    std::vector<ValueType> stateRewardWeights(model.getNumberOfStates(), storm::utility::zero<ValueType>());
-    for (auto const markovianState : model.getMarkovianStates()) {
-        stateRewardWeights[markovianState] = storm::utility::one<ValueType>() / model.getExitRate(markovianState);
-    }
-    return rewardModel.getTotalActionRewardVector(model.getTransitionMatrix(), stateRewardWeights);
-}
-
-template<typename ValueType>
-std::vector<ValueType> getTotalRewardVector(storm::models::sparse::Mdp<ValueType> const& model, storm::logic::Formula const& formula) {
-    boost::optional<std::string> rewardModelName = formula.asRewardOperatorFormula().getOptionalRewardModelName();
-    typename storm::models::sparse::Mdp<ValueType>::RewardModelType const& rewardModel =
-        rewardModelName.is_initialized() ? model.getRewardModel(rewardModelName.get()) : model.getUniqueRewardModel();
-    return rewardModel.getTotalRewardVector(model.getTransitionMatrix());
-}
-
-template<typename ModelType>
-std::map<uint64_t, typename ModelType::ValueType> const& DeterministicSchedsObjectiveHelper<ModelType>::getSchedulerIndependentStateValues() const {
-    if (!schedulerIndependentStateValues) {
-        auto const& formula = *objective.formula;
-        std::map<uint64_t, ValueType> result;
-        if (formula.isProbabilityOperatorFormula() && formula.getSubformula().isUntilFormula()) {
-            storm::storage::BitVector phiStates = evaluatePropositionalFormula(model, formula.getSubformula().asUntilFormula().getLeftSubformula());
-            storm::storage::BitVector psiStates = evaluatePropositionalFormula(model, formula.getSubformula().asUntilFormula().getRightSubformula());
-            auto backwardTransitions = model.getBackwardTransitions();
-            {
-                storm::storage::BitVector prob1States = storm::utility::graph::performProb1A(
-                    model.getTransitionMatrix(), model.getNondeterministicChoiceIndices(), backwardTransitions, phiStates, psiStates);
-                for (auto prob1State : prob1States) {
-                    result[prob1State] = storm::utility::one<ValueType>();
-                }
-            }
-            {
-                storm::storage::BitVector prob0States = storm::utility::graph::performProb0A(backwardTransitions, phiStates, psiStates);
-                for (auto prob0State : prob0States) {
-                    result[prob0State] = storm::utility::zero<ValueType>();
-                }
-            }
-        } else if (formula.getSubformula().isEventuallyFormula() && (formula.isRewardOperatorFormula() || formula.isTimeOperatorFormula())) {
-            storm::storage::BitVector rew0States = evaluatePropositionalFormula(model, formula.getSubformula().asEventuallyFormula().getSubformula());
-            if (formula.isRewardOperatorFormula()) {
-                auto const& baseRewardModel = formula.asRewardOperatorFormula().hasRewardModelName()
-                                                  ? model.getRewardModel(formula.asRewardOperatorFormula().getRewardModelName())
-                                                  : model.getUniqueRewardModel();
-                auto rewardModel =
-                    storm::utility::createFilteredRewardModel(baseRewardModel, model.isDiscreteTimeModel(), formula.getSubformula().asEventuallyFormula());
-                storm::storage::BitVector statesWithoutReward = rewardModel.get().getStatesWithZeroReward(model.getTransitionMatrix());
-                rew0States = storm::utility::graph::performProb1A(model.getTransitionMatrix(), model.getNondeterministicChoiceIndices(),
-                                                                  model.getBackwardTransitions(), statesWithoutReward, rew0States);
-            }
-            for (auto rew0State : rew0States) {
-                result[rew0State] = storm::utility::zero<ValueType>();
-            }
-        } else if (formula.isRewardOperatorFormula() && formula.getSubformula().isTotalRewardFormula()) {
-            auto const& baseRewardModel = formula.asRewardOperatorFormula().hasRewardModelName()
-                                              ? model.getRewardModel(formula.asRewardOperatorFormula().getRewardModelName())
-                                              : model.getUniqueRewardModel();
-            auto rewardModel =
-                storm::utility::createFilteredRewardModel(baseRewardModel, model.isDiscreteTimeModel(), formula.getSubformula().asTotalRewardFormula());
-            storm::storage::BitVector statesWithoutReward = rewardModel.get().getStatesWithZeroReward(model.getTransitionMatrix());
-            storm::storage::BitVector rew0States =
-                storm::utility::graph::performProbGreater0E(model.getBackwardTransitions(), statesWithoutReward, ~statesWithoutReward);
-            rew0States.complement();
-            for (auto rew0State : rew0States) {
-                result[rew0State] = storm::utility::zero<ValueType>();
-            }
-        } else {
-            STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "The given formula " << formula << " is not supported.");
+        // Get a reward model where the state rewards are scaled accordingly
+        std::vector<ValueType> stateRewardWeights(model.getNumberOfStates(), storm::utility::zero<ValueType>());
+        for (auto const markovianState : model.getMarkovianStates()) {
+            stateRewardWeights[markovianState] = storm::utility::one<ValueType>() / model.getExitRate(markovianState);
         }
-        schedulerIndependentStateValues = std::move(result);
-    }
-    return schedulerIndependentStateValues.get();
-}
-
-template<typename ModelType>
-std::map<uint64_t, typename ModelType::ValueType> const& DeterministicSchedsObjectiveHelper<ModelType>::getChoiceValueOffsets() const {
-    if (!choiceValueOffsets) {
-        auto const& formula = *objective.formula;
-        auto const& subformula = formula.getSubformula();
-        std::map<uint64_t, ValueType> result;
-        if (formula.isProbabilityOperatorFormula() && subformula.isUntilFormula()) {
-            // In this case, there is nothing to be done.
-        } else if (formula.isRewardOperatorFormula() && (subformula.isTotalRewardFormula() || subformula.isEventuallyFormula())) {
-            auto const& baseRewardModel = formula.asRewardOperatorFormula().hasRewardModelName()
-                                              ? model.getRewardModel(formula.asRewardOperatorFormula().getRewardModelName())
-                                              : model.getUniqueRewardModel();
-            auto rewardModel = subformula.isEventuallyFormula()
-                                   ? storm::utility::createFilteredRewardModel(baseRewardModel, model.isDiscreteTimeModel(), subformula.asEventuallyFormula())
-                                   : storm::utility::createFilteredRewardModel(baseRewardModel, model.isDiscreteTimeModel(), subformula.asTotalRewardFormula());
-            std::vector<ValueType> choiceBasedRewards = getTotalRewardVector(model, *objective.formula);
-
-            // Set entries for all non-zero reward choices at states whose value is not already known.
-            // This relies on the fact that for goal states in reachability reward formulas, getSchedulerIndependentStateValues()[state] is set to zero.
-            auto const& rowGroupIndices = model.getTransitionMatrix().getRowGroupIndices();
-            auto const& stateValues = getSchedulerIndependentStateValues();
-            for (uint64_t state = 0; state < model.getNumberOfStates(); ++state) {
-                if (stateValues.find(state) == stateValues.end()) {
-                    for (uint64_t choice = rowGroupIndices[state]; choice < rowGroupIndices[state + 1]; ++choice) {
-                        if (!storm::utility::isZero(choiceBasedRewards[choice])) {
-                            result[choice] = choiceBasedRewards[choice];
-                        }
-                    }
-                }
-            }
-        } else if (formula.isTimeOperatorFormula() && subformula.isEventuallyFormula()) {
-            auto const& rowGroupIndices = model.getTransitionMatrix().getRowGroupIndices();
-            auto const& stateValues = getSchedulerIndependentStateValues();
-            std::vector<ValueType> const* rates = nullptr;
-            storm::storage::BitVector const* ms = nullptr;
-            if (model.isOfType(storm::models::ModelType::MarkovAutomaton)) {
-                auto ma = model.template as<storm::models::sparse::MarkovAutomaton<ValueType>>();
-                rates = &ma->getExitRates();
-                ms = &ma->getMarkovianStates();
-            }
-            // Set all choice offsets to one, except for the ones at states in scheduerIndependentStateValues.
-            for (uint64_t state = 0; state < model.getNumberOfStates(); ++state) {
-                if (stateValues.find(state) == stateValues.end()) {
-                    ValueType value = storm::utility::one<ValueType>();
-                    if (rates) {
-                        if (ms->get(state)) {
-                            value /= (*rates)[state];
-                        } else {
-                            // Nothing to be done for probabilistic states
-                            continue;
-                        }
-                    }
-                    for (uint64_t choice = rowGroupIndices[state]; choice < rowGroupIndices[state + 1]; ++choice) {
-                        result[choice] = value;
-                    }
-                }
-            }
-        } else {
-            STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "The given formula " << formula << " is not supported.");
-        }
-        choiceValueOffsets = std::move(result);
-    }
-    return choiceValueOffsets.get();
-}
-
-template<typename ValueType>
-std::vector<ValueType> evaluateOperatorFormula(Environment const& env, storm::models::sparse::Mdp<ValueType> const& model,
-                                               storm::logic::Formula const& formula) {
-    storm::modelchecker::SparseMdpPrctlModelChecker<storm::models::sparse::Mdp<ValueType>> mc(model);
-    storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> task(formula, false);
-    auto checkResult = mc.check(env, task);
-    STORM_LOG_THROW(checkResult && checkResult->isExplicitQuantitativeCheckResult(), storm::exceptions::UnexpectedException,
-                    "Unexpected type of check result for subformula " << formula << ".");
-    return checkResult->template asExplicitQuantitativeCheckResult<ValueType>().getValueVector();
-}
-
-template<typename ValueType>
-std::vector<ValueType> evaluateOperatorFormula(Environment const& env, storm::models::sparse::MarkovAutomaton<ValueType> const& model,
-                                               storm::logic::Formula const& formula) {
-    storm::modelchecker::SparseMarkovAutomatonCslModelChecker<storm::models::sparse::MarkovAutomaton<ValueType>> mc(model);
-    storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> task(formula, false);
-    auto checkResult = mc.check(env, task);
-    STORM_LOG_THROW(checkResult && checkResult->isExplicitQuantitativeCheckResult(), storm::exceptions::UnexpectedException,
-                    "Unexpected type of check result for subformula " << formula << ".");
-    return checkResult->template asExplicitQuantitativeCheckResult<ValueType>().getValueVector();
-}
-
-template<typename ModelType>
-std::vector<typename ModelType::ValueType> computeValueBounds(Environment const& env, bool lowerValueBounds, ModelType const& model,
-                                                              storm::logic::Formula const& formula) {
-    // Change the optimization direction in the formula.
-    auto newFormula = storm::logic::CloneVisitor().clone(formula);
-    newFormula->asOperatorFormula().setOptimalityType(lowerValueBounds ? storm::solver::OptimizationDirection::Minimize
-                                                                       : storm::solver::OptimizationDirection::Maximize);
-
-    if (std::is_same<typename ModelType::ValueType, storm::RationalNumber>::value) {
-        // don't have to worry about precision in exact mode.
-        return evaluateOperatorFormula(env, model, *newFormula);
+        return rewardModel.getTotalActionRewardVector(model.getTransitionMatrix(), stateRewardWeights);
     } else {
-        // Create an environment where sound results are enforced
-        storm::Environment soundEnv(env);
-        soundEnv.solver().setForceSoundness(true);
-        auto result = evaluateOperatorFormula(soundEnv, model, *newFormula);
-
-        auto eps = storm::utility::convertNumber<typename ModelType::ValueType>(soundEnv.solver().minMax().getPrecision());
-        // Add/substract eps to all entries to make up for precision errors
-        if (lowerValueBounds) {
-            eps = -eps;
-        }
-        for (auto& v : result) {
-            v += eps;
+        assert(formula.isTimeOperatorFormula());
+        std::vector<ValueType> result(model.getNumberOfChoices(), storm::utility::zero<ValueType>());
+        for (auto const markovianState : model.getMarkovianStates()) {
+            for (auto const& choice : model.getTransitionMatrix().getRowGroupIndices(markovianState)) {
+                result[choice] = storm::utility::one<ValueType>() / model.getExitRate(markovianState);
+            }
         }
         return result;
     }
 }
 
-template<typename ModelType>
-typename ModelType::ValueType const& DeterministicSchedsObjectiveHelper<ModelType>::getUpperValueBoundAtState(Environment const& env, uint64_t state) const {
-    computeUpperBounds(env);
-    return upperResultBounds.get()[state];
+template<typename ValueType>
+std::vector<ValueType> getTotalRewardVector(storm::models::sparse::Mdp<ValueType> const& model, storm::logic::Formula const& formula) {
+    if (formula.isRewardOperatorFormula()) {
+        boost::optional<std::string> rewardModelName = formula.asRewardOperatorFormula().getOptionalRewardModelName();
+        typename storm::models::sparse::Mdp<ValueType>::RewardModelType const& rewardModel =
+            rewardModelName.is_initialized() ? model.getRewardModel(rewardModelName.get()) : model.getUniqueRewardModel();
+        return rewardModel.getTotalRewardVector(model.getTransitionMatrix());
+    } else {
+        assert(formula.isTimeOperatorFormula());
+        return std::vector<ValueType>(model.getNumberOfChoices(), storm::utility::one<ValueType>());
+    }
 }
 
 template<typename ModelType>
-typename ModelType::ValueType const& DeterministicSchedsObjectiveHelper<ModelType>::getLowerValueBoundAtState(Environment const& env, uint64_t state) const {
-    computeLowerBounds(env);
-    return lowerResultBounds.get()[state];
+void DeterministicSchedsObjectiveHelper<ModelType>::initialize() {
+    STORM_LOG_ASSERT(model.getInitialStates().getNumberOfSetBits() == 1, "Expected a single initial state.");
+    uint64_t initialState = *model.getInitialStates().begin();
+    relevantZeroRewardChoices = storm::storage::BitVector(model.getTransitionMatrix().getRowCount(), false);
+    auto const& formula = *objective.formula;
+    if (formula.isProbabilityOperatorFormula() && formula.getSubformula().isUntilFormula()) {
+        storm::storage::BitVector phiStates = evaluatePropositionalFormula(model, formula.getSubformula().asUntilFormula().getLeftSubformula());
+        storm::storage::BitVector psiStates = evaluatePropositionalFormula(model, formula.getSubformula().asUntilFormula().getRightSubformula());
+        auto backwardTransitions = model.getBackwardTransitions();
+        auto prob1States = storm::utility::graph::performProb1A(model.getTransitionMatrix(), model.getNondeterministicChoiceIndices(), backwardTransitions,
+                                                                phiStates, psiStates);
+        auto prob0States = storm::utility::graph::performProb0A(backwardTransitions, phiStates, psiStates);
+        if (prob0States.get(initialState)) {
+            constantInitialStateValue = storm::utility::zero<ValueType>();
+        } else if (prob1States.get(initialState)) {
+            constantInitialStateValue = storm::utility::one<ValueType>();
+        }
+        maybeStates = ~(prob0States | prob1States);
+        // Cut away those states that are not reachable, or only reachable via non-maybe states.
+        maybeStates &= storm::utility::graph::getReachableStates(model.getTransitionMatrix(), model.getInitialStates(), maybeStates, ~maybeStates);
+        for (auto const& state : maybeStates) {
+            for (auto const& choice : model.getTransitionMatrix().getRowGroupIndices(state)) {
+                auto rowSum = model.getTransitionMatrix().getConstrainedRowSum(choice, prob1States);
+                if (storm::utility::isZero(rowSum)) {
+                    relevantZeroRewardChoices.set(choice);
+                } else {
+                    choiceRewards.emplace(choice, rowSum);
+                }
+            }
+        }
+    } else if (formula.getSubformula().isEventuallyFormula() && (formula.isRewardOperatorFormula() || formula.isTimeOperatorFormula())) {
+        storm::storage::BitVector rew0States = evaluatePropositionalFormula(model, formula.getSubformula().asEventuallyFormula().getSubformula());
+        if (formula.isRewardOperatorFormula()) {
+            auto const& baseRewardModel = formula.asRewardOperatorFormula().hasRewardModelName()
+                                              ? model.getRewardModel(formula.asRewardOperatorFormula().getRewardModelName())
+                                              : model.getUniqueRewardModel();
+            auto rewardModel =
+                storm::utility::createFilteredRewardModel(baseRewardModel, model.isDiscreteTimeModel(), formula.getSubformula().asEventuallyFormula());
+            storm::storage::BitVector statesWithoutReward = rewardModel.get().getStatesWithZeroReward(model.getTransitionMatrix());
+            rew0States = storm::utility::graph::performProb1A(model.getTransitionMatrix(), model.getNondeterministicChoiceIndices(),
+                                                              model.getBackwardTransitions(), statesWithoutReward, rew0States);
+        }
+        if (rew0States.get(initialState)) {
+            constantInitialStateValue = storm::utility::zero<ValueType>();
+        }
+        maybeStates = ~rew0States;
+        // Cut away those states that are not reachable, or only reachable via non-maybe states.
+        maybeStates &= storm::utility::graph::getReachableStates(model.getTransitionMatrix(), model.getInitialStates(), maybeStates, ~maybeStates);
+        std::vector<ValueType> choiceBasedRewards = getTotalRewardVector(model, *objective.formula);
+        for (auto const& state : maybeStates) {
+            for (auto const& choice : model.getTransitionMatrix().getRowGroupIndices(state)) {
+                auto const& value = choiceBasedRewards[choice];
+                if (storm::utility::isZero(value)) {
+                    relevantZeroRewardChoices.set(choice);
+                } else {
+                    choiceRewards.emplace(choice, value);
+                }
+            }
+        }
+    } else if (formula.isRewardOperatorFormula() && formula.getSubformula().isTotalRewardFormula()) {
+        auto const& baseRewardModel = formula.asRewardOperatorFormula().hasRewardModelName()
+                                          ? model.getRewardModel(formula.asRewardOperatorFormula().getRewardModelName())
+                                          : model.getUniqueRewardModel();
+        auto rewardModel =
+            storm::utility::createFilteredRewardModel(baseRewardModel, model.isDiscreteTimeModel(), formula.getSubformula().asTotalRewardFormula());
+        storm::storage::BitVector statesWithoutReward = rewardModel.get().getStatesWithZeroReward(model.getTransitionMatrix());
+        storm::storage::BitVector rew0States =
+            storm::utility::graph::performProbGreater0E(model.getBackwardTransitions(), statesWithoutReward, ~statesWithoutReward);
+        rew0States.complement();
+        if (rew0States.get(initialState)) {
+            constantInitialStateValue = storm::utility::zero<ValueType>();
+        }
+        maybeStates = ~rew0States;
+        // Cut away those states that are not reachable, or only reachable via non-maybe states.
+        maybeStates &= storm::utility::graph::getReachableStates(model.getTransitionMatrix(), model.getInitialStates(), maybeStates, ~maybeStates);
+        std::vector<ValueType> choiceBasedRewards = getTotalRewardVector(model, *objective.formula);
+        for (auto const& state : maybeStates) {
+            for (auto const& choice : model.getTransitionMatrix().getRowGroupIndices(state)) {
+                auto const& value = choiceBasedRewards[choice];
+                if (storm::utility::isZero(value)) {
+                    relevantZeroRewardChoices.set(choice);
+                } else {
+                    choiceRewards.emplace(choice, value);
+                }
+            }
+        }
+    } else {
+        STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "The given formula " << formula << " is not supported.");
+    }
+
+    // negate choice rewards for minimizing objectives
+    if (storm::solver::minimize(formula.getOptimalityType())) {
+        for (auto& entry : choiceRewards) {
+            entry.second *= -storm::utility::one<ValueType>();
+        }
+    }
+
+    // Find out if we have to deal with infinite positive or negative rewards
+    storm::storage::BitVector negativeRewardChoices(model.getNumberOfChoices(), false);
+    storm::storage::BitVector positiveRewardChoices(model.getNumberOfChoices(), false);
+    for (auto const& rew : getChoiceRewards()) {
+        if (rew.second > storm::utility::zero<ValueType>()) {
+            positiveRewardChoices.set(rew.first, true);
+        } else {
+            assert(rew.second < storm::utility::zero<ValueType>());
+            negativeRewardChoices.set(rew.first, true);
+        }
+    }
+    auto backwardTransitions = model.getBackwardTransitions();
+    bool hasNegativeEC =
+        storm::utility::graph::checkIfECWithChoiceExists(model.getTransitionMatrix(), backwardTransitions, getMaybeStates(), negativeRewardChoices);
+    bool hasPositiveEc =
+        storm::utility::graph::checkIfECWithChoiceExists(model.getTransitionMatrix(), backwardTransitions, getMaybeStates(), positiveRewardChoices);
+    STORM_LOG_THROW(!(hasNegativeEC && hasPositiveEc), storm::exceptions::NotSupportedException,
+                    "Objective is not convergent: Infinite positive and infinite negative reward is possible.");
+    infinityCase = hasNegativeEC ? InfinityCase::HasNegativeInfinite : (hasPositiveEc ? InfinityCase::HasPositiveInfinite : InfinityCase::AlwaysFinite);
+
+    if (infinityCase == InfinityCase::HasNegativeInfinite) {
+        storm::storage::BitVector negativeEcStates(maybeStates.size(), false);
+        storm::storage::MaximalEndComponentDecomposition<ValueType> mecs(model.getTransitionMatrix(), backwardTransitions, getMaybeStates());
+        for (auto const& mec : mecs) {
+            if (std::any_of(mec.begin(), mec.end(), [&negativeRewardChoices](auto const& sc) {
+                    return std::any_of(sc.second.begin(), sc.second.end(), [&negativeRewardChoices](auto const& c) { return negativeRewardChoices.get(c); });
+                })) {
+                for (auto const& sc : mec) {
+                    negativeEcStates.set(sc.first);
+                }
+            }
+        }
+        STORM_LOG_ASSERT(!negativeEcStates.empty(), "Expected some negative ec");
+        rewMinusInfEStates = storm::utility::graph::performProbGreater0E(backwardTransitions, getMaybeStates(), negativeEcStates);
+        STORM_LOG_ASSERT(model.getInitialStates().isSubsetOf(rewMinusInfEStates), "Initial state does not reach all maybestates");
+    }
 }
 
 template<typename ModelType>
-bool DeterministicSchedsObjectiveHelper<ModelType>::minimizing() const {
-    return storm::solver::minimize(objective.formula->getOptimalityType());
+storm::storage::BitVector const& DeterministicSchedsObjectiveHelper<ModelType>::getMaybeStates() const {
+    return maybeStates;
+}
+
+template<typename ModelType>
+storm::storage::BitVector const& DeterministicSchedsObjectiveHelper<ModelType>::getRewMinusInfEStates() const {
+    STORM_LOG_ASSERT(getInfinityCase() == InfinityCase::HasNegativeInfinite, "Tried to get -inf states, but there are none");
+    return rewMinusInfEStates;
+}
+
+template<typename ModelType>
+bool DeterministicSchedsObjectiveHelper<ModelType>::hasConstantInitialStateValue() const {
+    return constantInitialStateValue.has_value();
+}
+
+template<typename ModelType>
+typename DeterministicSchedsObjectiveHelper<ModelType>::ValueType DeterministicSchedsObjectiveHelper<ModelType>::getConstantInitialStateValue() const {
+    assert(hasConstantInitialStateValue());
+    return *constantInitialStateValue;
+}
+
+template<typename ModelType>
+std::map<uint64_t, typename ModelType::ValueType> const& DeterministicSchedsObjectiveHelper<ModelType>::getChoiceRewards() const {
+    return choiceRewards;
+}
+
+template<typename ModelType>
+storm::storage::BitVector const& DeterministicSchedsObjectiveHelper<ModelType>::getRelevantZeroRewardChoices() const {
+    return relevantZeroRewardChoices;
+}
+
+template<typename ModelType>
+typename ModelType::ValueType const& DeterministicSchedsObjectiveHelper<ModelType>::getUpperValueBoundAtState(uint64_t state) const {
+    STORM_LOG_ASSERT(maybeStates.get(state), "Expected a maybestate.");
+    STORM_LOG_ASSERT(upperResultBounds.has_value(), "requested upper value bounds but they were not computed.");
+    return upperResultBounds->at(state);
+}
+
+template<typename ModelType>
+typename ModelType::ValueType const& DeterministicSchedsObjectiveHelper<ModelType>::getLowerValueBoundAtState(uint64_t state) const {
+    STORM_LOG_ASSERT(maybeStates.get(state), "Expected a maybestate.");
+    STORM_LOG_ASSERT(lowerResultBounds.has_value(), "requested lower value bounds but they were not computed.");
+    return lowerResultBounds->at(state);
+}
+
+template<typename ModelType>
+typename DeterministicSchedsObjectiveHelper<ModelType>::InfinityCase const& DeterministicSchedsObjectiveHelper<ModelType>::getInfinityCase() const {
+    return infinityCase;
 }
 
 template<typename ModelType>
@@ -263,308 +272,431 @@ bool DeterministicSchedsObjectiveHelper<ModelType>::isTotalRewardObjective() con
     return objective.formula->isRewardOperatorFormula() && objective.formula->getSubformula().isTotalRewardFormula();
 }
 
-/*
-template <typename ValueType>
-ValueType getLpathDfs(uint64_t currentState, ValueType currentValue, storm::storage::BitVector& visited, storm::storage::BitVector const& mecStates,
-storm::storage::SparseMatrix<ValueType> const& transitions, uint64_t& counter) {
-    // exhausive dfs
-    if (visited.get(currentState)) {
-        if (++counter % 1000000 == 0) {
-            std::cout << "\t\t checked " << counter << " paths\n";
-        }
-        return currentValue;
-    } else {
-        visited.set(currentState);
-        ValueType result = storm::utility::one<ValueType>();
-        for (auto const& transition : transitions.getRowGroup(currentState)) {
-            result = std::min(result, getLpathDfs<ValueType>(transition.getColumn(), currentValue * transition.getValue(), visited, mecStates, transitions,
-counter));
-        }
-        visited.set(currentState, false);
-        return result;
-    }
+template<typename ModelType>
+bool DeterministicSchedsObjectiveHelper<ModelType>::hasThreshold() const {
+    return objective.formula->hasBound();
 }
-
-void oneOfManyEncoding(std::vector<storm::expressions::Expression>& operands, storm::solver::SmtSolver& solver) {
-    assert(!operands.empty());
-    uint64_t currentOperand = 0;
-    while (currentOperand + 2 < operands.size()) {
-        solver.add(!(operands[currentOperand] && operands[currentOperand + 1]));
-        auto auxVar = solver.getManager().declareFreshBooleanVariable(true).getExpression();
-        solver.add(storm::expressions::iff(auxVar, (operands[currentOperand] || operands[currentOperand + 1])));
-        operands.push_back(auxVar);
-        currentOperand += 2;
-    }
-    if (currentOperand + 1 == operands.size()) {
-        solver.add(operands[currentOperand]);
-    } else if (currentOperand + 2 == operands.size()) {
-        solver.add(storm::expressions::xclusiveor(operands[currentOperand], operands[currentOperand + 1]));
-    }
-}
-*/
-
-/*
-template <typename ValueType>
-ValueType getExpVisitsUpperBoundForMec(storm::storage::BitVector const& mecStates, storm::storage::SparseMatrix<ValueType> const& transitions) {
-    auto generalSolver = storm::utility::solver::getLpSolver<ValueType>("mecBounds", storm::solver::LpSolverTypeSelection::Gurobi);
-    auto solver = dynamic_cast<storm::solver::GurobiLpSolver<ValueType>*>(generalSolver.get());
-    solver->setOptimizationDirection(storm::solver::OptimizationDirection::Maximize);
-
-    auto one = solver->getConstant(storm::utility::one<ValueType>());
-    auto zero = solver->getConstant(storm::utility::zero<ValueType>());
-
-    std::vector<std::vector<storm::expressions::Expression>> ins(mecStates.size()), outs(mecStates.size());
-    std::vector<storm::expressions::Expression> choiceVars(transitions.getRowCount()), ecVars(mecStates.size());
-    std::vector<storm::expressions::Expression> choicesDisjunction;
-    std::vector<storm::expressions::Expression> leavingSum;
-    for (auto const& mecState : mecStates) {
-        std::vector<storm::expressions::Expression> choiceIndicatorVars;
-        ecVars[mecState] = solver->addLowerBoundedContinuousVariable("e" + std::to_string(mecState), storm::utility::zero<ValueType>()).getExpression();
-        ins[mecState].push_back(one);
-        outs[mecState].push_back(ecVars[mecState]);
-        leavingSum.push_back(ecVars[mecState]);
-        choiceIndicatorVars.push_back(solver->addBoundedIntegerVariable("c_mec" + std::to_string(mecState), storm::utility::zero<ValueType>(),
-storm::utility::one<ValueType>())); solver->addIndicatorConstraint("", choiceIndicatorVars.back().getBaseExpression().asVariableExpression().getVariable(), 0,
-ecVars[mecState] <= zero); for (uint64_t choice = transitions.getRowGroupIndices()[mecState]; choice < transitions.getRowGroupIndices()[mecState + 1]; ++choice)
-{ choiceVars[choice] = solver->addLowerBoundedContinuousVariable("y" + std::to_string(choice), storm::utility::zero<ValueType>()).getExpression();
-            choiceIndicatorVars.push_back(solver->addBoundedIntegerVariable("c" + std::to_string(choice), storm::utility::zero<ValueType>(),
-storm::utility::one<ValueType>()).getExpression()); solver->addIndicatorConstraint("",
-choiceIndicatorVars.back().getBaseExpression().asVariableExpression().getVariable(), 0, choiceVars[choice] <= zero);
-            choicesDisjunction.push_back(choiceVars[choice]);
-            outs[mecState].push_back(choiceVars[choice]);
-            for (auto const& entry : transitions.getRow(choice)) {
-                if (!storm::utility::isZero(entry.getValue())) {
-                    if (mecStates.get(entry.getColumn())) {
-                        ins[entry.getColumn()].push_back(choiceVars[choice] * solver->getConstant(entry.getValue()));
-                    } else {
-                        leavingSum.push_back(choiceVars[choice] * solver->getConstant(entry.getValue()));
-                    }
-                }
-            }
-        }
-        //oneOfManyEncoding(choicesSum, *solver);
-        solver->addConstraint("", storm::expressions::sum(choiceIndicatorVars) == one);
-    }
-    for (auto const& mecState : mecStates) {
-        STORM_LOG_ASSERT(!ins[mecState].empty(), "empty in set at a state");
-        STORM_LOG_ASSERT(!outs[mecState].empty(), "empty out set at a state");
-        solver->addConstraint("", storm::expressions::sum(ins[mecState]) == storm::expressions::sum(outs[mecState]));
-    }
-    STORM_LOG_ASSERT(!leavingSum.empty(), "empty leaving sum at a mec");
-    solver->addConstraint("", storm::expressions::sum(leavingSum) == solver->getConstant(storm::utility::convertNumber<ValueType,
-uint64_t>(mecStates.getNumberOfSetBits()))); choicesDisjunction.push_back(one); auto boundVar = solver->addUnboundedContinuousVariable("bound",
-storm::utility::one<ValueType>()); solver->addGeneralConstraint("", boundVar, storm::solver::GurobiLpSolver<ValueType>::GeneralConstraintOperator::Max,
-choicesDisjunction); solver->optimize(); STORM_LOG_THROW(!solver->isInfeasible(), storm::exceptions::UnexpectedException, "MEC LP has infeasable solution");
-    STORM_LOG_THROW(!solver->isUnbounded(), storm::exceptions::UnexpectedException, "MEC LP has unbounded solution");
-    return solver->getObjectiveValue();
-}
-*/
 
 template<typename ModelType>
-std::vector<typename ModelType::ValueType> DeterministicSchedsObjectiveHelper<ModelType>::computeUpperBoundOnExpectedVisitingTimes(
-    storm::storage::SparseMatrix<ValueType> const& modelTransitions, storm::storage::BitVector const& bottomStates,
-    storm::storage::BitVector const& nonBottomStates, bool hasEndComponents) {
-    storm::storage::SparseMatrix<ValueType> transitions;
-    std::vector<ValueType> probabilitiesToBottomStates;
-    boost::optional<std::vector<uint64_t>> modelToSubsystemStateMapping;
-    if (hasEndComponents) {
-        // We assume that end components will always be left (or form a sink state).
-        // The approach is to give a lower bound lpath on a path that leaves the end component.
-        // Then we use end component elimination and add a self loop on the 'ec' states with probability 1-lpath
-        storm::storage::MaximalEndComponentDecomposition<ValueType> mecs(modelTransitions, modelTransitions.transpose(true), nonBottomStates);
-        auto mecElimination = storm::transformer::EndComponentEliminator<ValueType>::transform(modelTransitions, mecs, nonBottomStates, nonBottomStates);
-
-        probabilitiesToBottomStates.reserve(mecElimination.matrix.getRowCount());
-        for (uint64_t row = 0; row < mecElimination.matrix.getRowCount(); ++row) {
-            if (mecElimination.matrix.getRow(row).getNumberOfEntries() == 0) {
-                probabilitiesToBottomStates.push_back(storm::utility::one<ValueType>());
-            } else {
-                probabilitiesToBottomStates.push_back(modelTransitions.getConstrainedRowSum(mecElimination.newToOldRowMapping[row], bottomStates));
-            }
-        }
-
-        modelToSubsystemStateMapping = std::move(mecElimination.oldToNewStateMapping);
-        transitions = storm::storage::SparseMatrix<ValueType>(mecElimination.matrix, true);  // insert diagonal entries
-
-        // slow down mec states by adding self loop probability 1-lpath
-        for (auto const& mec : mecs) {
-            ValueType lpath = storm::utility::one<ValueType>();
-            /* //smt/lp
-                storm::storage::BitVector mecStates(modelTransitions.getRowGroupCount(), false);
-                uint64_t numTransitions = 0;
-                uint64_t numChoices = 0;
-                for (auto const& stateChoices : mec) {
-                    mecStates.set(stateChoices.first);
-                    numTransitions += modelTransitions.getRowGroup(stateChoices.first).getNumberOfEntries();
-                    numChoices += modelTransitions.getRowGroupSize(stateChoices.first);
-                }
-                std::cout << "Checking a mec with " << mecStates.getNumberOfSetBits() << " states " << numChoices << " choices and " << numTransitions << "
-            transitions.\n"; lpath = storm::utility::one<ValueType>() / getExpVisitsUpperBoundForMec(mecStates, modelTransitions);
-            }*/
-            // We multiply the smallest transition probabilities occurring at each state and MEC-Choice
-            // as well as the smallest 'exit' probability
-            ValueType minExitProbability = storm::utility::one<ValueType>();
-            for (auto const& stateChoices : mec) {
-                auto state = stateChoices.first;
-                ValueType minProb = storm::utility::one<ValueType>();
-                for (uint64_t choice = modelTransitions.getRowGroupIndices()[state]; choice < modelTransitions.getRowGroupIndices()[state + 1]; ++choice) {
-                    if (stateChoices.second.count(choice) == 0) {
-                        // The choice leaves the EC, so we take the sum over the exiting probabilities
-                        ValueType exitProbabilitySum = storm::utility::zero<ValueType>();
-                        for (auto const& transition : modelTransitions.getRow(choice)) {
-                            if (!mec.containsState(transition.getColumn())) {
-                                exitProbabilitySum += transition.getValue();
-                            }
-                        }
-                        minExitProbability = std::min(minExitProbability, exitProbabilitySum);
-                    } else {
-                        // Get the minimum over all transition probabilities
-                        for (auto const& transition : modelTransitions.getRow(choice)) {
-                            if (!storm::utility::isZero(transition.getValue())) {
-                                minProb = std::min(minProb, transition.getValue());
-                            }
-                        }
-                    }
-                }
-                lpath *= minProb;
-            }
-            lpath *= minExitProbability;
-            /* other ideas...
-                std::vector<ValueType> leastPathProbs(modelTransitions.getRowGroupCount(), storm::utility::one<ValueType>());
-                std::vector<ValueType> prevLeastPathProbs(modelTransitions.getRowGroupCount(), storm::utility::one<ValueType>());
-                uint64_t mecSize = std::distance(mec.begin(), mec.end());
-                for (uint64_t i = 0; i < mecSize; ++i) {
-                    for (auto const& stateChoices : mec) {
-                        auto state = stateChoices.first;
-                        auto currVal = prevLeastPathProbs[state];
-                        for (auto const& transition : modelTransitions.getRowGroup(state)) {
-                            if (!storm::utility::isZero(transition.getValue()) && transition.getColumn() != state) {
-                                currVal = std::min<ValueType>(currVal, transition.getValue() * prevLeastPathProbs[transition.getColumn()]);
-                            }
-                        }
-                        leastPathProbs[state] = currVal;
-                    }
-                    leastPathProbs.swap(prevLeastPathProbs);
-                }
-                lpath = *std::min_element(leastPathProbs.begin(), leastPathProbs.end());
-                //lpath = std::max(lpath, storm::utility::convertNumber<ValueType>(1e-2)); // TODO
-            }
-            if (false) {
-                storm::storage::BitVector mecStates(modelTransitions.getRowGroupCount(), false);
-                uint64_t numTransitions = 0;
-                uint64_t numChoices = 0;
-                for (auto const& stateChoices : mec) {
-                    mecStates.set(stateChoices.first);
-                    numTransitions += modelTransitions.getRowGroup(stateChoices.first).getNumberOfEntries();
-                    numChoices += modelTransitions.getRowGroupSize(stateChoices.first);
-                }
-                std::cout << "Checking a mec with " << mecStates.getNumberOfSetBits() << " states " << numChoices << " choices and " << numTransitions << "
-            transitions.\n"; lpath = storm::utility::one<ValueType>(); for (auto const& stateChoices : mec) { storm::storage::BitVector visited =
-            ~mecStates; uint64_t counter = 0; ValueType lpathOld = lpath; lpath = std::min(lpath, getLpathDfs(stateChoices.first,
-            storm::utility::one<ValueType>(), visited, mecStates, modelTransitions, counter)); if (lpathOld > lpath) { std::cout << "\tnew lpath is " <<
-            storm::utility::convertNumber<double>(lpath) << ". checked " << counter << " paths.\n";
-                    }
-                }
-            }*/
-            STORM_LOG_ASSERT(!storm::utility::isZero(lpath), "unexpected value of lpath");
-            STORM_LOG_WARN_COND(
-                lpath >= storm::utility::convertNumber<ValueType>(0.001),
-                "Small lower bound for the probability to leave a mec: " << storm::utility::convertNumber<double>(lpath) << ". Numerical issues might occur.");
-            uint64_t mecState = modelToSubsystemStateMapping.get()[mec.begin()->first];
-            // scale all the probabilities at this state with lpath
-            for (uint64_t mecChoice = transitions.getRowGroupIndices()[mecState]; mecChoice < transitions.getRowGroupIndices()[mecState + 1]; ++mecChoice) {
-                for (auto& entry : transitions.getRow(mecChoice)) {
-                    if (entry.getColumn() == mecState) {
-                        entry.setValue(entry.getValue() * lpath + storm::utility::one<ValueType>() - lpath);
-                    } else {
-                        entry.setValue(entry.getValue() * lpath);
-                    }
-                }
-                probabilitiesToBottomStates[mecChoice] *= lpath;
-            }
-        }
+typename DeterministicSchedsObjectiveHelper<ModelType>::ValueType DeterministicSchedsObjectiveHelper<ModelType>::getThreshold() const {
+    STORM_LOG_ASSERT(hasThreshold(), "Trying to get a threshold but there is none");
+    STORM_LOG_THROW(!storm::logic::isStrict(objective.formula->getBound().comparisonType), storm::exceptions::NotSupportedException,
+                    "Objective " << *objective.originalFormula << ":  Strict objective thresholds are not supported.");
+    ValueType threshold = objective.formula->template getThresholdAs<ValueType>();
+    if (storm::solver::minimize(objective.formula->getOptimalityType())) {
+        threshold *= -storm::utility::one<ValueType>();  // negate minimizing thresholds
+        STORM_LOG_THROW(!storm::logic::isLowerBound(objective.formula->getBound().comparisonType), storm::exceptions::NotSupportedException,
+                        "Objective " << *objective.originalFormula << ":  Minimizing objective should specify an upper bound.");
     } else {
-        transitions = modelTransitions.getSubmatrix(true, nonBottomStates, nonBottomStates);
-        probabilitiesToBottomStates = modelTransitions.getConstrainedRowGroupSumVector(nonBottomStates, bottomStates);
+        STORM_LOG_THROW(storm::logic::isLowerBound(objective.formula->getBound().comparisonType), storm::exceptions::NotSupportedException,
+                        "Objective " << *objective.originalFormula << ":  Maximizing objective should specify a lower bound.");
+    }
+    return threshold;
+}
+
+template<typename ModelType>
+bool DeterministicSchedsObjectiveHelper<ModelType>::minimizing() const {
+    return storm::solver::minimize(objective.formula->getOptimalityType());
+}
+
+template<typename ValueType>
+void setLowerUpperTotalRewardBoundsToSolver(storm::solver::AbstractEquationSolver<ValueType>& solver, storm::storage::SparseMatrix<ValueType> const& matrix,
+                                            std::vector<ValueType> const& rewards, std::vector<ValueType> const& exitProbabilities,
+                                            std::optional<storm::OptimizationDirection> dir, bool reqLower, bool reqUpper) {
+    if (!reqLower && !reqUpper) {
+        return;  // nothing to be done!
+    }
+    STORM_LOG_ASSERT(!rewards.empty(), "empty reward vector,");
+
+    auto [minIt, maxIt] = std::minmax_element(rewards.begin(), rewards.end());
+    bool const hasNegativeValues = *minIt < storm::utility::zero<ValueType>();
+    bool const hasPositiveValues = *maxIt > storm::utility::zero<ValueType>();
+
+    std::optional<ValueType> lowerBound, upperBound;
+
+    // Get 0 as a  trivial lower/upper bound if possible
+    if (!hasNegativeValues) {
+        lowerBound = storm::utility::zero<ValueType>();
+    }
+    if (!hasPositiveValues) {
+        upperBound = storm::utility::zero<ValueType>();
     }
 
-    auto subsystemBounds = storm::modelchecker::helper::BaierUpperRewardBoundsComputer<ValueType>::computeUpperBoundOnExpectedVisitingTimes(
-        transitions, probabilitiesToBottomStates);
-    uint64_t subsystemState = 0;
-
-    std::vector<ValueType> visitingTimesUpperBounds;
-    visitingTimesUpperBounds.reserve(bottomStates.size());
-    for (uint64_t state = 0; state < bottomStates.size(); ++state) {
-        if (bottomStates.get(state)) {
-            visitingTimesUpperBounds.push_back(storm::utility::zero<ValueType>());
+    // Invoke the respective reward bound computers if needed
+    std::vector<ValueType> tmpRewards;
+    if (reqUpper && !upperBound.has_value()) {
+        if (hasNegativeValues) {
+            tmpRewards.resize(rewards.size());
+            storm::utility::vector::applyPointwise(rewards, tmpRewards, [](ValueType const& v) { return std::max(storm::utility::zero<ValueType>(), v); });
+        }
+        if (dir.has_value() && maximize(*dir)) {
+            solver.setUpperBound(
+                storm::modelchecker::helper::BaierUpperRewardBoundsComputer<ValueType>(matrix, hasNegativeValues ? tmpRewards : rewards, exitProbabilities)
+                    .computeUpperBound());
         } else {
-            if (modelToSubsystemStateMapping) {
-                visitingTimesUpperBounds.push_back(subsystemBounds[modelToSubsystemStateMapping.get()[state]]);
-            } else {
-                visitingTimesUpperBounds.push_back(subsystemBounds[subsystemState]);
-            }
-            ++subsystemState;
+            solver.setUpperBounds(
+                storm::modelchecker::helper::DsMpiMdpUpperRewardBoundsComputer<ValueType>(matrix, hasNegativeValues ? tmpRewards : rewards, exitProbabilities)
+                    .computeUpperBounds());
         }
     }
-    return visitingTimesUpperBounds;
+    if (reqLower && !upperBound.has_value()) {
+        // For lower bounds we actually compute upper bounds for the negated rewards.
+        // We therefore need tmpRewards in any way.
+        tmpRewards.resize(rewards.size());
+        storm::utility::vector::applyPointwise(rewards, tmpRewards,
+                                               [](ValueType const& v) { return std::max<ValueType>(storm::utility::zero<ValueType>(), -v); });
+        if (dir.has_value() && minimize(*dir)) {
+            solver.setLowerBound(
+                -storm::modelchecker::helper::BaierUpperRewardBoundsComputer<ValueType>(matrix, tmpRewards, exitProbabilities).computeUpperBound());
+        } else {
+            auto lowerBounds =
+                storm::modelchecker::helper::DsMpiMdpUpperRewardBoundsComputer<ValueType>(matrix, tmpRewards, exitProbabilities).computeUpperBounds();
+            storm::utility::vector::applyPointwise(lowerBounds, lowerBounds, [](ValueType const& v) { return -v; });
+            solver.setLowerBounds(std::move(lowerBounds));
+        }
+    }
 }
 
-template<typename ModelType>
-typename ModelType::ValueType const& DeterministicSchedsObjectiveHelper<ModelType>::getLargestUpperBound(Environment const& env) const {
-    computeUpperBounds(env);
-    return *std::max_element(upperResultBounds->begin(), upperResultBounds->end());
-}
-
-template<typename ModelType>
-void DeterministicSchedsObjectiveHelper<ModelType>::computeUpperBounds(Environment const& env) const {
-    if (!upperResultBounds) {
-        upperResultBounds = computeValueBounds(env, false, model, *objective.formula);
-        auto upperResultBound = objective.upperResultBound;
-        if (!upperResultBound.is_initialized() && storm::utility::vector::hasInfinityEntry(upperResultBounds.get())) {
-            STORM_LOG_THROW(objective.formula->isRewardOperatorFormula(), storm::exceptions::NotSupportedException,
-                            "The upper bound for objective " << *objective.originalFormula
-                                                             << " is infinity at some state. This is only supported for reachability rewards / total rewards.");
-            STORM_LOG_THROW(objective.formula->getSubformula().isTotalRewardFormula() || objective.formula->getSubformula().isEventuallyFormula(),
-                            storm::exceptions::NotSupportedException,
-                            "The upper bound for objective " << *objective.originalFormula
-                                                             << " is infinity at some state. This is only supported for reachability rewards / total rewards.");
-            auto rewards = getTotalRewardVector(model, *objective.formula);
-            auto zeroValuedStates = storm::utility::vector::filterZero(upperResultBounds.get());
-            auto expVisits = computeUpperBoundOnExpectedVisitingTimes(model.getTransitionMatrix(), zeroValuedStates, ~zeroValuedStates, true);
-            ValueType upperBound = storm::utility::zero<ValueType>();
-            for (uint64_t state = 0; state < expVisits.size(); ++state) {
-                ValueType maxReward = storm::utility::zero<ValueType>();
-                for (auto row = model.getTransitionMatrix().getRowGroupIndices()[state], endRow = model.getTransitionMatrix().getRowGroupIndices()[state + 1];
-                     row < endRow; ++row) {
-                    maxReward = std::max(maxReward, rewards[row]);
+template<typename ValueType>
+std::vector<ValueType> computeValuesOfReducedSystem(Environment const& env, storm::storage::SparseMatrix<ValueType> const& submatrix,
+                                                    std::vector<ValueType> const& exitProbs, std::vector<ValueType> const& rewards,
+                                                    storm::OptimizationDirection const& dir) {
+    auto minMaxSolver = storm::solver::GeneralMinMaxLinearEquationSolverFactory<ValueType>().create(env, submatrix);
+    minMaxSolver->setHasUniqueSolution(true);
+    minMaxSolver->setOptimizationDirection(dir);
+    auto req = minMaxSolver->getRequirements(env, dir);
+    setLowerUpperTotalRewardBoundsToSolver(*minMaxSolver, submatrix, rewards, exitProbs, dir, req.lowerBounds(), req.upperBounds());
+    req.clearBounds();
+    if (req.validInitialScheduler()) {
+        std::vector<uint64_t> initSched(submatrix.getRowGroupCount());
+        auto backwardsTransitions = submatrix.transpose(true);
+        storm::storage::BitVector statesWithChoice(initSched.size(), false);
+        storm::storage::BitVector foundStates(initSched.size(), false);
+        std::vector<uint64_t> stack;
+        for (uint64_t state = 0; state < initSched.size(); ++state) {
+            if (foundStates.get(state)) {
+                continue;
+            }
+            for (auto choice : submatrix.getRowGroupIndices(state)) {
+                if (!storm::utility::isZero(exitProbs[choice])) {
+                    initSched[state] = choice - submatrix.getRowGroupIndices()[state];
+                    statesWithChoice.set(state);
+                    foundStates.set(state);
+                    for (auto const& predecessor : backwardsTransitions.getRow(state)) {
+                        if (!foundStates.get(predecessor.getColumn())) {
+                            stack.push_back(predecessor.getColumn());
+                            foundStates.set(predecessor.getColumn());
+                        }
+                    }
+                    break;
                 }
-                upperBound += expVisits[state] * maxReward;
             }
-            upperResultBound = upperBound;
         }
-        storm::utility::vector::clip(upperResultBounds.get(), objective.lowerResultBound, upperResultBound);
+        while (!stack.empty()) {
+            auto state = stack.back();
+            stack.pop_back();
+            for (auto choice : submatrix.getRowGroupIndices(state)) {
+                auto row = submatrix.getRow(choice);
+                if (std::any_of(row.begin(), row.end(), [&statesWithChoice](auto const& entry) {
+                        return !storm::utility::isZero(entry.getValue()) && statesWithChoice.get(entry.getColumn());
+                    })) {
+                    initSched[state] = choice - submatrix.getRowGroupIndices()[state];
+                    statesWithChoice.set(state);
+                    break;
+                }
+            }
+            assert(statesWithChoice.get(state));
+            for (auto const& predecessor : backwardsTransitions.getRow(state)) {
+                if (!foundStates.get(predecessor.getColumn())) {
+                    stack.push_back(predecessor.getColumn());
+                    foundStates.set(predecessor.getColumn());
+                }
+            }
+        }
+        assert(statesWithChoice.full());
+        minMaxSolver->setInitialScheduler(std::move(initSched));
+        req.clearValidInitialScheduler();
+    }
+    STORM_LOG_THROW(!req.hasEnabledCriticalRequirement(), storm::exceptions::UncheckedRequirementException,
+                    "Solver requirements " + req.getEnabledRequirementsAsString() + " not checked.");
+    minMaxSolver->setRequirementsChecked(true);
+
+    std::vector<ValueType> result(submatrix.getRowGroupCount());
+    minMaxSolver->solveEquations(env, result, rewards);
+
+    return result;
+}
+
+template<typename ValueType>
+void plusMinMaxSolverPrecision(Environment const& env, ValueType& value) {
+    if (!storm::NumberTraits<ValueType>::IsExact) {
+        auto eps = storm::utility::convertNumber<ValueType>(env.solver().minMax().getPrecision());
+        if (env.solver().minMax().getRelativeTerminationCriterion()) {
+            value += value * eps;
+        } else {
+            value += eps;
+        }
     }
 }
 
-template<typename ModelType>
-void DeterministicSchedsObjectiveHelper<ModelType>::computeLowerBounds(Environment const& env) const {
-    if (!lowerResultBounds) {
-        lowerResultBounds = computeValueBounds(env, true, model, *objective.formula);
-        storm::utility::vector::clip(lowerResultBounds.get(), objective.lowerResultBound, objective.upperResultBound);
-        STORM_LOG_THROW(!storm::utility::vector::hasInfinityEntry(lowerResultBounds.get()), storm::exceptions::NotSupportedException,
-                        "The lower bound for objective " << *objective.originalFormula << " is infinity at some state. This is not supported.");
+template<typename ValueType>
+void minusMinMaxSolverPrecision(Environment const& env, ValueType& value) {
+    if (!storm::NumberTraits<ValueType>::IsExact) {
+        auto eps = storm::utility::convertNumber<ValueType>(env.solver().minMax().getPrecision());
+        if (env.solver().minMax().getRelativeTerminationCriterion()) {
+            value -= value * eps;
+        } else {
+            value -= eps;
+        }
     }
 }
 
+template<storm::OptimizationDirection Dir, typename ValueType>
+ValueType sumOfMecRewards(storm::storage::MaximalEndComponent const& mec, std::vector<ValueType> const& rewards) {
+    auto sum = storm::utility::zero<ValueType>();
+    for (auto const& stateChoices : mec) {
+        storm::utility::Extremum<Dir, ValueType> optimalStateValue;
+        for (auto const& choice : stateChoices.second) {
+            optimalStateValue &= rewards.at(choice);
+        }
+        sum += *optimalStateValue;
+    }
+    return sum;
+}
+
+template<typename ValueType>
+ValueType getLowerBoundForNonZeroReachProb(storm::storage::SparseMatrix<ValueType> const& transitions, uint64_t init, uint64_t target) {
+    storm::storage::BitVector allStates(transitions.getRowGroupCount(), true);
+    storm::storage::BitVector initialAsBitVector(transitions.getRowGroupCount(), false);
+    initialAsBitVector.set(init, true);
+    storm::storage::BitVector targetAsBitVector(transitions.getRowGroupCount(), false);
+    targetAsBitVector.set(target, true);
+    auto relevantStates = storm::utility::graph::getReachableStates(transitions, initialAsBitVector, allStates, targetAsBitVector);
+    auto product = storm::utility::one<ValueType>();
+    for (auto state : relevantStates) {
+        if (state == target) {
+            continue;
+        }
+        storm::utility::Minimum<ValueType> minProb;
+        for (auto const& entry : transitions.getRowGroup(state)) {
+            if (relevantStates.get(entry.getColumn())) {
+                minProb &= entry.getValue();
+            }
+        }
+        product *= *minProb;
+    }
+    return product;
+}
+
 template<typename ModelType>
-typename ModelType::ValueType DeterministicSchedsObjectiveHelper<ModelType>::evaluateOnModel(Environment const& env, ModelType const& evaluatedModel) const {
-    return evaluateOperatorFormula(env, evaluatedModel, *objective.formula)[*evaluatedModel.getInitialStates().begin()];
+void DeterministicSchedsObjectiveHelper<ModelType>::computeLowerUpperBounds(Environment const& env) const {
+    assert(!upperResultBounds.has_value() && !lowerResultBounds.has_value());
+    auto backwardTransitions = model.getBackwardTransitions();
+    auto nonMaybeStates = ~maybeStates;
+    // Eliminate problematic mecs
+    storm::storage::MaximalEndComponentDecomposition<ValueType> problMecs(model.getTransitionMatrix(), backwardTransitions, maybeStates,
+                                                                          getRelevantZeroRewardChoices());
+    auto quotient1 = storm::transformer::EndComponentEliminator<ValueType>::transform(model.getTransitionMatrix(), problMecs, maybeStates, maybeStates);
+    auto backwardTransitions1 = quotient1.matrix.transpose(true);
+    std::vector<ValueType> rewards1(quotient1.matrix.getRowCount(), storm::utility::zero<ValueType>());
+    std::vector<ValueType> exitProbs1(quotient1.matrix.getRowCount(), storm::utility::zero<ValueType>());
+    storm::storage::BitVector subsystemChoices1(quotient1.matrix.getRowCount(), true);
+    storm::storage::BitVector allQuotient1States(quotient1.matrix.getRowGroupCount(), true);
+    for (uint64_t choice = 0; choice < quotient1.matrix.getRowCount(); ++choice) {
+        auto const& oldChoice = quotient1.newToOldRowMapping[choice];
+        if (auto findRes = choiceRewards.find(oldChoice); findRes != choiceRewards.end()) {
+            rewards1[choice] = findRes->second;
+        }
+        if (quotient1.sinkRows.get(choice)) {
+            subsystemChoices1.set(choice, false);
+            exitProbs1[choice] = storm::utility::one<ValueType>();
+        } else if (auto prob = model.getTransitionMatrix().getConstrainedRowSum(oldChoice, nonMaybeStates); !storm::utility::isZero(prob)) {
+            exitProbs1[choice] = prob;
+            subsystemChoices1.set(choice, false);
+        }
+    }
+    // Assert that every state can eventually exit the subsystem. If that is not the case, we get infinite reward as problematic (aka zero mecs) are removed.
+    auto exitStates1 = quotient1.matrix.getRowGroupFilter(~subsystemChoices1, false);
+    STORM_LOG_THROW(storm::utility::graph::performProbGreater0E(backwardTransitions1, allQuotient1States, exitStates1).full(),
+                    storm::exceptions::InvalidOperationException, "Objective " << *objective.originalFormula << " does not induce finite value.");
+
+    // Compute bounds for finite cases
+    if (getInfinityCase() != InfinityCase::HasNegativeInfinite) {
+        auto result1 = computeValuesOfReducedSystem(env, quotient1.matrix, exitProbs1, rewards1, storm::OptimizationDirection::Minimize);
+        lowerResultBounds = std::vector<ValueType>(model.getNumberOfStates(), storm::utility::zero<ValueType>());
+        for (auto const& state : maybeStates) {
+            ValueType val = result1.at(quotient1.oldToNewStateMapping.at(state));
+            minusMinMaxSolverPrecision(env, val);
+            (*lowerResultBounds)[state] = val;
+        }
+    }
+    if (getInfinityCase() != InfinityCase::HasPositiveInfinite) {
+        auto result1 = computeValuesOfReducedSystem(env, quotient1.matrix, exitProbs1, rewards1, storm::OptimizationDirection::Maximize);
+        upperResultBounds = std::vector<ValueType>(model.getNumberOfStates(), storm::utility::zero<ValueType>());
+        for (auto const& state : maybeStates) {
+            ValueType val = result1.at(quotient1.oldToNewStateMapping.at(state));
+            plusMinMaxSolverPrecision(env, val);
+            if (infinityCase == InfinityCase::HasNegativeInfinite) {  // Upper bound has to be at least 0 to allow for "trivial solution" in encoding
+                val = std::max(val, storm::utility::zero<ValueType>());
+            }
+            (*upperResultBounds)[state] = val;
+        }
+    }
+    if (getInfinityCase() != InfinityCase::AlwaysFinite) {
+        assert(getInfinityCase() == InfinityCase::HasPositiveInfinite || getInfinityCase() == InfinityCase::HasNegativeInfinite);
+        STORM_LOG_THROW(
+            hasThreshold() || getInfinityCase() == InfinityCase::HasNegativeInfinite, storm::exceptions::NotSupportedException,
+            "The upper bound for objective " << *objective.originalFormula << " is infinity at some state. This is only supported for thresholded objectives");
+        // Eliminate remaining mecs
+        storm::storage::MaximalEndComponentDecomposition<ValueType> remainingMecs(quotient1.matrix, backwardTransitions1, allQuotient1States,
+                                                                                  subsystemChoices1);
+        STORM_LOG_ASSERT(!remainingMecs.empty(), "Incorrect infinityCase: There is no MEC with rewards.");
+        auto quotient2 =
+            storm::transformer::EndComponentEliminator<ValueType>::transform(quotient1.matrix, remainingMecs, allQuotient1States, allQuotient1States);
+        std::vector<ValueType> rewards2(quotient2.matrix.getRowCount(), storm::utility::zero<ValueType>());
+        std::vector<ValueType> exitProbs2(quotient2.matrix.getRowCount(), storm::utility::zero<ValueType>());
+        for (uint64_t choice = 0; choice < quotient2.matrix.getRowCount(); ++choice) {
+            auto const& oldChoice = quotient2.newToOldRowMapping[choice];
+            if (quotient2.sinkRows.get(choice)) {
+                exitProbs2[choice] = storm::utility::one<ValueType>();
+            } else {
+                rewards2[choice] = rewards1[oldChoice];
+                exitProbs2[choice] = exitProbs1[oldChoice];
+            }
+        }
+
+        // Add rewards within ECs
+        auto initialState2 = quotient2.oldToNewStateMapping.at(quotient1.oldToNewStateMapping.at(*model.getInitialStates().begin()));
+        ValueType rewardValueForPosInfCase;
+        if (getInfinityCase() == InfinityCase::HasPositiveInfinite) {
+            rewardValueForPosInfCase = getThreshold();
+            ;
+            // We need to substract a lower bound for the value at the initial state
+            std::vector<ValueType> rewards2Negative;
+            rewards2Negative.reserve(rewards2.size());
+            for (auto const& rew : rewards2) {
+                rewards2Negative.push_back(std::min(rew, storm::utility::zero<ValueType>()));
+            }
+            auto lower2 = computeValuesOfReducedSystem(env, quotient2.matrix, exitProbs2, rewards2Negative, storm::OptimizationDirection::Minimize);
+            rewardValueForPosInfCase -= lower2.at(initialState2);
+        }
+        for (auto const& mec : remainingMecs) {
+            auto mecState2 = quotient2.oldToNewStateMapping[mec.begin()->first];
+            ValueType mecReward = getInfinityCase() == InfinityCase::HasPositiveInfinite
+                                      ? sumOfMecRewards<storm::OptimizationDirection::Maximize>(mec, rewards1)
+                                      : sumOfMecRewards<storm::OptimizationDirection::Minimize>(mec, rewards1);
+            mecReward /= VisitingTimesHelper<ValueType>::computeMecTraversalLowerBound(mec, quotient1.matrix);
+            auto groupIndices = quotient2.matrix.getRowGroupIndices(mecState2);
+            for (auto const choice2 : groupIndices) {
+                rewards2[choice2] += mecReward;
+            }
+            if (getInfinityCase() == InfinityCase::HasPositiveInfinite) {
+                auto sinkChoice = quotient2.sinkRows.getNextSetIndex(*groupIndices.begin());
+                STORM_LOG_ASSERT(sinkChoice < quotient2.matrix.getRowGroupIndices()[mecState2 + 1], "EC state in quotient has no sink row.");
+                rewards2[sinkChoice] += rewardValueForPosInfCase / getLowerBoundForNonZeroReachProb(quotient2.matrix, initialState2, mecState2);
+            }
+        }
+
+        // Compute and insert missing bounds
+        if (getInfinityCase() == InfinityCase::HasNegativeInfinite) {
+            auto result2 = computeValuesOfReducedSystem(env, quotient2.matrix, exitProbs2, rewards2, storm::OptimizationDirection::Minimize);
+            lowerResultBounds = std::vector<ValueType>(model.getNumberOfStates(), storm::utility::zero<ValueType>());
+            for (auto const& state : maybeStates) {
+                ValueType val = result2.at(quotient2.oldToNewStateMapping.at(quotient1.oldToNewStateMapping.at(state)));
+                minusMinMaxSolverPrecision(env, val);
+                (*lowerResultBounds)[state] = val;
+            }
+        } else {
+            assert(getInfinityCase() == InfinityCase::HasPositiveInfinite);
+            auto result2 = computeValuesOfReducedSystem(env, quotient2.matrix, exitProbs2, rewards2, storm::OptimizationDirection::Maximize);
+            upperResultBounds = std::vector<ValueType>(model.getNumberOfStates(), storm::utility::zero<ValueType>());
+            for (auto const& state : maybeStates) {
+                ValueType val = result2.at(quotient2.oldToNewStateMapping.at(quotient1.oldToNewStateMapping.at(state)));
+                plusMinMaxSolverPrecision(env, val);
+                (*upperResultBounds)[state] = val;
+            }
+        }
+    }
+    STORM_LOG_THROW(
+        std::all_of(maybeStates.begin(), maybeStates.end(), [this](auto const& s) { return this->lowerResultBounds->at(s) <= this->upperResultBounds->at(s); }),
+        storm::exceptions::UnexpectedException, "Pre-computed lower bound exceeds upper bound.");
+}
+
+template<typename ModelType>
+typename DeterministicSchedsObjectiveHelper<ModelType>::ValueType DeterministicSchedsObjectiveHelper<ModelType>::evaluateScheduler(
+    Environment const& env, storm::storage::BitVector const& selectedChoices) const {
+    STORM_LOG_ASSERT(model.getInitialStates().getNumberOfSetBits() == 1u, "Expected a single initial state.");
+    STORM_LOG_ASSERT(model.getInitialStates().isSubsetOf(getMaybeStates()), "Expected initial state to be maybestate.");
+    STORM_LOG_ASSERT(selectedChoices.getNumberOfSetBits() == model.getNumberOfStates(), "invalid choice selection.");
+    storm::storage::BitVector allStates(model.getNumberOfStates(), true);
+    auto selectedMatrix = model.getTransitionMatrix().getSubmatrix(false, selectedChoices, allStates);
+    assert(selectedMatrix.getRowCount() == selectedMatrix.getRowGroupCount());
+    selectedMatrix.makeRowGroupingTrivial();
+    auto subMaybeStates =
+        getMaybeStates() & storm::utility::graph::getReachableStates(selectedMatrix, model.getInitialStates(), getMaybeStates(), ~getMaybeStates());
+    auto bsccCandidates = storm::utility::graph::performProbGreater0(selectedMatrix.transpose(true), subMaybeStates, ~subMaybeStates);
+    bsccCandidates.complement();  // i.e. states that can not reach non-maybe states
+    if (!bsccCandidates.empty()) {
+        storm::storage::StronglyConnectedComponentDecompositionOptions bsccOptions;
+        bsccOptions.onlyBottomSccs(true).subsystem(bsccCandidates);
+        storm::storage::StronglyConnectedComponentDecomposition bsccs(selectedMatrix, bsccOptions);
+        for (auto const& bscc : bsccs) {
+            for (auto const& s : bscc) {
+                subMaybeStates.set(s, false);
+            }
+        }
+    }
+
+    if (subMaybeStates.get(*model.getInitialStates().begin())) {
+        storm::solver::GeneralLinearEquationSolverFactory<ValueType> factory;
+        bool const useEqSysFormat = factory.getEquationProblemFormat(env) == storm::solver::LinearEquationSolverProblemFormat::EquationSystem;
+        auto eqSysMatrix = selectedMatrix.getSubmatrix(true, subMaybeStates, subMaybeStates, useEqSysFormat);
+        assert(eqSysMatrix.getRowCount() == eqSysMatrix.getRowGroupCount());
+        auto exitProbs = selectedMatrix.getConstrainedRowSumVector(subMaybeStates, ~subMaybeStates);
+        std::vector<ValueType> rewards;
+        rewards.reserve(exitProbs.size());
+        auto const& allRewards = getChoiceRewards();
+        for (auto const& state : getMaybeStates()) {
+            auto choice = selectedChoices.getNextSetIndex(model.getTransitionMatrix().getRowGroupIndices()[state]);
+            STORM_LOG_ASSERT(choice < model.getTransitionMatrix().getRowGroupIndices()[state + 1], " no choice selected at state" << state);
+            if (subMaybeStates.get(state)) {
+                if (auto findRes = allRewards.find(choice); findRes != allRewards.end()) {
+                    rewards.push_back(findRes->second);
+                } else {
+                    rewards.push_back(storm::utility::zero<ValueType>());
+                }
+            } else {
+                STORM_LOG_ASSERT(!bsccCandidates.get(state) || allRewards.count(choice) == 0, "Strategy selected a bscc with rewards");
+            }
+        }
+        if (useEqSysFormat) {
+            eqSysMatrix.convertToEquationSystem();
+        }
+        auto solver = factory.create(env, eqSysMatrix);
+        storm::storage::BitVector init = model.getInitialStates() % subMaybeStates;
+        assert(init.getNumberOfSetBits() == 1);
+        auto const initState = *init.begin();
+        solver->setRelevantValues(std::move(init));
+        auto req = solver->getRequirements(env);
+        if (!useEqSysFormat) {
+            setLowerUpperTotalRewardBoundsToSolver(*solver, eqSysMatrix, rewards, exitProbs, std::nullopt, req.lowerBounds(), req.upperBounds());
+            req.clearUpperBounds();
+            req.clearLowerBounds();
+        }
+        STORM_LOG_THROW(!req.hasEnabledCriticalRequirement(), storm::exceptions::UncheckedRequirementException,
+                        "Solver requirements " + req.getEnabledRequirementsAsString() + " not checked.");
+        std::vector<ValueType> x(rewards.size());
+        solver->solveEquations(env, x, rewards);
+
+        return x[initState];
+    } else {
+        // initial state is on a bscc
+        return storm::utility::zero<ValueType>();
+    }
 }
 
 template class DeterministicSchedsObjectiveHelper<storm::models::sparse::Mdp<double>>;
 template class DeterministicSchedsObjectiveHelper<storm::models::sparse::Mdp<storm::RationalNumber>>;
 template class DeterministicSchedsObjectiveHelper<storm::models::sparse::MarkovAutomaton<double>>;
 template class DeterministicSchedsObjectiveHelper<storm::models::sparse::MarkovAutomaton<storm::RationalNumber>>;
-}  // namespace multiobjective
-}  // namespace modelchecker
-}  // namespace storm
+}  // namespace storm::modelchecker::multiobjective

--- a/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsObjectiveHelper.h
+++ b/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsObjectiveHelper.h
@@ -1,18 +1,21 @@
 #pragma once
 
-#include <boost/optional.hpp>
 #include <map>
+#include <optional>
 
 #include "storm/modelchecker/multiobjective/Objective.h"
 #include "storm/storage/BitVector.h"
-#include "storm/storage/SparseMatrix.h"
 
 namespace storm {
 
+namespace storage {
+template<typename ValueType>
+class MaximalEndComponentDecomposition;
+}
+
 class Environment;
 
-namespace modelchecker {
-namespace multiobjective {
+namespace modelchecker::multiobjective {
 
 template<typename ModelType>
 class DeterministicSchedsObjectiveHelper {
@@ -21,46 +24,89 @@ class DeterministicSchedsObjectiveHelper {
     DeterministicSchedsObjectiveHelper(ModelType const& model, Objective<ValueType> const& objective);
 
     /*!
-     * Returns states and values for states that are independent of the scheduler.
+     * Returns true iff the value at the (unique) initial state is a constant (that is independent of the scheduler)
      */
-    std::map<uint64_t, ValueType> const& getSchedulerIndependentStateValues() const;
+    bool hasConstantInitialStateValue() const;
 
     /*!
-     * Returns offsets of each choice value (e.g., the reward) if non-zero.
-     * This does not include choices of states with independent state values
+     * If hasConstantInitialStateValue is true, this returns that constant value.
      */
-    std::map<uint64_t, ValueType> const& getChoiceValueOffsets() const;
+    ValueType getConstantInitialStateValue() const;
 
-    ValueType const& getUpperValueBoundAtState(Environment const& env, uint64_t state) const;
-    ValueType const& getLowerValueBoundAtState(Environment const& env, uint64_t state) const;
+    /*!
+     * Returns those states for which the scheduler potentially influences the value.
+     *
+     * @return
+     */
+    storm::storage::BitVector const& getMaybeStates() const;
 
-    ValueType const& getLargestUpperBound(Environment const& env) const;
+    /*!
+     * Returns the set of states for which value -inf is possible
+     * @pre getInfinityCase() == HasNegativeInfinite has to hold
+     * @return
+     */
+    storm::storage::BitVector const& getRewMinusInfEStates() const;
+
+    /*!
+     * Returns the choice rewards if non-zero.
+     * This does not include choices of non-maybe states
+     */
+    std::map<uint64_t, ValueType> const& getChoiceRewards() const;
+
+    /*!
+     * Returns the choices that (i) originate from a maybestate and (ii) have zero value
+     *
+     */
+    storm::storage::BitVector const& getRelevantZeroRewardChoices() const;
+
+    ValueType const& getUpperValueBoundAtState(uint64_t state) const;
+    ValueType const& getLowerValueBoundAtState(uint64_t state) const;
+
+    enum class InfinityCase { AlwaysFinite, HasPositiveInfinite, HasNegativeInfinite };
+
+    InfinityCase const& getInfinityCase() const;
 
     bool minimizing() const;
+
+    void computeLowerUpperBounds(Environment const& env) const;
 
     /*!
      * Returns true if this is a total reward objective
      */
     bool isTotalRewardObjective() const;
 
-    ValueType evaluateOnModel(Environment const& env, ModelType const& evaluatedModel) const;
+    /*!
+     * Returns true, if this objective specifies a threshold
+     */
+    bool hasThreshold() const;
 
-    static std::vector<ValueType> computeUpperBoundOnExpectedVisitingTimes(storm::storage::SparseMatrix<ValueType> const& modelTransitions,
-                                                                           storm::storage::BitVector const& bottomStates,
-                                                                           storm::storage::BitVector const& nonBottomStates, bool hasEndComponents);
+    /*!
+     * Returns the threshold (if specified)
+     */
+    ValueType getThreshold() const;
+
+    /*!
+     * Computes the value at the initial state under the given scheduler.
+     * @return
+     */
+    ValueType evaluateScheduler(Environment const& env, storm::storage::BitVector const& selectedChoices) const;
 
    private:
-    void computeUpperBounds(Environment const& env) const;
-    void computeLowerBounds(Environment const& env) const;
+    void initialize();
 
-    mutable boost::optional<std::map<uint64_t, ValueType>> schedulerIndependentStateValues;
-    mutable boost::optional<std::map<uint64_t, ValueType>> choiceValueOffsets;
-    mutable boost::optional<std::vector<ValueType>> lowerResultBounds;
-    mutable boost::optional<std::vector<ValueType>> upperResultBounds;
+    storm::storage::BitVector maybeStates;         // S_?^j
+    storm::storage::BitVector rewMinusInfEStates;  // S_{-infty}^j
+    std::optional<ValueType> constantInitialStateValue;
+    storm::storage::BitVector relevantZeroRewardChoices;
+    std::map<uint64_t, ValueType> choiceRewards;
+    InfinityCase infinityCase;
+
+    // Computed on demand:
+    mutable std::optional<std::vector<ValueType>> lowerResultBounds;
+    mutable std::optional<std::vector<ValueType>> upperResultBounds;
 
     ModelType const& model;
     Objective<ValueType> const& objective;
 };
-}  // namespace multiobjective
-}  // namespace modelchecker
+}  // namespace modelchecker::multiobjective
 }  // namespace storm

--- a/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsParetoExplorer.cpp
+++ b/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsParetoExplorer.cpp
@@ -302,6 +302,7 @@ DeterministicSchedsParetoExplorer<SparseModelType, GeometryValueType>::Determini
     objectiveHelper.reserve(objectives.size());
     for (auto const& obj : objectives) {
         objectiveHelper.emplace_back(*model, obj);
+        STORM_LOG_ASSERT(!objectiveHelper.back().hasThreshold(), "Unexpected input: got a Pareto query with a thresholded objective.");
     }
     lpChecker = std::make_shared<DeterministicSchedsLpChecker<SparseModelType, GeometryValueType>>(*model, objectiveHelper);
     if (preprocessorResult.containsOnlyTotalRewardFormulas()) {
@@ -309,54 +310,34 @@ DeterministicSchedsParetoExplorer<SparseModelType, GeometryValueType>::Determini
     } else {
         wvChecker = nullptr;
     }
-    if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-        storm::utility::Stopwatch sw(true);
-        std::string modelname = "original-model";
-        std::vector<SparseModelType const*> models;
-        models.push_back(&preprocessorResult.originalModel);
-        models.push_back(model.get());
-        for (SparseModelType const* m : models) {
-            STORM_PRINT_AND_LOG("#STATS " << m->getNumberOfStates() << " states in " << modelname << '\n');
-            STORM_PRINT_AND_LOG("#STATS " << m->getNumberOfChoices() << " choices in " << modelname << '\n');
-            STORM_PRINT_AND_LOG("#STATS " << m->getNumberOfTransitions() << " transitions in " << modelname << '\n');
-            storm::RationalNumber numScheds = storm::utility::one<storm::RationalNumber>();
-            for (uint64_t state = 0; state < m->getNumberOfStates(); ++state) {
-                storm::RationalNumber numChoices = storm::utility::convertNumber<storm::RationalNumber, uint64_t>(m->getNumberOfChoices(state));
-                numScheds *= storm::utility::max(storm::utility::one<storm::RationalNumber>(), numChoices);
-            }
-            auto numSchedsStr = storm::utility::to_string(numScheds);
-            STORM_PRINT_AND_LOG("#STATS " << numSchedsStr.front() << "e" << (numSchedsStr.size() - 1) << " memoryless deterministic schedulers in " << modelname
-                                          << '\n');
-            storm::storage::MaximalEndComponentDecomposition<ModelValueType> mecs(*m);
-            uint64_t nonConstMecCounter = 0;
-            uint64_t nonConstMecStateCounter = 0;
-            for (auto const& mec : mecs) {
-                bool mecHasNonConstValue = false;
-                for (auto const& stateChoices : mec) {
-                    for (auto const& helper : objectiveHelper) {
-                        if (helper.getSchedulerIndependentStateValues().count(stateChoices.first) == 0) {
-                            ++nonConstMecStateCounter;
-                            mecHasNonConstValue = true;
-                            break;
-                        }
-                    }
-                }
-                if (mecHasNonConstValue)
-                    ++nonConstMecCounter;
-            }
-            STORM_PRINT_AND_LOG("#STATS " << nonConstMecCounter << " non-constant MECS in " << modelname << '\n');
-            STORM_PRINT_AND_LOG("#STATS " << nonConstMecStateCounter << " non-constant MEC States in " << modelname << '\n');
-            // Print the same statistics for the unfolded model as well.
-            modelname = "unfolded-model";
-        }
-        sw.stop();
-        STORM_PRINT_AND_LOG("#STATS " << sw << " seconds for computing these statistics.\n");
-    }
+    //    if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
+    //        storm::utility::Stopwatch sw(true);
+    //        STORM_PRINT_AND_LOG("#STATS " << model->getNumberOfStates() << " states in unfolded-model\n");
+    //        STORM_PRINT_AND_LOG("#STATS " << model->getNumberOfChoices() << " choices in unfolded-model\n");
+    //        STORM_PRINT_AND_LOG("#STATS " << model->getNumberOfTransitions() << " transitions in unfolded-model\n");
+    //        double log10numScheds = 0;
+    //        for (uint64_t state = 0; state < model->getNumberOfStates(); ++state) {
+    //            log10numScheds += storm::utility::log10<double>(model->getNumberOfChoices(state));
+    //        }
+    //        STORM_PRINT_AND_LOG("#STATS 10^" << log10numScheds << " memoryless deterministic schedulers in unfolded-model\n");
+    //        storm::storage::MaximalEndComponentDecomposition<ModelValueType> mecs(*model);
+    //        uint64_t mecStates = 0;
+    //        for (auto const& mec : mecs) {
+    //            mecStates += mec.size();
+    //        }
+    //        STORM_PRINT_AND_LOG("#STATS " << mecs.size() << " MECS in unfolded-model\n");
+    //        STORM_PRINT_AND_LOG("#STATS " << mecStates << " MEC States in unfolded-model\n");
+    //        sw.stop();
+    //        STORM_PRINT_AND_LOG("#STATS " << sw << " seconds for computing these statistics.\n");
+    //    }
 }
 
 template<class SparseModelType, typename GeometryValueType>
 std::unique_ptr<CheckResult> DeterministicSchedsParetoExplorer<SparseModelType, GeometryValueType>::check(Environment const& env) {
     clean();
+    for (auto& obj : objectiveHelper) {
+        obj.computeLowerUpperBounds(env);
+    }
     initializeFacets(env);
 
     // Compute the relative precision in each dimension.
@@ -385,7 +366,8 @@ std::unique_ptr<CheckResult> DeterministicSchedsParetoExplorer<SparseModelType, 
                 eps.back() = storm::utility::convertNumber<GeometryValueType>(1e-8);
             }
         }
-        STORM_PRINT_AND_LOG("Relative precision is " << storm::utility::vector::toString(storm::utility::vector::convertNumericVector<double>(eps)) << '\n');
+        STORM_LOG_INFO("Relative precision for deterministic scheduler Pareto explorer is "
+                       << storm::utility::vector::toString(storm::utility::vector::convertNumericVector<double>(eps)) << '\n');
     } else {
         STORM_LOG_THROW(env.modelchecker().multi().getPrecisionType() == MultiObjectiveModelCheckerEnvironment::PrecisionType::Absolute,
                         storm::exceptions::IllegalArgumentException, "Unknown multiobjective precision type.");
@@ -407,12 +389,12 @@ std::unique_ptr<CheckResult> DeterministicSchedsParetoExplorer<SparseModelType, 
                 storm::utility::vector::convertNumericVector<ModelValueType>(transformObjectiveValuesToOriginal(objectives, p.second.get())));
         }
     }
-    if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-        STORM_PRINT_AND_LOG("#STATS " << paretoPoints.size() << " Pareto points\n");
-        STORM_PRINT_AND_LOG("#STATS " << unachievableAreas.size() << " unachievable areas\n");
-        STORM_PRINT_AND_LOG("#STATS " << overApproximation->getHalfspaces().size() << " unachievable halfspaces\n");
-        STORM_PRINT_AND_LOG(lpChecker->getStatistics("#STATS "));
-    }
+    //    if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
+    //        STORM_PRINT_AND_LOG("#STATS " << paretoPoints.size() << " Pareto points\n");
+    //        STORM_PRINT_AND_LOG("#STATS " << unachievableAreas.size() << " unachievable areas\n");
+    //        STORM_PRINT_AND_LOG("#STATS " << overApproximation->getHalfspaces().size() << " unachievable halfspaces\n");
+    //        STORM_PRINT_AND_LOG(lpChecker->getStatistics("#STATS "));
+    //    }
     return std::make_unique<storm::modelchecker::ExplicitParetoCurveCheckResult<ModelValueType>>(originalModelInitialState, std::move(paretoPoints), nullptr,
                                                                                                  nullptr);
 }
@@ -509,21 +491,25 @@ void DeterministicSchedsParetoExplorer<SparseModelType, GeometryValueType>::init
     for (uint64_t objIndex = 0; objIndex < objectives.size(); ++objIndex) {
         std::vector<GeometryValueType> weightVector(objectives.size(), storm::utility::zero<GeometryValueType>());
         weightVector[objIndex] = storm::utility::one<GeometryValueType>();
-        std::vector<GeometryValueType> point;
+        std::vector<GeometryValueType> pointCoord;
+        GeometryValueType offset;
         if (wvChecker) {
             wvChecker->check(env, storm::utility::vector::convertNumericVector<ModelValueType>(weightVector));
-            point = storm::utility::vector::convertNumericVector<GeometryValueType>(wvChecker->getUnderApproximationOfInitialStateResults());
-            negateMinObjectives(point);
+            pointCoord = storm::utility::vector::convertNumericVector<GeometryValueType>(wvChecker->getUnderApproximationOfInitialStateResults());
+            negateMinObjectives(pointCoord);
+            auto upperBoundPoint = storm::utility::vector::convertNumericVector<GeometryValueType>(wvChecker->getOverApproximationOfInitialStateResults());
+            negateMinObjectives(upperBoundPoint);
+            offset = storm::utility::vector::dotProduct(weightVector, upperBoundPoint);
         } else {
             lpChecker->setCurrentWeightVector(env, weightVector);
             auto optionalPoint = lpChecker->check(env, overApproximation);
-            STORM_LOG_THROW(optionalPoint.is_initialized(), storm::exceptions::UnexpectedException, "Unable to find a point in the current overapproximation.");
-            point = std::move(optionalPoint.get());
+            STORM_LOG_THROW(optionalPoint.has_value(), storm::exceptions::UnexpectedException, "Unable to find a point in the current overapproximation.");
+            pointCoord = std::move(optionalPoint->first);
+            offset = std::move(optionalPoint->second);
         }
-        Point p(point);
+        Point p(pointCoord);
         p.setOnFacet();
         // Adapt the overapproximation
-        GeometryValueType offset = storm::utility::vector::dotProduct(weightVector, p.get());
         addHalfspaceToOverApproximation(env, weightVector, offset);
         pointset.addPoint(env, std::move(p));
     }
@@ -549,13 +535,8 @@ template<class SparseModelType, typename GeometryValueType>
 std::vector<GeometryValueType> DeterministicSchedsParetoExplorer<SparseModelType, GeometryValueType>::getReferenceCoordinates(Environment const& env) const {
     std::vector<GeometryValueType> result;
     for (uint64_t objIndex = 0; objIndex < objectives.size(); ++objIndex) {
-        ModelValueType value;
-        if (objectiveHelper[objIndex].minimizing()) {
-            value = -objectiveHelper[objIndex].getUpperValueBoundAtState(env, *model->getInitialStates().begin());
-        } else {
-            value = objectiveHelper[objIndex].getLowerValueBoundAtState(env, *model->getInitialStates().begin());
-        }
-        result.push_back(storm::utility::convertNumber<GeometryValueType>(value));
+        result.push_back(
+            storm::utility::convertNumber<GeometryValueType>(objectiveHelper[objIndex].getLowerValueBoundAtState(*model->getInitialStates().begin())));
     }
     return result;
 }
@@ -605,24 +586,29 @@ template<class SparseModelType, typename GeometryValueType>
 bool DeterministicSchedsParetoExplorer<SparseModelType, GeometryValueType>::optimizeAndSplitFacet(Environment const& env, Facet& f) {
     // Invoke optimization and insert the explored points
     boost::optional<PointId> optPointId;
-    std::vector<GeometryValueType> point;
+    std::vector<GeometryValueType> pointCoord;
+    GeometryValueType offset;
     if (wvChecker) {
         wvChecker->check(env, storm::utility::vector::convertNumericVector<ModelValueType>(f.getHalfspace().normalVector()));
-        point = storm::utility::vector::convertNumericVector<GeometryValueType>(wvChecker->getUnderApproximationOfInitialStateResults());
-        negateMinObjectives(point);
+        pointCoord = storm::utility::vector::convertNumericVector<GeometryValueType>(wvChecker->getUnderApproximationOfInitialStateResults());
+        negateMinObjectives(pointCoord);
+        auto upperBoundPoint = storm::utility::vector::convertNumericVector<GeometryValueType>(wvChecker->getOverApproximationOfInitialStateResults());
+        negateMinObjectives(upperBoundPoint);
+        offset = storm::utility::vector::dotProduct(f.getHalfspace().normalVector(), upperBoundPoint);
     } else {
         auto currentArea = overApproximation->intersection(f.getHalfspace().invert());
-        auto optionalPoint = lpChecker->check(env, currentArea);
-        if (optionalPoint.is_initialized()) {
-            point = std::move(optionalPoint.get());
+        auto optionalPoint = lpChecker->check(env, overApproximation, eps);
+        if (optionalPoint.has_value()) {
+            pointCoord = std::move(optionalPoint->first);
         } else {
             // As we did not find any feasable solution in the given area, we take a point that lies on the facet
-            point = pointset.getPoint(f.getPoints().front()).get();
+            pointCoord = pointset.getPoint(f.getPoints().front()).get();
         }
+        offset = std::move(optionalPoint->second);
     }
-    Point p(point);
+
+    Point p(pointCoord);
     p.setOnFacet();
-    GeometryValueType offset = storm::utility::vector::dotProduct(f.getHalfspace().normalVector(), p.get());
     addHalfspaceToOverApproximation(env, f.getHalfspace().normalVector(), offset);
     optPointId = pointset.addPoint(env, std::move(p));
 

--- a/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsParetoExplorer.cpp
+++ b/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsParetoExplorer.cpp
@@ -310,26 +310,6 @@ DeterministicSchedsParetoExplorer<SparseModelType, GeometryValueType>::Determini
     } else {
         wvChecker = nullptr;
     }
-    //    if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-    //        storm::utility::Stopwatch sw(true);
-    //        STORM_PRINT_AND_LOG("#STATS " << model->getNumberOfStates() << " states in unfolded-model\n");
-    //        STORM_PRINT_AND_LOG("#STATS " << model->getNumberOfChoices() << " choices in unfolded-model\n");
-    //        STORM_PRINT_AND_LOG("#STATS " << model->getNumberOfTransitions() << " transitions in unfolded-model\n");
-    //        double log10numScheds = 0;
-    //        for (uint64_t state = 0; state < model->getNumberOfStates(); ++state) {
-    //            log10numScheds += storm::utility::log10<double>(model->getNumberOfChoices(state));
-    //        }
-    //        STORM_PRINT_AND_LOG("#STATS 10^" << log10numScheds << " memoryless deterministic schedulers in unfolded-model\n");
-    //        storm::storage::MaximalEndComponentDecomposition<ModelValueType> mecs(*model);
-    //        uint64_t mecStates = 0;
-    //        for (auto const& mec : mecs) {
-    //            mecStates += mec.size();
-    //        }
-    //        STORM_PRINT_AND_LOG("#STATS " << mecs.size() << " MECS in unfolded-model\n");
-    //        STORM_PRINT_AND_LOG("#STATS " << mecStates << " MEC States in unfolded-model\n");
-    //        sw.stop();
-    //        STORM_PRINT_AND_LOG("#STATS " << sw << " seconds for computing these statistics.\n");
-    //    }
 }
 
 template<class SparseModelType, typename GeometryValueType>
@@ -389,12 +369,6 @@ std::unique_ptr<CheckResult> DeterministicSchedsParetoExplorer<SparseModelType, 
                 storm::utility::vector::convertNumericVector<ModelValueType>(transformObjectiveValuesToOriginal(objectives, p.second.get())));
         }
     }
-    //    if (storm::settings::getModule<storm::settings::modules::CoreSettings>().isShowStatisticsSet()) {
-    //        STORM_PRINT_AND_LOG("#STATS " << paretoPoints.size() << " Pareto points\n");
-    //        STORM_PRINT_AND_LOG("#STATS " << unachievableAreas.size() << " unachievable areas\n");
-    //        STORM_PRINT_AND_LOG("#STATS " << overApproximation->getHalfspaces().size() << " unachievable halfspaces\n");
-    //        STORM_PRINT_AND_LOG(lpChecker->getStatistics("#STATS "));
-    //    }
     return std::make_unique<storm::modelchecker::ExplicitParetoCurveCheckResult<ModelValueType>>(originalModelInitialState, std::move(paretoPoints), nullptr,
                                                                                                  nullptr);
 }

--- a/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsParetoExplorer.h
+++ b/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsParetoExplorer.h
@@ -21,6 +21,10 @@ class Environment;
 namespace modelchecker {
 namespace multiobjective {
 
+/*!
+ * Implements the exploration of the Pareto front.
+ * @see http://doi.org/10.18154/RWTH-2023-09669 Chapter 8.5
+ */
 template<class SparseModelType, typename GeometryValueType>
 class DeterministicSchedsParetoExplorer {
    public:

--- a/src/storm/modelchecker/multiobjective/deterministicScheds/VisitingTimesHelper.cpp
+++ b/src/storm/modelchecker/multiobjective/deterministicScheds/VisitingTimesHelper.cpp
@@ -1,0 +1,151 @@
+#include "storm/modelchecker/multiobjective/deterministicScheds/VisitingTimesHelper.h"
+
+#include "storm/modelchecker/prctl/helper/BaierUpperRewardBoundsComputer.h"
+#include "storm/storage/MaximalEndComponentDecomposition.h"
+#include "storm/storage/SparseMatrix.h"
+#include "storm/transformer/EndComponentEliminator.h"
+#include "storm/utility/Extremum.h"
+#include "storm/utility/constants.h"
+
+namespace storm::modelchecker::multiobjective {
+
+template<typename ValueType>
+ValueType VisitingTimesHelper<ValueType>::computeMecTraversalLowerBound(storm::storage::MaximalEndComponent const& mec,
+                                                                        storm::storage::SparseMatrix<ValueType> const& transitions,
+                                                                        bool assumeOptimalTransitionProbabilities) {
+    STORM_LOG_ASSERT(mec.size() > 0, "empty mec not expected");
+    auto res = storm::utility::one<ValueType>();
+    if (mec.size() == 1) {
+        return res;
+    }
+    // Whenever s' is reachable from s, there is at least one finite path that visits each state of the mec at most once.
+    // We compute a naive lower bound for the probability of such a single path using the product of the smallest probabilities occurring at each state
+    // (Excluding self-loop probabilities)
+    for (auto const& stateChoices : mec) {
+        storm::utility::Minimum<ValueType> v;
+        auto const& s = stateChoices.first;
+        for (auto const& c : stateChoices.second) {
+            auto row = transitions.getRow(c);
+            if (assumeOptimalTransitionProbabilities) {
+                // Count the number of non-selfloop entries and assume a uniform distribution (which gives us the largest minimal probability)
+                auto numEntries = row.getNumberOfEntries();
+                for (auto const& entry : row) {
+                    if (entry.getColumn() > s) {
+                        if (entry.getColumn() == s) {
+                            --numEntries;
+                        }
+                        break;
+                    }
+                }
+                if (numEntries > 0) {
+                    v &= storm::utility::one<ValueType>() / storm::utility::convertNumber<ValueType>(numEntries);
+                }
+            } else {
+                // actually determine the minimal probability
+                for (auto const& entry : row) {
+                    if (entry.getColumn() != s && !storm::utility::isZero(entry.getValue())) {
+                        v &= entry.getValue();
+                    }
+                }
+            }
+        }
+        STORM_LOG_ASSERT(!v.empty(), "self-loop state in non-singleton mec?");
+        res *= *v;
+    }
+    return res;
+}
+
+template<typename ValueType>
+ValueType VisitingTimesHelper<ValueType>::computeMecVisitsUpperBound(storm::storage::MaximalEndComponent const& mec,
+                                                                     storm::storage::SparseMatrix<ValueType> const& transitions,
+                                                                     bool assumeOptimalTransitionProbabilities) {
+    auto const one = storm::utility::one<ValueType>();
+    auto const l = computeMecTraversalLowerBound(mec, transitions, assumeOptimalTransitionProbabilities);
+    if (assumeOptimalTransitionProbabilities) {
+        // We assume that the probability to go back to the MEC using an exiting choice is zero.
+        return one / l;
+    } else {
+        // compute the largest probability to go back to the MEC when using an exiting choice
+        storm::utility::Maximum<ValueType> q(storm::utility::zero<ValueType>());
+        for (auto const& stateChoices : mec) {
+            for (auto c : transitions.getRowGroupIndices(stateChoices.first)) {
+                if (stateChoices.second.contains(c)) {
+                    continue;  // not an exit choice!
+                }
+                auto choiceValue = storm::utility::zero<ValueType>();
+                for (auto const& entry : transitions.getRow(c)) {
+                    if (mec.containsState(entry.getColumn())) {
+                        choiceValue += entry.getValue();
+                    }
+                }
+                q &= choiceValue;
+            }
+        }
+        return one / (l * (one - *q));
+    }
+}
+
+template<typename ValueType>
+std::vector<ValueType> VisitingTimesHelper<ValueType>::computeUpperBoundsOnExpectedVisitingTimes(
+    storm::storage::BitVector const& subsystem, storm::storage::SparseMatrix<ValueType> const& transitions,
+    storm::storage::SparseMatrix<ValueType> const& backwardTransitions) {
+    storm::storage::MaximalEndComponentDecomposition mecs(transitions, backwardTransitions, subsystem);
+    storm::storage::BitVector allStates(subsystem.size(), true);
+    auto quotientData = storm::transformer::EndComponentEliminator<ValueType>::transform(transitions, mecs, subsystem, subsystem);
+    auto notSubsystem = ~subsystem;
+
+    // map collapsed states in the quotient to the value l that is to be multiplied to the transitions of those states
+    std::map<uint64_t, ValueType> collapsedStateToValueMap;
+    for (auto const& mec : mecs) {
+        collapsedStateToValueMap.emplace(quotientData.oldToNewStateMapping.at(mec.begin()->first), computeMecTraversalLowerBound(mec, transitions));
+    }
+
+    // Create a modified quotient with scaled transitions
+    storm::storage::SparseMatrixBuilder<ValueType> modifiedQuotientBuilder(quotientData.matrix.getRowCount(), quotientData.matrix.getColumnCount(), 0, true,
+                                                                           true, quotientData.matrix.getRowGroupCount());
+    std::vector<ValueType> toSinkProbabilities;
+    toSinkProbabilities.reserve(quotientData.matrix.getRowGroupCount());
+    for (uint64_t state = 0; state < quotientData.matrix.getRowGroupCount(); ++state) {
+        modifiedQuotientBuilder.newRowGroup(quotientData.matrix.getRowGroupIndices()[state]);
+        ValueType scalingFactor = storm::utility::one<ValueType>();
+        if (auto findRes = collapsedStateToValueMap.find(state); findRes != collapsedStateToValueMap.end()) {
+            scalingFactor = findRes->second;
+        }
+        for (auto const choice : quotientData.matrix.getRowGroupIndices(state)) {
+            if (!storm::utility::isOne(scalingFactor)) {
+                modifiedQuotientBuilder.addDiagonalEntry(choice, storm::utility::one<ValueType>() - scalingFactor);
+            }
+            for (auto const& entry : quotientData.matrix.getRow(choice)) {
+                modifiedQuotientBuilder.addNextValue(choice, entry.getColumn(), scalingFactor * entry.getValue());
+            }
+            if (quotientData.sinkRows.get(choice)) {
+                toSinkProbabilities.push_back(scalingFactor);
+            } else {
+                toSinkProbabilities.push_back(scalingFactor * transitions.getConstrainedRowSum(quotientData.newToOldRowMapping.at(choice), notSubsystem));
+            }
+        }
+    }
+    auto modifiedQuotient = modifiedQuotientBuilder.build();
+    STORM_LOG_ASSERT(modifiedQuotient.getRowCount() == toSinkProbabilities.size(), "Unexpected row count");
+
+    // compute upper visiting time bounds
+    auto quotientUpperBounds =
+        storm::modelchecker::helper::BaierUpperRewardBoundsComputer<ValueType>::computeUpperBoundOnExpectedVisitingTimes(modifiedQuotient, toSinkProbabilities);
+
+    std::vector<ValueType> result;
+    result.reserve(subsystem.size());
+    for (uint64_t state = 0; state < subsystem.size(); ++state) {
+        auto const& quotientState = quotientData.oldToNewStateMapping[state];
+        if (quotientState < quotientData.matrix.getRowGroupCount()) {
+            result.push_back(quotientUpperBounds.at(quotientState));
+        } else {
+            result.push_back(-storm::utility::one<ValueType>());  // not in given subsystem;
+        }
+    }
+    return result;
+}
+
+template class VisitingTimesHelper<double>;
+template class VisitingTimesHelper<storm::RationalNumber>;
+
+}  // namespace storm::modelchecker::multiobjective

--- a/src/storm/modelchecker/multiobjective/deterministicScheds/VisitingTimesHelper.cpp
+++ b/src/storm/modelchecker/multiobjective/deterministicScheds/VisitingTimesHelper.cpp
@@ -60,10 +60,10 @@ ValueType VisitingTimesHelper<ValueType>::computeMecVisitsUpperBound(storm::stor
                                                                      storm::storage::SparseMatrix<ValueType> const& transitions,
                                                                      bool assumeOptimalTransitionProbabilities) {
     auto const one = storm::utility::one<ValueType>();
-    auto const l = computeMecTraversalLowerBound(mec, transitions, assumeOptimalTransitionProbabilities);
+    auto const traversalLowerBound = computeMecTraversalLowerBound(mec, transitions, assumeOptimalTransitionProbabilities);
     if (assumeOptimalTransitionProbabilities) {
         // We assume that the probability to go back to the MEC using an exiting choice is zero.
-        return one / l;
+        return one / traversalLowerBound;
     } else {
         // compute the largest probability to go back to the MEC when using an exiting choice
         storm::utility::Maximum<ValueType> q(storm::utility::zero<ValueType>());
@@ -81,7 +81,7 @@ ValueType VisitingTimesHelper<ValueType>::computeMecVisitsUpperBound(storm::stor
                 q &= choiceValue;
             }
         }
-        return one / (l * (one - *q));
+        return one / (traversalLowerBound * (one - *q));
     }
 }
 

--- a/src/storm/modelchecker/multiobjective/deterministicScheds/VisitingTimesHelper.h
+++ b/src/storm/modelchecker/multiobjective/deterministicScheds/VisitingTimesHelper.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <vector>
+
+namespace storm::storage {
+class BitVector;
+class MaximalEndComponent;
+template<typename ValueType>
+class SparseMatrix;
+}  // namespace storm::storage
+
+namespace storm::modelchecker::multiobjective {
+
+/*!
+ * Provides helper functions for computing bounds on the expected visiting times
+ * @see http://doi.org/10.18154/RWTH-2023-09669 Chapter 8.2
+ */
+template<typename ValueType>
+class VisitingTimesHelper {
+   public:
+    /*!
+     * Computes value l in (0,1] such that for any pair of distinct states s,s' and deterministic, memoryless scheduler under which s' is reachable from s we
+     * have that l is a lower bound for the probability that we reach s' from s without visiting s in between.
+     * @param assumeOptimalTransitionProbabilities if true, we assume transitions with the same graph structure (except for selfloops) with uniform distribution
+     */
+    static ValueType computeMecTraversalLowerBound(storm::storage::MaximalEndComponent const& mec, storm::storage::SparseMatrix<ValueType> const& transitions,
+                                                   bool assumeOptimalTransitionProbabilities = false);
+
+    /*!
+     * Computes an upper bound for the largest finite expected number of times a state s in the given MEC is visited without leaving the MEC (under all
+     * deterministic, memoryless scheduler)
+     * @param assumeOptimalTransitionProbabilities if true, we assume transitions with the same graph structure (except for selfloops and MEC exiting choices)
+     with uniform distribution
+
+     */
+    static ValueType computeMecVisitsUpperBound(storm::storage::MaximalEndComponent const& mec, storm::storage::SparseMatrix<ValueType> const& transitions,
+                                                bool assumeOptimalTransitionProbabilities = false);
+
+    /*!
+     * Computes for each state in the given subsystem an upper bound for the maximal finite expected number of visits. Assumes that there is a strategy that
+     * yields finite expected number of visits for each state in the subsystem
+     * @return a vector with the upper bounds. The vector has size subsystem.size() with a -1 in it wherever subsystem is false.
+     */
+    static std::vector<ValueType> computeUpperBoundsOnExpectedVisitingTimes(storm::storage::BitVector const& subsystem,
+                                                                            storm::storage::SparseMatrix<ValueType> const& transitions,
+                                                                            storm::storage::SparseMatrix<ValueType> const& backwardTransitions);
+};
+}  // namespace storm::modelchecker::multiobjective

--- a/src/storm/settings/modules/MultiObjectiveSettings.cpp
+++ b/src/storm/settings/modules/MultiObjectiveSettings.cpp
@@ -76,12 +76,25 @@ MultiObjectiveSettings::MultiObjectiveSettings() : ModuleSettings(moduleName) {
         storm::settings::OptionBuilder(moduleName, printResultsOptionName, true, "Prints intermediate results of the computation to standard output.")
             .setIsAdvanced()
             .build());
-    std::vector<std::string> encodingTypes = {"auto", "classic", "flow"};
-    this->addOption(storm::settings::OptionBuilder(moduleName, encodingOptionName, true, "The preferred type of encoding for constraint-based methods.")
+    this->addOption(storm::settings::OptionBuilder(moduleName, encodingOptionName, true, "The preferred for encoding for constraint-based methods.")
                         .setIsAdvanced()
-                        .addArgument(storm::settings::ArgumentBuilder::createStringArgument("type", "The type.")
+                        .addArgument(storm::settings::ArgumentBuilder::createStringArgument("style", "The main type of encoding.")
                                          .setDefaultValueString("auto")
-                                         .addValidatorString(ArgumentValidatorFactory::createMultipleChoiceValidator(encodingTypes))
+                                         .addValidatorString(ArgumentValidatorFactory::createMultipleChoiceValidator({"auto", "classic", "flow"}))
+                                         .build())
+                        .addArgument(storm::settings::ArgumentBuilder::createStringArgument("constraints", "type of constraints.")
+                                         .setDefaultValueString("bigm")
+                                         .addValidatorString(ArgumentValidatorFactory::createMultipleChoiceValidator({"bigm", "indicator"}))
+                                         .makeOptional()
+                                         .build())
+                        .addArgument(storm::settings::ArgumentBuilder::createStringArgument("bscc", "bscc encoding.")
+                                         .setDefaultValueString("flow")
+                                         .addValidatorString(ArgumentValidatorFactory::createMultipleChoiceValidator({"flow", "order"}))
+                                         .makeOptional()
+                                         .build())
+                        .addArgument(storm::settings::ArgumentBuilder::createBooleanArgument("redundant", "enable redundant bscc constraints.")
+                                         .setDefaultValueBoolean(false)
+                                         .makeOptional()
                                          .build())
                         .build());
 
@@ -171,15 +184,35 @@ bool MultiObjectiveSettings::isPrintResultsSet() const {
 }
 
 bool MultiObjectiveSettings::isClassicEncodingSet() const {
-    return this->getOption(encodingOptionName).getArgumentByName("type").getValueAsString() == "classic";
+    return this->getOption(encodingOptionName).getArgumentByName("style").getValueAsString() == "classic";
 }
 
 bool MultiObjectiveSettings::isFlowEncodingSet() const {
-    return this->getOption(encodingOptionName).getArgumentByName("type").getValueAsString() == "flow";
+    return this->getOption(encodingOptionName).getArgumentByName("style").getValueAsString() == "flow";
 }
 
 bool MultiObjectiveSettings::isAutoEncodingSet() const {
-    return this->getOption(encodingOptionName).getArgumentByName("type").getValueAsString() == "auto";
+    return this->getOption(encodingOptionName).getArgumentByName("style").getValueAsString() == "auto";
+}
+
+bool MultiObjectiveSettings::isBsccDetectionViaFlowConstraintsSet() const {
+    return this->getOption(encodingOptionName).getArgumentByName("bscc").getValueAsString() == "flow";
+}
+
+bool MultiObjectiveSettings::isBsccDetectionViaOrderConstraintsSet() const {
+    return this->getOption(encodingOptionName).getArgumentByName("bscc").getValueAsString() == "order";
+}
+
+bool MultiObjectiveSettings::isBigMConstraintsSet() const {
+    return this->getOption(encodingOptionName).getArgumentByName("constraints").getValueAsString() == "bigm";
+}
+
+bool MultiObjectiveSettings::isIndicatorConstraintsSet() const {
+    return this->getOption(encodingOptionName).getArgumentByName("constraints").getValueAsString() == "indicator";
+}
+
+bool MultiObjectiveSettings::isRedundantBsccConstraintsSet() const {
+    return this->getOption(encodingOptionName).getArgumentByName("redundant").getValueAsBoolean();
 }
 
 bool MultiObjectiveSettings::isLexicographicModelCheckingSet() const {

--- a/src/storm/settings/modules/MultiObjectiveSettings.h
+++ b/src/storm/settings/modules/MultiObjectiveSettings.h
@@ -97,9 +97,34 @@ class MultiObjectiveSettings : public ModuleSettings {
     bool isAutoEncodingSet() const;
 
     /*!
+     * Retrieves whether the encoding for constraint-based methods should use flow constraints for BSCC detection.
+     */
+    bool isBsccDetectionViaFlowConstraintsSet() const;
+
+    /*!
+     * Retrieves whether the encoding for constraint-based methods should use order constraints for BSCC detection.
+     */
+    bool isBsccDetectionViaOrderConstraintsSet() const;
+
+    /*!
+     * Retrieves whether the encoding for constraint-based methods should use BigM constraints
+     */
+    bool isBigMConstraintsSet() const;
+
+    /*!
+     * Retrieves whether the encoding for constraint-based methods should use indicator constraints
+     */
+    bool isIndicatorConstraintsSet() const;
+
+    /*!
      * Retrieves whether lexicographic model checking has been set
      */
     bool isLexicographicModelCheckingSet() const;
+
+    /*!
+     * Retrieves whether redundant BSCC constraints are to be added
+     */
+    bool isRedundantBsccConstraintsSet() const;
 
     /*!
      * Checks whether the settings are consistent. If they are inconsistent, an exception is thrown.

--- a/src/test/storm/modelchecker/multiobjective/MultiObjectiveSchedRestModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/multiobjective/MultiObjectiveSchedRestModelCheckerTest.cpp
@@ -1,76 +1,181 @@
 #include "storm-config.h"
 #include "test/storm_gtest.h"
 
-#include "storm/environment/modelchecker/MultiObjectiveModelCheckerEnvironment.h"
-#include "storm/modelchecker/multiobjective/multiObjectiveModelChecking.h"
-
 #include "storm-parsers/api/storm-parsers.h"
 #include "storm/api/storm.h"
 #include "storm/environment/Environment.h"
+#include "storm/environment/modelchecker/MultiObjectiveModelCheckerEnvironment.h"
 #include "storm/exceptions/InvalidOperationException.h"
+#include "storm/modelchecker/multiobjective/multiObjectiveModelChecking.h"
 #include "storm/modelchecker/results/ExplicitParetoCurveCheckResult.h"
-#include "storm/models/sparse/MarkovAutomaton.h"
+#include "storm/modelchecker/results/ExplicitQualitativeCheckResult.h"
+#include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
 #include "storm/models/sparse/Mdp.h"
-#include "storm/settings/SettingsManager.h"
-#include "storm/settings/modules/GeneralSettings.h"
 #include "storm/storage/SchedulerClass.h"
-#include "storm/storage/jani/Property.h"
 
 #ifdef STORM_HAVE_Z3_OPTIMIZE
 
 namespace {
 
-storm::Environment getPositionalDeterministicEnvironment() {
-    storm::Environment env;
-    env.modelchecker().multi().setSchedulerRestriction(storm::storage::SchedulerClass().setPositional().setIsDeterministic());
-    return env;
-}
-
-storm::Environment getGoalDeterministicEnvironment() {
-    storm::Environment env;
-    env.modelchecker().multi().setSchedulerRestriction(
-        storm::storage::SchedulerClass().setMemoryPattern(storm::storage::SchedulerClass::MemoryPattern::GoalMemory).setIsDeterministic());
-    return env;
-}
-
-typedef std::vector<storm::RationalNumber> Point;
-
-std::vector<Point> parsePoints(std::vector<std::string> const& input) {
-    std::vector<Point> result;
-    for (auto const& i : input) {
-        Point currPoint;
-        std::size_t pos1 = 0;
-        std::size_t pos2 = i.find(",");
-        while (pos2 != std::string::npos) {
-            currPoint.push_back(storm::utility::convertNumber<storm::RationalNumber, std::string>(i.substr(pos1, pos2 - pos1)));
-            pos1 = pos2 + 1;
-            pos2 = i.find(",", pos1);
-        }
-        currPoint.push_back(storm::utility::convertNumber<storm::RationalNumber, std::string>(i.substr(pos1)));
-        result.push_back(currPoint);
+class FlowBigMEnvironment {
+   public:
+    static storm::Environment getEnv() {
+        storm::Environment env;
+        env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow);
+        env.modelchecker().multi().setUseIndicatorConstraints(false);
+        env.modelchecker().multi().setUseBsccOrderEncoding(false);         // not relevant for Flow
+        env.modelchecker().multi().setUseRedundantBsccConstraints(false);  // not relevant for Flow
+        return env;
     }
-    return result;
-}
+};
 
-std::set<Point> setMinus(std::vector<Point> const& lhs, std::vector<Point> const& rhs) {
-    std::set<Point> result(lhs.begin(), lhs.end());
-    for (auto const& r : rhs) {
-        for (auto lIt = result.begin(); lIt != result.end(); ++lIt) {
-            if (*lIt == r) {
-                result.erase(lIt);
-                break;
+class FlowIndicatorEnvironment {
+   public:
+    static storm::Environment getEnv() {
+        storm::Environment env;
+        env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow);
+        env.modelchecker().multi().setUseIndicatorConstraints(true);
+        env.modelchecker().multi().setUseBsccOrderEncoding(false);         // not relevant for Flow
+        env.modelchecker().multi().setUseRedundantBsccConstraints(false);  // not relevant for Flow
+        return env;
+    }
+};
+
+class BigMEnvironment {
+   public:
+    static storm::Environment getEnv() {
+        storm::Environment env;
+        env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
+        env.modelchecker().multi().setUseIndicatorConstraints(false);
+        env.modelchecker().multi().setUseBsccOrderEncoding(false);
+        env.modelchecker().multi().setUseRedundantBsccConstraints(false);
+        return env;
+    }
+};
+
+class IndicatorEnvironment {
+   public:
+    static storm::Environment getEnv() {
+        storm::Environment env;
+        env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
+        env.modelchecker().multi().setUseIndicatorConstraints(true);
+        env.modelchecker().multi().setUseBsccOrderEncoding(false);
+        env.modelchecker().multi().setUseRedundantBsccConstraints(false);
+        return env;
+    }
+};
+
+class BigMOrderEnvironment {
+   public:
+    static storm::Environment getEnv() {
+        storm::Environment env;
+        env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
+        env.modelchecker().multi().setUseIndicatorConstraints(false);
+        env.modelchecker().multi().setUseBsccOrderEncoding(true);
+        env.modelchecker().multi().setUseRedundantBsccConstraints(false);
+        return env;
+    }
+};
+
+class IndicatorOrderEnvironment {
+   public:
+    static storm::Environment getEnv() {
+        storm::Environment env;
+        env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
+        env.modelchecker().multi().setUseIndicatorConstraints(true);
+        env.modelchecker().multi().setUseBsccOrderEncoding(true);
+        env.modelchecker().multi().setUseRedundantBsccConstraints(false);
+        return env;
+    }
+};
+
+class RedundantEnvironment {
+   public:
+    static storm::Environment getEnv() {
+        storm::Environment env;
+        env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
+        env.modelchecker().multi().setUseIndicatorConstraints(false);
+        env.modelchecker().multi().setUseBsccOrderEncoding(false);
+        env.modelchecker().multi().setUseRedundantBsccConstraints(true);
+        return env;
+    }
+};
+
+class RedundantOrderEnvironment {
+   public:
+    static storm::Environment getEnv() {
+        storm::Environment env;
+        env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
+        env.modelchecker().multi().setUseIndicatorConstraints(false);
+        env.modelchecker().multi().setUseBsccOrderEncoding(true);
+        env.modelchecker().multi().setUseRedundantBsccConstraints(true);
+        return env;
+    }
+};
+
+template<typename TestType>
+class MultiObjectiveSchedRestModelCheckerTest : public ::testing::Test {
+   public:
+    typedef storm::RationalNumber ValueType;
+
+    bool isFlowEncoding() const {
+        return TestType::getEnv().modelchecker().multi().getEncodingType() == storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow;
+    }
+
+    storm::Environment getPositionalDeterministicEnvironment() {
+        auto env = TestType::getEnv();
+        env.modelchecker().multi().setSchedulerRestriction(storm::storage::SchedulerClass().setPositional().setIsDeterministic());
+        return env;
+    }
+
+    storm::Environment getGoalDeterministicEnvironment() {
+        auto env = TestType::getEnv();
+        env.modelchecker().multi().setSchedulerRestriction(
+            storm::storage::SchedulerClass().setMemoryPattern(storm::storage::SchedulerClass::MemoryPattern::GoalMemory).setIsDeterministic());
+        return env;
+    }
+
+    typedef std::vector<storm::RationalNumber> Point;
+
+    ValueType parseNumber(std::string const& input) const {
+        return storm::utility::convertNumber<ValueType>(input);
+    }
+
+    std::vector<Point> parsePoints(std::vector<std::string> const& input) {
+        std::vector<Point> result;
+        for (auto const& i : input) {
+            Point currPoint;
+            std::size_t pos1 = 0;
+            std::size_t pos2 = i.find(",");
+            while (pos2 != std::string::npos) {
+                currPoint.push_back(parseNumber(i.substr(pos1, pos2 - pos1)));
+                pos1 = pos2 + 1;
+                pos2 = i.find(",", pos1);
+            }
+            currPoint.push_back(parseNumber(i.substr(pos1)));
+            result.push_back(currPoint);
+        }
+        return result;
+    }
+
+    std::set<Point> setMinus(std::vector<Point> const& lhs, std::vector<Point> const& rhs) {
+        std::set<Point> result(lhs.begin(), lhs.end());
+        for (auto const& r : rhs) {
+            for (auto lIt = result.begin(); lIt != result.end(); ++lIt) {
+                if (*lIt == r) {
+                    result.erase(lIt);
+                    break;
+                }
             }
         }
+        return result;
     }
-    return result;
-}
 
-std::string toString(std::vector<Point> pointset, bool asDouble) {
-    std::stringstream s;
-    for (auto const& p : pointset) {
+    std::string toString(Point point, bool asDouble) {
+        std::stringstream s;
         s << "[";
         bool first = true;
-        for (auto const& pi : p) {
+        for (auto const& pi : point) {
             if (first) {
                 first = false;
             } else {
@@ -82,187 +187,198 @@ std::string toString(std::vector<Point> pointset, bool asDouble) {
                 s << pi;
             }
         }
-        s << "]\n";
+        s << "]";
+        return s.str();
     }
-    return s.str();
-}
 
-TEST(MultiObjectiveSchedRestModelCheckerTest, steps) {
+    std::string getDiffString(std::vector<Point> const& expected, std::vector<Point> const& actual) {
+        std::stringstream stream;
+        stream << "Unexpected set of Points:\n";
+        stream << "    Expected  |  Actual  |  Point\n";
+        for (auto const& p : expected) {
+            if (std::find(actual.begin(), actual.end(), p) != actual.end()) {
+                stream << "       yes    |   yes    |  " << toString(p, true) << "\n";
+            } else {
+                stream << " -->   yes    |   no     |  " << toString(p, true) << "\n";
+            }
+        }
+        for (auto const& p : actual) {
+            if (std::find(expected.begin(), expected.end(), p) == expected.end()) {
+                stream << " -->   no     |   yes    |  " << toString(p, true) << "\n";
+            }
+        }
+        return stream.str();
+    }
+
+    bool isSame(std::vector<Point> const& expected, std::vector<Point> const& actual, std::string& diffString) {
+        if (expected.size() != actual.size()) {
+            diffString = getDiffString(expected, actual);
+            return false;
+        }
+        for (auto const& p : expected) {
+            if (std::find(actual.begin(), actual.end(), p) == actual.end()) {
+                diffString = getDiffString(expected, actual);
+                return false;
+            }
+        }
+        diffString = "";
+        return true;
+    }
+
+    template<typename SparseModelType>
+    bool testParetoFormula(storm::Environment const& env, SparseModelType const& model, storm::logic::Formula const& formula,
+                           std::vector<Point> const& expected, std::string& errorString) {
+        auto result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *model, formula.asMultiObjectiveFormula());
+        if (!result->isParetoCurveCheckResult()) {
+            errorString = "Not a ParetoCurveCheckResult";
+            return false;
+        }
+        return isSame(expected, result->template asExplicitParetoCurveCheckResult<ValueType>().getPoints(), errorString);
+    }
+};
+
+typedef ::testing::Types<FlowBigMEnvironment, FlowIndicatorEnvironment, BigMEnvironment, IndicatorEnvironment, BigMOrderEnvironment, IndicatorOrderEnvironment,
+                         RedundantEnvironment, RedundantOrderEnvironment>
+    TestingTypes;
+
+TYPED_TEST_SUITE(MultiObjectiveSchedRestModelCheckerTest, TestingTypes, );
+
+TYPED_TEST(MultiObjectiveSchedRestModelCheckerTest, steps) {
+    typedef typename TestFixture::ValueType ValueType;
+    typedef typename TestFixture::Point Point;
+
     std::string programFile = STORM_TEST_RESOURCES_DIR "/mdp/multiobj_stairs.nm";
     std::string constantsString = "N=3";
-    std::string formulasAsString = "multi(Pmax=? [ F y=1], Pmax=? [ F y=2 ])";
+    std::string formulasAsString = "multi(Pmax=? [ F y=1], Pmax=? [ F y=2 ]);";
+    formulasAsString += "multi(P>=0.375 [ F y=1], Pmax>=0.5 [ F y=2 ]);";
+    formulasAsString += "multi(P>=0.4 [ F y=1], Pmax>=0.4 [ F y=2 ]);";
+    formulasAsString += "multi(Pmax=? [ F y=1], Pmax>=0.4 [ F y=2 ]);";
+    formulasAsString += "multi(Pmax=? [ F y=1], Pmax>=0.9 [ F y=2 ]);";
 
     // programm, model, formula
     storm::prism::Program program = storm::api::parseProgram(programFile);
     program = storm::utility::prism::preprocess(program, constantsString);
     std::vector<std::shared_ptr<storm::logic::Formula const>> formulas =
         storm::api::extractFormulasFromProperties(storm::api::parsePropertiesForPrismProgram(formulasAsString, program));
-    std::shared_ptr<storm::models::sparse::Mdp<storm::RationalNumber>> mdp =
-        storm::api::buildSparseModel<storm::RationalNumber>(program, formulas)->as<storm::models::sparse::Mdp<storm::RationalNumber>>();
-    std::vector<Point> expected, actual;
-    std::set<Point> incorrectPoints, missingPoints;
-    std::unique_ptr<storm::modelchecker::CheckResult> result;
+    std::shared_ptr<storm::models::sparse::Mdp<ValueType>> mdp =
+        storm::api::buildSparseModel<ValueType>(program, formulas)->template as<storm::models::sparse::Mdp<ValueType>>();
+    std::string errorString;  // storage for error reporting
 
-    storm::Environment env = getPositionalDeterministicEnvironment();
-
-    expected = parsePoints({"0.875,0", "0,0.875", "0.125,0.75", "0.25,0.625", "0.375,0.5", "0.5,0.375", "0.625,0.25", "0.75,0.125"});
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[0]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[0]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
+    storm::Environment env = this->getPositionalDeterministicEnvironment();
+    uint64_t formulaIndex = 0;
+    {
+        auto expected = this->parsePoints({"0.875,0", "0,0.875", "0.125,0.75", "0.25,0.625", "0.375,0.5", "0.5,0.375", "0.625,0.25", "0.75,0.125"});
+        EXPECT_TRUE(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString)) << errorString;
+    }
+    ++formulaIndex;
+    {
+        auto result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
+        ASSERT_TRUE(result->isExplicitQualitativeCheckResult());
+        EXPECT_TRUE(result->asExplicitQualitativeCheckResult()[*mdp->getInitialStates().begin()]);
+    }
+    ++formulaIndex;
+    {
+        auto result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
+        ASSERT_TRUE(result->isExplicitQualitativeCheckResult());
+        EXPECT_FALSE(result->asExplicitQualitativeCheckResult()[*mdp->getInitialStates().begin()]);
+    }
+    ++formulaIndex;
+    {
+        auto result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
+        ASSERT_TRUE(result->isExplicitQuantitativeCheckResult());
+        auto expected = storm::utility::convertNumber<ValueType, std::string>("0.375");
+        EXPECT_EQ(result->template asExplicitQuantitativeCheckResult<ValueType>()[*mdp->getInitialStates().begin()], expected);
+    }
+    ++formulaIndex;
+    {
+        auto result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
+        ASSERT_TRUE(result->isExplicitQualitativeCheckResult());
+        EXPECT_FALSE(result->asExplicitQualitativeCheckResult()[*mdp->getInitialStates().begin()]);
+    }
 }
 
-TEST(MultiObjectiveSchedRestModelCheckerTest, mecs) {
+TYPED_TEST(MultiObjectiveSchedRestModelCheckerTest, mecs) {
+    typedef typename TestFixture::ValueType ValueType;
+    typedef typename TestFixture::Point Point;
     std::string programFile = STORM_TEST_RESOURCES_DIR "/mdp/multiobj_mecs.nm";
     std::string constantsString = "";
     std::string formulasAsString = "multi(Pmin=? [ F x=3], Pmax=? [ F x=4 ]);";
     formulasAsString += "\nmulti(R{\"test\"}min=? [C], Pmin=? [F \"t1\"]);";
     formulasAsString += "\nmulti(R{\"test\"}min=? [C], Pmin=? [F \"t2\"]);";
     formulasAsString += "\nmulti(R{\"test\"}min=? [C], Pmin=? [F \"t2\"], Pmax=? [F \"t1\"]);";
+    formulasAsString += "\nmulti(R{\"test\"}<=0 [C], P<=1 [F \"t2\"], P>=0 [F \"t1\"]);";
+    formulasAsString += "\nmulti(R{\"test\"}<=1 [C], P<=1 [F \"t2\"], P>=0.1 [F \"t1\"]);";
     // programm, model, formula
     storm::prism::Program program = storm::api::parseProgram(programFile);
     program = storm::utility::prism::preprocess(program, constantsString);
     std::vector<std::shared_ptr<storm::logic::Formula const>> formulas =
         storm::api::extractFormulasFromProperties(storm::api::parsePropertiesForPrismProgram(formulasAsString, program));
-    std::shared_ptr<storm::models::sparse::Mdp<storm::RationalNumber>> mdp =
-        storm::api::buildSparseModel<storm::RationalNumber>(program, formulas)->as<storm::models::sparse::Mdp<storm::RationalNumber>>();
-    std::vector<Point> expected, actual;
-    std::set<Point> incorrectPoints, missingPoints;
-    std::unique_ptr<storm::modelchecker::CheckResult> result;
+    std::shared_ptr<storm::models::sparse::Mdp<ValueType>> mdp =
+        storm::api::buildSparseModel<ValueType>(program, formulas)->template as<storm::models::sparse::Mdp<ValueType>>();
+    std::string errorString;  // storage for error reporting
+    std::vector<Point> expected;
 
-    storm::Environment env = getPositionalDeterministicEnvironment();
+    storm::Environment env = this->getPositionalDeterministicEnvironment();
 
     uint64_t formulaIndex = 0;
-    expected = parsePoints({"0.5,0.5", "1,1"});
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow);
-    STORM_SILENT_EXPECT_THROW(
-        storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula()),
-        storm::exceptions::InvalidOperationException);
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
+    expected = this->parsePoints({"0.5,0.5", "1,1"});
+    if (this->isFlowEncoding()) {
+        STORM_SILENT_EXPECT_THROW(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString),
+                                  storm::exceptions::InvalidOperationException);
+    } else {
+        EXPECT_TRUE(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString)) << errorString;
+    }
 
     ++formulaIndex;
-    expected = parsePoints({"0,0"});
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow);
-
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
+    expected = this->parsePoints({"0,0"});
+    EXPECT_TRUE(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString)) << errorString;
 
     ++formulaIndex;
-    expected = parsePoints({"0,1"});
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow);
-    STORM_SILENT_EXPECT_THROW(
-        storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula()),
-        storm::exceptions::InvalidOperationException);
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
+    expected = this->parsePoints({"0,1"});
+    if (this->isFlowEncoding()) {
+        STORM_SILENT_EXPECT_THROW(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString),
+                                  storm::exceptions::InvalidOperationException);
+    } else {
+        EXPECT_TRUE(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString)) << errorString;
+    }
 
     ++formulaIndex;
-    expected = parsePoints({"0,1,0", "2,1,1"});
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow);
-    STORM_SILENT_EXPECT_THROW(
-        storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula()),
-        storm::exceptions::InvalidOperationException);
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
+    expected = this->parsePoints({"0,1,0", "2,1,1"});
+    if (this->isFlowEncoding()) {
+        STORM_SILENT_EXPECT_THROW(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString),
+                                  storm::exceptions::InvalidOperationException);
+    } else {
+        EXPECT_TRUE(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString)) << errorString;
+    }
+    ++formulaIndex;
+    {
+        if (this->isFlowEncoding()) {
+            STORM_SILENT_EXPECT_THROW(
+                storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula()),
+                storm::exceptions::InvalidOperationException);
+        } else {
+            auto result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
+            ASSERT_TRUE(result->isExplicitQualitativeCheckResult());
+            EXPECT_TRUE(result->asExplicitQualitativeCheckResult()[*mdp->getInitialStates().begin()]);
+        }
+    }
+    ++formulaIndex;
+    {
+        if (this->isFlowEncoding()) {
+            STORM_SILENT_EXPECT_THROW(
+                storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula()),
+                storm::exceptions::InvalidOperationException);
+        } else {
+            auto result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
+            ASSERT_TRUE(result->isExplicitQualitativeCheckResult());
+            EXPECT_FALSE(result->asExplicitQualitativeCheckResult()[*mdp->getInitialStates().begin()]);
+        }
+    }
 }
 
-TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
+TYPED_TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
+    typedef typename TestFixture::ValueType ValueType;
+    typedef typename TestFixture::Point Point;
     std::string programFile = STORM_TEST_RESOURCES_DIR "/mdp/multiobj_compromise.nm";
     std::string constantsString = "";
     std::string formulasAsString = "multi(Pmax=? [ F x=1], Pmax=? [ F x=2 ]);";
@@ -274,260 +390,92 @@ TEST(MultiObjectiveSchedRestModelCheckerTest, compromise) {
     program = storm::utility::prism::preprocess(program, constantsString);
     std::vector<std::shared_ptr<storm::logic::Formula const>> formulas =
         storm::api::extractFormulasFromProperties(storm::api::parsePropertiesForPrismProgram(formulasAsString, program));
-    std::shared_ptr<storm::models::sparse::Mdp<storm::RationalNumber>> mdp =
-        storm::api::buildSparseModel<storm::RationalNumber>(program, formulas)->as<storm::models::sparse::Mdp<storm::RationalNumber>>();
-    std::vector<Point> expected, actual;
-    std::set<Point> incorrectPoints, missingPoints;
-    std::unique_ptr<storm::modelchecker::CheckResult> result;
+    std::shared_ptr<storm::models::sparse::Mdp<ValueType>> mdp =
+        storm::api::buildSparseModel<ValueType>(program, formulas)->template as<storm::models::sparse::Mdp<ValueType>>();
+    std::string errorString;  // storage for error reporting
+    std::vector<Point> expected;
 
-    storm::Environment env = getPositionalDeterministicEnvironment();
+    storm::Environment env = this->getPositionalDeterministicEnvironment();
 
     uint64_t formulaIndex = 0;
-    expected = parsePoints({"1,0", "0,1", "0.3,3/7"});
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow);
-    STORM_SILENT_EXPECT_THROW(
-        storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula()),
-        storm::exceptions::InvalidOperationException);
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
+    expected = this->parsePoints({"1,0", "0,1", "0.3,3/7"});
+    if (this->isFlowEncoding()) {
+        STORM_SILENT_EXPECT_THROW(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString),
+                                  storm::exceptions::InvalidOperationException);
+    } else {
+        EXPECT_TRUE(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString)) << errorString;
+    }
 
     ++formulaIndex;
-    expected = parsePoints({"0,0.3", "2,1"});
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
+    expected = this->parsePoints({"0,0.3", "2,1"});
+    EXPECT_TRUE(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString)) << errorString;
 
     ++formulaIndex;
-    expected = parsePoints({"1,0,0", "0,1,0", "0.3,3/7,4/7"});
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow);
-    STORM_SILENT_EXPECT_THROW(
-        storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula()),
-        storm::exceptions::InvalidOperationException);
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
+    expected = this->parsePoints({"1,0,0", "0,1,0", "0.3,3/7,4/7"});
+    if (this->isFlowEncoding()) {
+        STORM_SILENT_EXPECT_THROW(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString),
+                                  storm::exceptions::InvalidOperationException);
+    } else {
+        EXPECT_TRUE(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString)) << errorString;
+    }
 
     ++formulaIndex;
-    expected = parsePoints({"0,1,0", "0,3/7,4/7"});
+    expected = this->parsePoints({"0,1,0", "0,3/7,4/7"});
+    EXPECT_TRUE(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString)) << errorString;
 
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-
-    env = getGoalDeterministicEnvironment();
+    env = this->getGoalDeterministicEnvironment();
 
     formulaIndex = 0;
-    expected = parsePoints({"1,1"});
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
+    expected = this->parsePoints({"1,1"});
+    EXPECT_TRUE(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString)) << errorString;
 
     ++formulaIndex;
-    expected = parsePoints({"0,0.3", "2,1"});
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
+    expected = this->parsePoints({"0,0.3", "2,1"});
+    EXPECT_TRUE(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString)) << errorString;
 
     ++formulaIndex;
-    expected = parsePoints({"1,1,0", "1,3/7,4/7"});
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
+    expected = this->parsePoints({"1,1,0", "1,3/7,4/7"});
+    EXPECT_TRUE(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString)) << errorString;
 
     ++formulaIndex;
-    expected = parsePoints({"0,1,0", "0,3/7,4/7"});
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Flow);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-
-    env.modelchecker().multi().setEncodingType(storm::MultiObjectiveModelCheckerEnvironment::EncodingType::Classic);
-    result = storm::modelchecker::multiobjective::performMultiObjectiveModelChecking(env, *mdp, formulas[formulaIndex]->asMultiObjectiveFormula());
-    ASSERT_TRUE(result->isParetoCurveCheckResult());
-    actual = result->asExplicitParetoCurveCheckResult<storm::RationalNumber>().getPoints();
-    missingPoints = setMinus(expected, actual);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the expected solution are missing:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
-    incorrectPoints = setMinus(actual, expected);
-    EXPECT_TRUE(incorrectPoints.empty()) << "Some points of the returned solution are not expected:\n"
-                                         << "Expected:\n"
-                                         << toString(expected, true) << "Actual:\n"
-                                         << toString(actual, true);
+    expected = this->parsePoints({"0,1,0", "0,3/7,4/7"});
+    EXPECT_TRUE(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString)) << errorString;
 }
+
+TYPED_TEST(MultiObjectiveSchedRestModelCheckerTest, infrew) {
+    typedef typename TestFixture::ValueType ValueType;
+    typedef typename TestFixture::Point Point;
+    std::string programFile = STORM_TEST_RESOURCES_DIR "/mdp/multiobj_infrew.nm";
+    std::string constantsString = "";
+    std::string formulasAsString = "multi(R{\"one\"}min=? [ F x=2], R{\"two\"}min=? [ C ]);";
+    // programm, model, formula
+    storm::prism::Program program = storm::api::parseProgram(programFile);
+    program = storm::utility::prism::preprocess(program, constantsString);
+    std::vector<std::shared_ptr<storm::logic::Formula const>> formulas =
+        storm::api::extractFormulasFromProperties(storm::api::parsePropertiesForPrismProgram(formulasAsString, program));
+    std::shared_ptr<storm::models::sparse::Mdp<ValueType>> mdp =
+        storm::api::buildSparseModel<ValueType>(program, formulas)->template as<storm::models::sparse::Mdp<ValueType>>();
+    std::string errorString;  // storage for error reporting
+    std::vector<Point> expected;
+
+    storm::Environment env = this->getPositionalDeterministicEnvironment();
+
+    uint64_t formulaIndex = 0;
+    expected = this->parsePoints({"10,1"});
+    if (this->isFlowEncoding()) {
+        STORM_SILENT_EXPECT_THROW(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString),
+                                  storm::exceptions::InvalidOperationException);
+    } else {
+        EXPECT_TRUE(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString)) << errorString;
+    }
+
+    env = this->getGoalDeterministicEnvironment();
+
+    formulaIndex = 0;
+    expected = this->parsePoints({"0,1"});
+    EXPECT_TRUE(this->testParetoFormula(env, mdp, *formulas[formulaIndex], expected, errorString)) << errorString;
+}
+
 }  // namespace
 
-#endif /* STORM_HAVE_Z3_OPTIMIZE */
+#endif /* defined STORM_HAVE_Z3_OPTIMIZE */


### PR DESCRIPTION
This is a revision of the corresponding LP encoding as presented in [Chapter 8 of my PhD Thesis](http://doi.org/10.18154/RWTH-2023-09669).

Also adds support for (qualitative and quantitative (aka numerical)) achievability queries.

I'm piggybacking support for gurobi version 11 here.

I still want to add a few tests for the new achievability functionality before this is ready to be merged.
