### PR TITLE
Fixed canHandle check for exploration and abstraction engine

### DIFF
--- a/src/storm/modelchecker/exploration/SparseExplorationModelChecker.cpp
+++ b/src/storm/modelchecker/exploration/SparseExplorationModelChecker.cpp
@@ -47,10 +47,15 @@ SparseExplorationModelChecker<ModelType, StateType>::SparseExplorationModelCheck
 }
 
 template<typename ModelType, typename StateType>
-bool SparseExplorationModelChecker<ModelType, StateType>::canHandle(CheckTask<storm::logic::Formula, ValueType> const& checkTask) const {
+bool SparseExplorationModelChecker<ModelType, StateType>::canHandleStatic(CheckTask<storm::logic::Formula, ValueType> const& checkTask) {
     storm::logic::Formula const& formula = checkTask.getFormula();
     storm::logic::FragmentSpecification fragment = storm::logic::reachability();
     return formula.isInFragment(fragment) && checkTask.isOnlyInitialStatesRelevantSet();
+}
+
+template<typename ModelType, typename StateType>
+bool SparseExplorationModelChecker<ModelType, StateType>::canHandle(CheckTask<storm::logic::Formula, ValueType> const& checkTask) const {
+    return canHandleStatic(checkTask);
 }
 
 template<typename ModelType, typename StateType>

--- a/src/storm/modelchecker/exploration/SparseExplorationModelChecker.h
+++ b/src/storm/modelchecker/exploration/SparseExplorationModelChecker.h
@@ -48,6 +48,8 @@ class SparseExplorationModelChecker : public AbstractModelChecker<ModelType> {
 
     SparseExplorationModelChecker(storm::prism::Program const& program);
 
+    static bool canHandleStatic(CheckTask<storm::logic::Formula, ValueType> const& checkTask);
+
     virtual bool canHandle(CheckTask<storm::logic::Formula, ValueType> const& checkTask) const override;
 
     virtual std::unique_ptr<CheckResult> computeUntilProbabilities(Environment const& env,

--- a/src/storm/utility/Engine.cpp
+++ b/src/storm/utility/Engine.cpp
@@ -2,6 +2,7 @@
 
 #include "storm/modelchecker/csl/SparseCtmcCslModelChecker.h"
 #include "storm/modelchecker/csl/SparseMarkovAutomatonCslModelChecker.h"
+#include "storm/modelchecker/exploration/SparseExplorationModelChecker.h"
 #include "storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.h"
 #include "storm/modelchecker/prctl/SparseMdpPrctlModelChecker.h"
 #include "storm/modelchecker/rpatl/SparseSmgRpatlModelChecker.h"
@@ -156,6 +157,39 @@ bool canHandle(storm::utility::Engine const& engine, storm::storage::SymbolicMod
                     return false;
             }
             break;
+        case Engine::Exploration:
+            if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) {
+                return false;
+            }
+            switch (modelType) {
+                case ModelType::DTMC:
+                    return storm::modelchecker::SparseExplorationModelChecker<storm::models::sparse::Dtmc<ValueType>>::canHandleStatic(checkTask);
+                case ModelType::MDP:
+                    return storm::modelchecker::SparseExplorationModelChecker<storm::models::sparse::Mdp<ValueType>>::canHandleStatic(checkTask);
+                case ModelType::CTMC:
+                case ModelType::MA:
+                case ModelType::POMDP:
+                case ModelType::SMG:
+                    return false;
+            }
+            break;
+        case Engine::AbstractionRefinement:
+            if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) {
+                return false;
+            }
+            switch (modelType) {
+                case ModelType::DTMC:
+                case ModelType::MDP:
+                    // Since the corresponding model checker is in a separate library, we can only make a very crude over-approximation of what can be handled
+                    // at this point.
+                    return true;
+                case ModelType::CTMC:
+                case ModelType::MA:
+                case ModelType::POMDP:
+                case ModelType::SMG:
+                    return false;
+            }
+            break;
         default:
             STORM_LOG_ERROR("The selected engine " << engine << " is not considered.");
     }
@@ -215,6 +249,9 @@ bool canHandle<storm::RationalFunction>(storm::utility::Engine const& engine, st
                     return false;
             }
             break;
+        case Engine::Exploration:
+        case Engine::AbstractionRefinement:
+            return false;
         default:
             STORM_LOG_ERROR("The selected engine" << engine << " is not considered.");
     }
@@ -226,18 +263,22 @@ bool canHandle<storm::RationalFunction>(storm::utility::Engine const& engine, st
 template<typename ValueType>
 bool canHandle(storm::utility::Engine const& engine, std::vector<storm::jani::Property> const& properties,
                storm::storage::SymbolicModelDescription const& modelDescription) {
-    // Check handability of properties based on model type
-    for (auto const& p : properties) {
-        for (auto const& f : {p.getRawFormula(), p.getFilter().getStatesFormula()}) {
-            auto task = storm::modelchecker::CheckTask<storm::logic::Formula, ValueType>(*f, true);
-            if (!canHandle(engine, modelDescription.getModelType(), task)) {
-                STORM_LOG_INFO("Engine " << engine << " can not handle formula '" << *f << "' on models of type " << modelDescription.getModelType() << ".");
-                return false;
-            }
+    auto canHandleFormula = [&engine, &modelDescription](auto const& formula, bool onlyInitialStatesRelevant) {
+        auto task = storm::modelchecker::CheckTask<storm::logic::Formula, ValueType>(formula, onlyInitialStatesRelevant);
+        bool result = canHandle(engine, modelDescription.getModelType(), task);
+        STORM_LOG_INFO_COND(result, "Engine " << engine << " can not handle formula '" << task.getFormula() << "' on models of type "
+                                              << modelDescription.getModelType() << ".");
+        return result;
+    };
+    auto canHandleProperty = [&canHandleFormula](auto const& property) {
+        if (property.getFilter().isDefault()) {
+            return canHandleFormula(*property.getRawFormula(), true);
+        } else {
+            return canHandleFormula(*property.getRawFormula(), false) && canHandleFormula(*property.getFilter().getStatesFormula(), false);
         }
-    }
-    // Check whether the model builder can handle the model description
-    return storm::builder::canHandle<ValueType>(getBuilderType(engine), modelDescription, properties);
+    };
+    return std::all_of(properties.begin(), properties.end(), canHandleProperty) &&
+           storm::builder::canHandle<ValueType>(getBuilderType(engine), modelDescription, properties);
 }
 
 // explicit template instantiations.


### PR DESCRIPTION
Fixes a current issue that when selecting `--engine expl` or `--engine abs` we always get output like this (no matter if the property is supported or not)

```
ERROR (Engine.cpp:160): The selected engine expl is not considered.
ERROR (Engine.cpp:163): The selected combination of engine (expl) and model type (dtmc) does not seem to be supported for this value type.
 WARN (storm.cpp:27): The model checking query does not seem to be supported for the selected engine. Storm will try to solve the query, but you will most likely get an error for at least one of the provided properties.
```