### PR TITLE
Fixed warnings for comparisons in tests

### DIFF
--- a/src/test/storm-pomdp/api/BeliefExplorationAPITest.cpp
+++ b/src/test/storm-pomdp/api/BeliefExplorationAPITest.cpp
@@ -102,7 +102,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple_Pmin) {
     ValueType expected = this->parseNumber("3/10");
     EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
 
-    EXPECT_EQ(1, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
+    EXPECT_EQ(1ul, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::extractSchedulerAsMarkovChain<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 0));
     EXPECT_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 1), std::out_of_range);
@@ -118,7 +118,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple_slippery_Pmax) {
     ValueType expected = this->parseNumber("7/10");
     EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
 
-    EXPECT_EQ(1, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
+    EXPECT_EQ(1ul, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::extractSchedulerAsMarkovChain<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 0));
     EXPECT_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 1), std::out_of_range);
@@ -134,7 +134,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple_slippery_Pmin) {
     ValueType expected = this->parseNumber("3/10");
     EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
 
-    EXPECT_EQ(1, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
+    EXPECT_EQ(1ul, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
 
     EXPECT_NO_THROW(storm::pomdp::api::extractSchedulerAsMarkovChain<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 0));
@@ -151,7 +151,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple_Rmax) {
     ValueType expected = this->parseNumber("29/50");
     EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
 
-    EXPECT_EQ(1, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
+    EXPECT_EQ(1ul, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::extractSchedulerAsMarkovChain<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 0));
     EXPECT_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 1), std::out_of_range);
@@ -167,7 +167,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple_Rmin) {
     ValueType expected = this->parseNumber("19/50");
     EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
 
-    EXPECT_EQ(1, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
+    EXPECT_EQ(1ul, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::extractSchedulerAsMarkovChain<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 0));
     EXPECT_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 1), std::out_of_range);
@@ -183,7 +183,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple_slippery_Rmax) {
     ValueType expected = this->parseNumber("29/30");
     EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
 
-    EXPECT_EQ(1, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
+    EXPECT_EQ(1ul, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::extractSchedulerAsMarkovChain<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 0));
     EXPECT_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 5), std::out_of_range);
@@ -199,7 +199,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple_slippery_Rmin) {
     ValueType expected = this->parseNumber("19/30");
     EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
 
-    EXPECT_EQ(1, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
+    EXPECT_EQ(1ul, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::extractSchedulerAsMarkovChain<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 0));
     EXPECT_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 5), std::out_of_range);
@@ -215,7 +215,7 @@ TYPED_TEST(BeliefExplorationAPITest, maze2_Rmin) {
     ValueType expected = this->parseNumber("74/91");
     EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
 
-    EXPECT_EQ(1, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
+    EXPECT_EQ(1ul, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::extractSchedulerAsMarkovChain<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 0));
     EXPECT_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 1), std::out_of_range);
@@ -231,7 +231,7 @@ TYPED_TEST(BeliefExplorationAPITest, maze2_slippery_Rmin) {
     ValueType expected = this->parseNumber("80/91");
     EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
 
-    EXPECT_EQ(1, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
+    EXPECT_EQ(1ul, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::extractSchedulerAsMarkovChain<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 0));
     EXPECT_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 1), std::out_of_range);
@@ -247,7 +247,7 @@ TYPED_TEST(BeliefExplorationAPITest, refuel_Pmax) {
     ValueType expected = this->parseNumber("38/155");
     EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
 
-    EXPECT_EQ(2, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
+    EXPECT_EQ(2ul, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::extractSchedulerAsMarkovChain<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 0));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 1));
@@ -264,7 +264,7 @@ TYPED_TEST(BeliefExplorationAPITest, refuel_Pmin) {
     ValueType expected = this->parseNumber("0");
     EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
 
-    EXPECT_EQ(1, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
+    EXPECT_EQ(1ul, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::extractSchedulerAsMarkovChain<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 0));
     EXPECT_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 1), std::out_of_range);
@@ -280,7 +280,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple2_Rmax) {
     ValueType expected = this->parseNumber("59040588757/103747000000");
     EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
 
-    EXPECT_EQ(2, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
+    EXPECT_EQ(2ul, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::extractSchedulerAsMarkovChain<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 0));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result, 1));


### PR DESCRIPTION
Mostly `1` -> `1ul`