### PR TITLE
prism program ops improvements and potential to update initial states

### DIFF
--- a/src/storm/generator/PrismNextStateGenerator.cpp
+++ b/src/storm/generator/PrismNextStateGenerator.cpp
@@ -183,7 +183,7 @@ std::vector<StateType> PrismNextStateGenerator<ValueType, StateType>::getInitial
     std::vector<StateType> initialStateIndices;
 
     // If all states are initial, we can simplify the enumeration substantially.
-    if (program.hasInitialConstruct() && program.getInitialConstruct().getInitialStatesExpression().isTrue()) {
+    if (program.hasInitialConstruct() && program.getInitialStatesExpression().isTrue()) {
         // Create vectors holding all possible values
         std::vector<std::vector<uint64_t>> allValues;
         for (auto const& intVar : this->variableInformation.integerVariables) {

--- a/src/storm/storage/prism/Constant.cpp
+++ b/src/storm/storage/prism/Constant.cpp
@@ -58,5 +58,9 @@ std::ostream& operator<<(std::ostream& stream, Constant const& constant) {
     stream << ";";
     return stream;
 }
+
+bool operator==(Constant const& lhs, Constant const& rhs) {
+    return (lhs.getExpressionVariable() == rhs.getExpressionVariable()) && (lhs.getExpression().isSyntacticallyEqual(rhs.getExpression()));
+}
 }  // namespace prism
 }  // namespace storm

--- a/src/storm/storage/prism/Constant.h
+++ b/src/storm/storage/prism/Constant.h
@@ -1,12 +1,10 @@
-#ifndef STORM_STORAGE_PRISM_CONSTANT_H_
-#define STORM_STORAGE_PRISM_CONSTANT_H_
+#pragma once
 
 #include <map>
 
 #include "storm/storage/expressions/Expression.h"
 #include "storm/storage/expressions/Variable.h"
 #include "storm/storage/prism/LocatedInformation.h"
-#include "storm/utility/OsDetection.h"
 
 namespace storm {
 namespace prism {
@@ -91,7 +89,8 @@ class Constant : public LocatedInformation {
     // The expression that defines the constant (in case it is defined).
     storm::expressions::Expression expression;
 };
+
+bool operator==(Constant const& lhs, Constant const& rhs);
+
 }  // namespace prism
 }  // namespace storm
-
-#endif /* STORM_STORAGE_PRISM_CONSTANT_H_ */

--- a/src/storm/storage/prism/Program.cpp
+++ b/src/storm/storage/prism/Program.cpp
@@ -652,6 +652,11 @@ boost::optional<InitialConstruct> const& Program::getOptionalInitialConstruct() 
     return this->initialConstruct;
 }
 
+void Program::updateInitialStatesExpression(expressions::Expression const& newExpression) {
+    STORM_LOG_THROW(hasInitialConstruct(), exceptions::InvalidOperationException, "We can only update the initial construct, if it already exists.");
+    this->initialConstruct = boost::make_optional(InitialConstruct(newExpression));
+}
+
 storm::expressions::Expression Program::getInitialStatesExpression() const {
     // If there is an initial construct, return its expression. If not, we construct the expression from the
     // initial values of the variables (which have to exist).
@@ -1202,9 +1207,10 @@ Program Program::replaceConstantByVariable(Constant const& c, expressions::Expre
     std::vector<BooleanVariable> newBooleanVariables = globalBooleanVariables;
     std::vector<IntegerVariable> newIntegerVariables = globalIntegerVariables;
     std::vector<Constant> newConstants = constants;
-    std::remove_if(newConstants.begin(), newConstants.end(),
-                   [&](const auto& item) -> bool { return item.getExpressionVariable() == c.getExpressionVariable(); });
-
+    auto newEnd = std::remove(newConstants.begin(), newConstants.end(), c);
+    newConstants.erase(newEnd, newConstants.end());  // Erase is necessary based on Erase-remove idiom
+    // The following throw is moved here as this is cheaper.
+    STORM_LOG_THROW(newConstants.size() == constants.size() - 1, exceptions::InvalidArgumentException, "Can only replace a constant if it is present.");
     if (c.getType().isBooleanType()) {
         newBooleanVariables.emplace_back(c.getExpressionVariable(), c.getExpression(), observable);
     } else {

--- a/src/storm/storage/prism/Program.h
+++ b/src/storm/storage/prism/Program.h
@@ -380,23 +380,15 @@ class Program : public LocatedInformation {
     std::map<std::string, uint_fast64_t> const& getActionNameToIndexMapping() const;
 
     /*!
+     * Sets a new initial states expression.
+     * May only be called if the program already has an initial states expression.
+     */
+    void updateInitialStatesExpression(expressions::Expression const& newExpression);
+
+    /*!
      * Retrieves whether the program specifies an initial construct.
      */
     bool hasInitialConstruct() const;
-
-    /*!
-     * Retrieves the initial construct of the program.
-     *
-     * @return The initial construct of the program.
-     */
-    InitialConstruct const& getInitialConstruct() const;
-
-    /*!
-     * Retrieves an optional containing the initial construct of the program if there is any and nothing otherwise.
-     *
-     * @return The initial construct of the program.
-     */
-    boost::optional<InitialConstruct> const& getOptionalInitialConstruct() const;
 
     /*!
      * Retrieves an expression characterizing the initial states.
@@ -779,6 +771,20 @@ class Program : public LocatedInformation {
     storm::storage::BitVector const& getPossiblySynchronizingCommands() const;
 
    private:
+    /*!
+     * Retrieves the initial construct of the program.
+     *
+     * @return The initial construct of the program.
+     */
+    InitialConstruct const& getInitialConstruct() const;
+
+    /*!
+     * Retrieves an optional containing the initial construct of the program if there is any and nothing otherwise.
+     *
+     * @return The initial construct of the program.
+     */
+    boost::optional<InitialConstruct> const& getOptionalInitialConstruct() const;
+
     /*!
      * This function builds a command that corresponds to the synchronization of the given list of commands.
      *

--- a/src/storm/storage/prism/ToJaniConverter.cpp
+++ b/src/storm/storage/prism/ToJaniConverter.cpp
@@ -250,9 +250,9 @@ storm::jani::Model ToJaniConverter::convert(storm::prism::Program const& program
 
     // Create an initial state restriction if there was an initial construct in the program.
     if (program.hasInitialConstruct()) {
-        janiModel.setInitialStatesRestriction(program.getInitialConstruct().getInitialStatesExpression());
+        janiModel.setInitialStatesRestriction(program.getInitialStatesExpression());
         // Variables in the initial state expression should be made global
-        std::set<storm::expressions::Variable> variables = program.getInitialConstruct().getInitialStatesExpression().getVariables();
+        std::set<storm::expressions::Variable> variables = program.getInitialStatesExpression().getVariables();
         for (auto const& variable : variables) {
             if (formulaToFunctionCallMap.count(variable) > 0) {
                 for (auto const& funVar : formulaToFunctionCallMap[variable].getVariables()) {


### PR DESCRIPTION
- Initial construct does not need to be exposed to the outside world. Makes the API tiny bit easier.
- Comparing two constants is helpful 
- Erase & Remove idiom correctly applied
- Updating initial state expression is helpful for programmatically changing the initial state.