### PR TITLE
bugfix in overlapping guards analysis

### DIFF
--- a/src/storm/storage/prism/OverlappingGuardAnalyser.cpp
+++ b/src/storm/storage/prism/OverlappingGuardAnalyser.cpp
@@ -11,7 +11,10 @@ OverlappingGuardAnalyser::OverlappingGuardAnalyser(Program const& program, std::
 
 bool OverlappingGuardAnalyser::hasModuleWithInnerActionOverlap() {
     if (!initializedWithStateConstraints) {
-        smtSolver->add(storm::expressions::conjunction((program.getAllRangeExpressions())));
+        std::vector<storm::expressions::Expression> expressions = program.getAllRangeExpressions();
+        if (!expressions.empty()) {
+            smtSolver->add(storm::expressions::conjunction(expressions));
+        }
     }
 
     for (auto const& module : program.getModules()) {


### PR DESCRIPTION
TQ rightfully pointed out that this should not be part of the huge interval commit..


Regarding content: The conjunction is not defined on empty sets. This fixes the issue. 