### PR TITLE
Removed warnings in tests

### DIFF
--- a/src/storm-dft/transformations/SftToBddTransformator.h
+++ b/src/storm-dft/transformations/SftToBddTransformator.h
@@ -150,14 +150,14 @@ class SftToBddTransformator {
         if (gate->type() == storm::dft::storage::elements::DFTElementType::AND) {
             // used only in conjunctions therefore neutral element -> 1
             auto tmpBdd{sylvanBddManager->getOne()};
-            for (const std::shared_ptr<storm::dft::storage::elements::DFTElement<ValueType> const>& child : gate->children()) {
+            for (auto const& child : gate->children()) {
                 tmpBdd &= translate(child);
             }
             return tmpBdd;
         } else if (gate->type() == storm::dft::storage::elements::DFTElementType::OR) {
             // used only in disjunctions therefore neutral element -> 0
             auto tmpBdd{sylvanBddManager->getZero()};
-            for (const std::shared_ptr<storm::dft::storage::elements::DFTElement<ValueType> const>& child : gate->children()) {
+            for (auto const& child : gate->children()) {
                 tmpBdd |= translate(child);
             }
             return tmpBdd;

--- a/src/storm-pomdp/api/verification.h
+++ b/src/storm-pomdp/api/verification.h
@@ -8,7 +8,6 @@ namespace api {
 /**
  * Uses the belief exploration with cut-offs to under-approximate the given objective on a POMDP.
  * @tparam ValueType number type to be used
- * @param env the environment to use
  * @param pomdp the input pomdp to be checked
  * @param task the check task to be performed
  * @param sizeThreshold number of states up to which the belief MDP should be unfolded
@@ -18,8 +17,8 @@ namespace api {
  */
 template<typename ValueType>
 typename storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>>::Result underapproximateWithCutoffs(
-    storm::Environment const& env, std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> pomdp,
-    storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& task, uint64_t sizeThreshold,
+    std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> pomdp, storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& task,
+    uint64_t sizeThreshold,
     std::vector<std::vector<std::unordered_map<uint64_t, ValueType>>> additionalPomdpStateValues =
         std::vector<std::vector<std::unordered_map<uint64_t, ValueType>>>()) {
     storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType> options(false, true);
@@ -34,7 +33,6 @@ typename storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::m
  * Uses the belief exploration with cut-offs *without* the pre-processing to generate cut-off values to under-approximate the given objective on a POMDP.
  * Cut-off values need to be provided in the form of a vector of vectors representing finite memory schedulers.
  * @tparam ValueType number type to be used
- * @param env the environment to use
  * @param pomdp the input pomdp to be checked
  * @param task the check task to be performed
  * @param sizeThreshold number of states up to which the belief MDP should be unfolded
@@ -44,9 +42,8 @@ typename storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::m
  */
 template<typename ValueType>
 typename storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>>::Result underapproximateWithoutHeuristicValues(
-    storm::Environment const& env, std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> pomdp,
-    storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& task, uint64_t sizeThreshold,
-    std::vector<std::vector<std::unordered_map<uint64_t, ValueType>>> pomdpStateValues) {
+    std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> pomdp, storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& task,
+    uint64_t sizeThreshold, std::vector<std::vector<std::unordered_map<uint64_t, ValueType>>> pomdpStateValues) {
     storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType> options(false, true);
     options.skipHeuristicSchedulers = true;
     options.useClipping = false;

--- a/src/test/storm-pomdp/api/BeliefExplorationAPITest.cpp
+++ b/src/test/storm-pomdp/api/BeliefExplorationAPITest.cpp
@@ -81,7 +81,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple_Pmax) {
 
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmax=? [F \"goal\" ]", "slippery=0");
     auto task = storm::api::createTask<ValueType>(data.formula, false);
-    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(data.model, task, 100);
 
     ValueType expected = this->parseNumber("7/10");
     EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
@@ -97,7 +97,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple_Pmin) {
 
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmin=? [F \"goal\" ]", "slippery=0");
     auto task = storm::api::createTask<ValueType>(data.formula, false);
-    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(data.model, task, 100);
 
     ValueType expected = this->parseNumber("3/10");
     EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
@@ -113,7 +113,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple_slippery_Pmax) {
 
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmax=? [F \"goal\" ]", "slippery=0.4");
     auto task = storm::api::createTask<ValueType>(data.formula, false);
-    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(data.model, task, 100);
 
     ValueType expected = this->parseNumber("7/10");
     EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
@@ -129,7 +129,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple_slippery_Pmin) {
 
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmin=? [F \"goal\" ]", "slippery=0.4");
     auto task = storm::api::createTask<ValueType>(data.formula, false);
-    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(data.model, task, 100);
 
     ValueType expected = this->parseNumber("3/10");
     EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
@@ -146,7 +146,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple_Rmax) {
 
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmax=? [F s>4 ]", "slippery=0");
     auto task = storm::api::createTask<ValueType>(data.formula, false);
-    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(data.model, task, 100);
 
     ValueType expected = this->parseNumber("29/50");
     EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
@@ -162,7 +162,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple_Rmin) {
 
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmin=? [F s>4 ]", "slippery=0");
     auto task = storm::api::createTask<ValueType>(data.formula, false);
-    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(data.model, task, 100);
 
     ValueType expected = this->parseNumber("19/50");
     EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
@@ -178,7 +178,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple_slippery_Rmax) {
 
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmax=? [F s>4 ]", "slippery=0.4");
     auto task = storm::api::createTask<ValueType>(data.formula, false);
-    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(data.model, task, 100);
 
     ValueType expected = this->parseNumber("29/30");
     EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
@@ -194,7 +194,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple_slippery_Rmin) {
 
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmin=? [F s>4 ]", "slippery=0.4");
     auto task = storm::api::createTask<ValueType>(data.formula, false);
-    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(data.model, task, 100);
 
     ValueType expected = this->parseNumber("19/30");
     EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
@@ -210,7 +210,7 @@ TYPED_TEST(BeliefExplorationAPITest, maze2_Rmin) {
 
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/maze2.prism", "R[exp]min=? [F \"goal\"]", "sl=0");
     auto task = storm::api::createTask<ValueType>(data.formula, false);
-    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(data.model, task, 100);
 
     ValueType expected = this->parseNumber("74/91");
     EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
@@ -226,7 +226,7 @@ TYPED_TEST(BeliefExplorationAPITest, maze2_slippery_Rmin) {
 
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/maze2.prism", "R[exp]min=? [F \"goal\"]", "sl=0.075");
     auto task = storm::api::createTask<ValueType>(data.formula, false);
-    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(data.model, task, 100);
 
     ValueType expected = this->parseNumber("80/91");
     EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
@@ -242,7 +242,7 @@ TYPED_TEST(BeliefExplorationAPITest, refuel_Pmax) {
 
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/refuel.prism", "Pmax=?[\"notbad\" U \"goal\"]", "N=4");
     auto task = storm::api::createTask<ValueType>(data.formula, false);
-    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(data.model, task, 100);
 
     ValueType expected = this->parseNumber("38/155");
     EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
@@ -259,7 +259,7 @@ TYPED_TEST(BeliefExplorationAPITest, refuel_Pmin) {
 
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/refuel.prism", "Pmin=?[\"notbad\" U \"goal\"]", "N=4");
     auto task = storm::api::createTask<ValueType>(data.formula, false);
-    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(data.model, task, 100);
 
     ValueType expected = this->parseNumber("0");
     EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
@@ -275,7 +275,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple2_Rmax) {
 
     auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple2.prism", "Rmax=?[F \"goal\"]");
     auto task = storm::api::createTask<ValueType>(data.formula, false);
-    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 10);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(data.model, task, 10);
 
     ValueType expected = this->parseNumber("59040588757/103747000000");
     EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
@@ -290,7 +290,7 @@ TYPED_TEST(BeliefExplorationAPITest, simple2_Rmax) {
     std::vector<std::unordered_map<uint64_t, ValueType>> obs1vals{{{2, 1}}, {{2, 1}}};
     std::vector<std::vector<std::unordered_map<uint64_t, ValueType>>> additionalVals{obs0vals, obs1vals};
 
-    result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 10, additionalVals);
+    result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(data.model, task, 10, additionalVals);
 
     EXPECT_LE(result.lowerBound, storm::utility::one<ValueType>() + this->modelcheckingPrecision());
 }
@@ -305,7 +305,7 @@ TYPED_TEST(BeliefExplorationAPITest, noHeuristicValues) {
     std::vector<std::unordered_map<uint64_t, ValueType>> obs1vals{{{2, 1}}, {{2, 1}}};
     std::vector<std::vector<std::unordered_map<uint64_t, ValueType>>> additionalVals{obs0vals, obs1vals};
 
-    auto result = storm::pomdp::api::underapproximateWithoutHeuristicValues<ValueType>(this->env(), data.model, task, 10, additionalVals);
+    auto result = storm::pomdp::api::underapproximateWithoutHeuristicValues<ValueType>(data.model, task, 10, additionalVals);
 
     EXPECT_LE(result.lowerBound, storm::utility::one<ValueType>() + this->modelcheckingPrecision());
 }

--- a/src/test/storm-pomdp/modelchecker/BeliefExplorationPomdpModelCheckerTest.cpp
+++ b/src/test/storm-pomdp/modelchecker/BeliefExplorationPomdpModelCheckerTest.cpp
@@ -45,7 +45,7 @@ class SelfloopReductionDefaultDoubleVIEnvironment {
     static ValueType precision() {
         return storm::utility::convertNumber<ValueType>(0.12);
     }  // there actually aren't any precision guarantees, but we still want to detect if results are weird.
-    static void adaptOptions(storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType>& options) { /* intentionally left empty */
+    static void adaptOptions(storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType>&) { /* intentionally left empty */
     }
     static PreprocessingType const preprocessingType = PreprocessingType::SelfloopReduction;
 };
@@ -63,7 +63,7 @@ class QualitativeReductionDefaultDoubleVIEnvironment {
     static ValueType precision() {
         return storm::utility::convertNumber<ValueType>(0.12);
     }  // there actually aren't any precision guarantees, but we still want to detect if results are weird.
-    static void adaptOptions(storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType>& options) { /* intentionally left empty */
+    static void adaptOptions(storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType>&) { /* intentionally left empty */
     }
     static PreprocessingType const preprocessingType = PreprocessingType::QualitativeReduction;
 };
@@ -81,7 +81,7 @@ class PreprocessedDefaultDoubleVIEnvironment {
     static ValueType precision() {
         return storm::utility::convertNumber<ValueType>(0.12);
     }  // there actually aren't any precision guarantees, but we still want to detect if results are weird.
-    static void adaptOptions(storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType>& options) { /* intentionally left empty */
+    static void adaptOptions(storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType>&) { /* intentionally left empty */
     }
     static PreprocessingType const preprocessingType = PreprocessingType::All;
 };
@@ -159,7 +159,7 @@ class DefaultDoubleOVIEnvironment {
     static ValueType precision() {
         return storm::utility::convertNumber<ValueType>(0.12);
     }  // there actually aren't any precision guarantees, but we still want to detect if results are weird.
-    static void adaptOptions(storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType>& options) { /* intentionally left empty */
+    static void adaptOptions(storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType>&) { /* intentionally left empty */
     }
     static PreprocessingType const preprocessingType = PreprocessingType::None;
 };
@@ -177,7 +177,7 @@ class DefaultRationalPIEnvironment {
     static ValueType precision() {
         return storm::utility::convertNumber<ValueType>(0.12);
     }  // there actually aren't any precision guarantees, but we still want to detect if results are weird.
-    static void adaptOptions(storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType>& options) { /* intentionally left empty */
+    static void adaptOptions(storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType>&) { /* intentionally left empty */
     }
     static PreprocessingType const preprocessingType = PreprocessingType::None;
 };
@@ -195,7 +195,7 @@ class PreprocessedDefaultRationalPIEnvironment {
     static ValueType precision() {
         return storm::utility::convertNumber<ValueType>(0.12);
     }  // there actually aren't any precision guarantees, but we still want to detect if results are weird.
-    static void adaptOptions(storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType>& options) { /* intentionally left empty */
+    static void adaptOptions(storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType>&) { /* intentionally left empty */
     }
     static PreprocessingType const preprocessingType = PreprocessingType::All;
 };

--- a/src/test/storm/modelchecker/prctl/mdp/RobustMdpPrctlModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/prctl/mdp/RobustMdpPrctlModelCheckerTest.cpp
@@ -39,10 +39,8 @@ double getQuantitativeResultAtInitialState(std::shared_ptr<storm::models::sparse
 }
 
 void expectThrow(std::string const& path, std::string const& formulaString) {
-    std::shared_ptr<storm::models::sparse::Model<storm::Interval>> modelPtr =
-        storm::parser::DirectEncodingParser<storm::Interval>::parseModel(STORM_TEST_RESOURCES_DIR "/imdp/tiny-04.drn");
-    std::vector<std::shared_ptr<storm::logic::Formula const>> formulas =
-        storm::api::extractFormulasFromProperties(storm::api::parseProperties("Rmin=? [ F \"target\"]"));
+    std::shared_ptr<storm::models::sparse::Model<storm::Interval>> modelPtr = storm::parser::DirectEncodingParser<storm::Interval>::parseModel(path);
+    std::vector<std::shared_ptr<storm::logic::Formula const>> formulas = storm::api::extractFormulasFromProperties(storm::api::parseProperties(formulaString));
 
     storm::Environment env;
     env.solver().minMax().setMethod(storm::solver::MinMaxMethod::ValueIteration);


### PR DESCRIPTION
Tests should build without warnings in the CI.
- removed hard-coded path and formula in `RobustMdpPrctlModelCheckerTest`
- removed `env` parameter in POMDP modelchecker which is unused