### PR TITLE
Improved expected visiting times (EVTs) and steady state distribution computations

### DIFF
--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -440,8 +440,8 @@ std::shared_ptr<storm::models::ModelBase> buildModelDd(SymbolicInput const& inpu
                                                              !buildSettings.isApplyNoMaximumProgressAssumptionSet());
 }
 
-storm::builder::BuilderOptions createBuildOptionsSparse(SymbolicInput const& input, storm::settings::modules::IOSettings const& ioSettings,
-                                                        storm::settings::modules::BuildSettings const& buildSettings) {
+inline storm::builder::BuilderOptions createBuildOptionsSparse(SymbolicInput const& input, storm::settings::modules::IOSettings const& ioSettings,
+                                                               storm::settings::modules::BuildSettings const& buildSettings) {
     storm::builder::BuilderOptions options(createFormulasToRespect(input.properties), input.model.get());
     options.setBuildChoiceLabels(options.isBuildChoiceLabelsSet() || buildSettings.isBuildChoiceLabelsSet());
     options.setBuildStateValuations(options.isBuildStateValuationsSet() || buildSettings.isBuildStateValuationsSet());

--- a/src/storm/environment/modelchecker/ModelCheckerEnvironment.cpp
+++ b/src/storm/environment/modelchecker/ModelCheckerEnvironment.cpp
@@ -3,6 +3,7 @@
 #include "storm/environment/modelchecker/MultiObjectiveModelCheckerEnvironment.h"
 
 #include "storm/settings/SettingsManager.h"
+#include "storm/settings/modules/IOSettings.h"
 #include "storm/settings/modules/ModelCheckerSettings.h"
 #include "storm/utility/macros.h"
 
@@ -16,10 +17,20 @@ ModelCheckerEnvironment::ModelCheckerEnvironment() {
     if (mcSettings.isLtl2daToolSet()) {
         ltl2daTool = mcSettings.getLtl2daTool();
     }
+    auto const& ioSettings = storm::settings::getModule<storm::settings::modules::IOSettings>();
+    steadyStateDistributionAlgorithm = ioSettings.getSteadyStateDistributionAlgorithm();
 }
 
 ModelCheckerEnvironment::~ModelCheckerEnvironment() {
     // Intentionally left empty
+}
+
+SteadyStateDistributionAlgorithm ModelCheckerEnvironment::getSteadyStateDistributionAlgorithm() const {
+    return steadyStateDistributionAlgorithm;
+}
+
+void ModelCheckerEnvironment::setSteadyStateDistributionAlgorithm(SteadyStateDistributionAlgorithm value) {
+    steadyStateDistributionAlgorithm = value;
 }
 
 MultiObjectiveModelCheckerEnvironment& ModelCheckerEnvironment::multi() {

--- a/src/storm/environment/modelchecker/ModelCheckerEnvironment.h
+++ b/src/storm/environment/modelchecker/ModelCheckerEnvironment.h
@@ -9,6 +9,8 @@
 
 namespace storm {
 
+enum class SteadyStateDistributionAlgorithm { Automatic, EquationSystem, ExpectedVisitingTimes, Classic };
+
 // Forward declare subenvironments
 class MultiObjectiveModelCheckerEnvironment;
 
@@ -20,6 +22,9 @@ class ModelCheckerEnvironment {
     MultiObjectiveModelCheckerEnvironment& multi();
     MultiObjectiveModelCheckerEnvironment const& multi() const;
 
+    SteadyStateDistributionAlgorithm getSteadyStateDistributionAlgorithm() const;
+    void setSteadyStateDistributionAlgorithm(SteadyStateDistributionAlgorithm value);
+
     bool isLtl2daToolSet() const;
     std::string const& getLtl2daTool() const;
     void setLtl2daTool(std::string const& value);
@@ -28,5 +33,6 @@ class ModelCheckerEnvironment {
    private:
     SubEnvironment<MultiObjectiveModelCheckerEnvironment> multiObjectiveModelCheckerEnvironment;
     boost::optional<std::string> ltl2daTool;
+    SteadyStateDistributionAlgorithm steadyStateDistributionAlgorithm;
 };
 }  // namespace storm

--- a/src/storm/environment/modelchecker/ModelCheckerEnvironment.h
+++ b/src/storm/environment/modelchecker/ModelCheckerEnvironment.h
@@ -6,10 +6,9 @@
 
 #include "storm/environment/Environment.h"
 #include "storm/environment/SubEnvironment.h"
+#include "storm/modelchecker/helper/infinitehorizon/SteadyStateDistributionAlgorithm.h"
 
 namespace storm {
-
-enum class SteadyStateDistributionAlgorithm { Automatic, EquationSystem, ExpectedVisitingTimes, Classic };
 
 // Forward declare subenvironments
 class MultiObjectiveModelCheckerEnvironment;

--- a/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.cpp
+++ b/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.cpp
@@ -7,51 +7,63 @@
 #include "storm/environment/solver/TopologicalSolverEnvironment.h"
 #include "storm/solver/LinearEquationSolver.h"
 
+#include "storm/modelchecker/prctl/helper/BaierUpperRewardBoundsComputer.h"
+
 #include "storm/utility/ProgressMeasurement.h"
 #include "storm/utility/SignalHandler.h"
 #include "storm/utility/constants.h"
 #include "storm/utility/macros.h"
 #include "storm/utility/vector.h"
 
+#include "storm/exceptions/NotSupportedException.h"
 #include "storm/exceptions/UnmetRequirementException.h"
+#include "utility/graph.h"
 
 namespace storm {
 namespace modelchecker {
 namespace helper {
 template<typename ValueType>
 SparseDeterministicVisitingTimesHelper<ValueType>::SparseDeterministicVisitingTimesHelper(storm::storage::SparseMatrix<ValueType> const& transitionMatrix)
-    : _transitionMatrix(transitionMatrix), _exitRates(nullptr), _backwardTransitions(nullptr), _sccDecomposition(nullptr) {
+    : transitionMatrix(transitionMatrix),
+      exitRates(nullptr),
+      backwardTransitions(nullptr),
+      sccDecomposition(nullptr),
+      nonBsccStates(transitionMatrix.getRowCount(), false) {
     // Intentionally left empty
 }
 
 template<typename ValueType>
 SparseDeterministicVisitingTimesHelper<ValueType>::SparseDeterministicVisitingTimesHelper(storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                                                           std::vector<ValueType> const& exitRates)
-    : _transitionMatrix(transitionMatrix), _exitRates(&exitRates), _backwardTransitions(nullptr), _sccDecomposition(nullptr) {
+    : transitionMatrix(transitionMatrix),
+      exitRates(&exitRates),
+      backwardTransitions(nullptr),
+      sccDecomposition(nullptr),
+      nonBsccStates(transitionMatrix.getRowCount(), false) {
     // For the CTMC case we assert that the caller actually provided the probabilistic transitions
-    STORM_LOG_ASSERT(this->_transitionMatrix.isProbabilistic(), "Non-probabilistic transitions");
+    STORM_LOG_ASSERT(this->transitionMatrix.isProbabilistic(), "Non-probabilistic transitions");
 }
 
 template<typename ValueType>
-void SparseDeterministicVisitingTimesHelper<ValueType>::provideBackwardTransitions(storm::storage::SparseMatrix<ValueType> const& backwardTransitions) {
-    STORM_LOG_WARN_COND(!_backwardTransitions, "Backward transition matrix was provided but it was already computed or provided before.");
-    _backwardTransitions = &backwardTransitions;
+void SparseDeterministicVisitingTimesHelper<ValueType>::provideBackwardTransitions(storm::storage::SparseMatrix<ValueType> const& providedBackwardTransitions) {
+    STORM_LOG_WARN_COND(!backwardTransitions, "Backward transition matrix was provided but it was already computed or provided before.");
+    backwardTransitions = &providedBackwardTransitions;
 }
 
 template<typename ValueType>
 void SparseDeterministicVisitingTimesHelper<ValueType>::provideSCCDecomposition(
     storm::storage::StronglyConnectedComponentDecomposition<ValueType> const& decomposition) {
-    STORM_LOG_WARN_COND(!_sccDecomposition, "SCC Decomposition was provided but it was already computed or provided before.");
-    _sccDecomposition = &decomposition;
+    STORM_LOG_WARN_COND(!sccDecomposition, "SCC Decomposition was provided but it was already computed or provided before.");
+    sccDecomposition = &decomposition;
 }
 
 template<typename ValueType>
 std::vector<ValueType> SparseDeterministicVisitingTimesHelper<ValueType>::computeExpectedVisitingTimes(Environment const& env,
                                                                                                        storm::storage::BitVector const& initialStates) {
     STORM_LOG_ASSERT(!initialStates.empty(), "provided an empty set of initial states.");
-    STORM_LOG_ASSERT(initialStates.size() == _transitionMatrix.getRowCount(), "Dimension mismatch.");
+    STORM_LOG_ASSERT(initialStates.size() == transitionMatrix.getRowCount(), "Dimension mismatch.");
     ValueType const p = storm::utility::one<ValueType>() / storm::utility::convertNumber<ValueType, uint64_t>(initialStates.getNumberOfSetBits());
-    std::vector<ValueType> result(_transitionMatrix.getRowCount(), storm::utility::zero<ValueType>());
+    std::vector<ValueType> result(transitionMatrix.getRowCount(), storm::utility::zero<ValueType>());
     storm::utility::vector::setVectorValues(result, initialStates, p);
     computeExpectedVisitingTimes(env, result);
     return result;
@@ -59,8 +71,8 @@ std::vector<ValueType> SparseDeterministicVisitingTimesHelper<ValueType>::comput
 
 template<typename ValueType>
 std::vector<ValueType> SparseDeterministicVisitingTimesHelper<ValueType>::computeExpectedVisitingTimes(Environment const& env, uint64_t initialState) {
-    STORM_LOG_ASSERT(initialState < _transitionMatrix.getRowCount(), "Invalid initial state index.");
-    std::vector<ValueType> result(_transitionMatrix.getRowCount(), storm::utility::zero<ValueType>());
+    STORM_LOG_ASSERT(initialState < transitionMatrix.getRowCount(), "Invalid initial state index.");
+    std::vector<ValueType> result(transitionMatrix.getRowCount(), storm::utility::zero<ValueType>());
     result[initialState] = storm::utility::one<ValueType>();
     computeExpectedVisitingTimes(env, result);
     return result;
@@ -70,8 +82,8 @@ template<typename ValueType>
 std::vector<ValueType> SparseDeterministicVisitingTimesHelper<ValueType>::computeExpectedVisitingTimes(Environment const& env,
                                                                                                        ValueGetter const& initialStateValueGetter) {
     std::vector<ValueType> result;
-    result.reserve(_transitionMatrix.getRowCount());
-    for (uint64_t s = 0; s != _transitionMatrix.getRowCount(); ++s) {
+    result.reserve(transitionMatrix.getRowCount());
+    for (uint64_t s = 0; s != transitionMatrix.getRowCount(); ++s) {
         result.push_back(initialStateValueGetter(s));
     }
     computeExpectedVisitingTimes(env, result);
@@ -80,18 +92,14 @@ std::vector<ValueType> SparseDeterministicVisitingTimesHelper<ValueType>::comput
 
 template<typename ValueType>
 void SparseDeterministicVisitingTimesHelper<ValueType>::computeExpectedVisitingTimes(Environment const& env, std::vector<ValueType>& stateValues) {
-    STORM_LOG_ASSERT(stateValues.size() == _transitionMatrix.getRowCount(), "Dimension missmatch.");
+    STORM_LOG_ASSERT(stateValues.size() == transitionMatrix.getRowCount(), "Dimension missmatch.");
     createBackwardTransitions();
     createDecomposition(env);
-    auto sccEnv = getEnvironmentForSccSolver(env);
+    createNonBsccStateVector();
 
     // Create auxiliary data and lambdas
     storm::storage::BitVector sccAsBitVector(stateValues.size(), false);
     auto isLeavingTransition = [&sccAsBitVector](auto const& e) { return !sccAsBitVector.get(e.getColumn()); };
-    auto isExitState = [this, &isLeavingTransition](uint64_t state) {
-        auto row = this->_transitionMatrix.getRow(state);
-        return std::any_of(row.begin(), row.end(), isLeavingTransition);
-    };
     auto isLeavingTransitionWithNonZeroValue = [&isLeavingTransition, &stateValues](auto const& e) {
         return isLeavingTransition(e) && !storm::utility::isZero(stateValues[e.getColumn()]);
     };
@@ -99,48 +107,80 @@ void SparseDeterministicVisitingTimesHelper<ValueType>::computeExpectedVisitingT
         if (!storm::utility::isZero(stateValues[state])) {
             return true;
         }
-        auto row = this->_backwardTransitions->getRow(state);
+        auto row = this->backwardTransitions->getRow(state);
         return std::any_of(row.begin(), row.end(), isLeavingTransitionWithNonZeroValue);
     };
 
-    // We solve each SCC individually in *forward* topological order
-    storm::utility::ProgressMeasurement progress("sccs");
-    progress.setMaxCount(_sccDecomposition->size());
-    progress.startNewMeasurement(0);
-    uint64_t sccIndex = 0;
-    auto sccItEnd = std::make_reverse_iterator(_sccDecomposition->begin());
-    for (auto sccIt = std::make_reverse_iterator(_sccDecomposition->end()); sccIt != sccItEnd; ++sccIt) {
-        auto const& scc = *sccIt;
-        if (scc.size() == 1) {
-            processSingletonScc(*scc.begin(), stateValues);
-        } else {
-            sccAsBitVector.set(scc.begin(), scc.end(), true);
-            if (std::any_of(sccAsBitVector.begin(), sccAsBitVector.end(), isExitState)) {
-                // This is not a BSCC
-                auto sccResult = computeValueForNonTrivialScc(sccEnv, sccAsBitVector, stateValues);
-                storm::utility::vector::setVectorValues(stateValues, sccAsBitVector, sccResult);
+    if (env.solver().getLinearEquationSolverType() == storm::solver::EquationSolverType::Topological) {
+        // Compute EVTs SCC wise in topological order
+        // We need to adapt precision if we solve each SCC separately (in topological order) and/or consider CTMCs
+        auto sccEnv = getEnvironmentForSolver(env, true);
+
+        // We solve each SCC individually in *forward* topological order
+        storm::utility::ProgressMeasurement progress("sccs");
+        progress.setMaxCount(sccDecomposition->size());
+        progress.startNewMeasurement(0);
+        uint64_t sccIndex = 0;
+        auto sccItEnd = std::make_reverse_iterator(sccDecomposition->begin());
+        for (auto sccIt = std::make_reverse_iterator(sccDecomposition->end()); sccIt != sccItEnd; ++sccIt) {
+            auto const& scc = *sccIt;
+            if (scc.size() == 1) {
+                processSingletonScc(*scc.begin(), stateValues);
             } else {
-                // This is a BSCC
+                sccAsBitVector.set(scc.begin(), scc.end(), true);
+                if (sccAsBitVector.isSubsetOf(nonBsccStates)) {
+                    // This is not a BSCC
+                    auto sccResult = computeValueForStateSet(sccEnv, sccAsBitVector, stateValues);
+                    storm::utility::vector::setVectorValues(stateValues, sccAsBitVector, sccResult);
+                } else {
+                    // This is a BSCC
+                    if (std::any_of(sccAsBitVector.begin(), sccAsBitVector.end(), isReachableInState)) {
+                        storm::utility::vector::setVectorValues(stateValues, sccAsBitVector, storm::utility::infinity<ValueType>());
+                    } else {
+                        storm::utility::vector::setVectorValues(stateValues, sccAsBitVector, storm::utility::zero<ValueType>());
+                    }
+                }
+                sccAsBitVector.clear();
+            }
+            ++sccIndex;
+            progress.updateProgress(sccIndex);
+            if (storm::utility::resources::isTerminate()) {
+                STORM_LOG_WARN("Visiting times computation aborted after analyzing " << sccIndex << "/" << this->computedSccDecomposition->size() << " SCCs.");
+                break;
+            }
+        }
+    } else {
+        // We solve the equation system for all non-BSCC in one step (not each SCC individually - adaption of precision is not necessary).
+        if (!nonBsccStates.empty()) {
+            // We need to adapt precision if we consider CTMCs.
+            Environment adjustedEnv = getEnvironmentForSolver(env, false);
+            auto result = computeValueForStateSet(adjustedEnv, nonBsccStates, stateValues);
+            storm::utility::vector::setVectorValues(stateValues, nonBsccStates, result);
+        }
+
+        // After computing the state values for the  non-BSCCs, we can set the values of the BSCC states.
+        auto sccItEnd = std::make_reverse_iterator(sccDecomposition->begin());
+        for (auto sccIt = std::make_reverse_iterator(sccDecomposition->end()); sccIt != sccItEnd; ++sccIt) {
+            auto const& scc = *sccIt;
+            sccAsBitVector.set(scc.begin(), scc.end(), true);
+            if (sccAsBitVector.isSubsetOf(~nonBsccStates)) {
+                // This is a BSCC, we set the values of the states to infinity or 0.
                 if (std::any_of(sccAsBitVector.begin(), sccAsBitVector.end(), isReachableInState)) {
+                    // The BSCC is reachable: The EVT is infinity
                     storm::utility::vector::setVectorValues(stateValues, sccAsBitVector, storm::utility::infinity<ValueType>());
                 } else {
+                    // The BSCC is not reachable: The EVT is zero
                     storm::utility::vector::setVectorValues(stateValues, sccAsBitVector, storm::utility::zero<ValueType>());
                 }
             }
             sccAsBitVector.clear();
-        }
-        ++sccIndex;
-        progress.updateProgress(sccIndex);
-        if (storm::utility::resources::isTerminate()) {
-            STORM_LOG_WARN("Visiting times computation aborted after analyzing " << sccIndex << "/" << this->_computedSccDecomposition->size() << " SCCs.");
-            break;
         }
     }
 
     if (isContinuousTime()) {
         // Divide with the exit rates
         // Since storm::utility::infinity<storm::RationalNumber>() is just set to some big number, we have to treat the infinity-case explicitly.
-        storm::utility::vector::applyPointwise(stateValues, *_exitRates, stateValues, [](ValueType const& xi, ValueType const& yi) -> ValueType {
+        storm::utility::vector::applyPointwise(stateValues, *exitRates, stateValues, [](ValueType const& xi, ValueType const& yi) -> ValueType {
             return storm::utility::isInfinity(xi) ? xi : xi / yi;
         });
     }
@@ -148,58 +188,227 @@ void SparseDeterministicVisitingTimesHelper<ValueType>::computeExpectedVisitingT
 
 template<typename ValueType>
 bool SparseDeterministicVisitingTimesHelper<ValueType>::isContinuousTime() const {
-    return _exitRates;
+    return exitRates;
 }
 
 template<typename ValueType>
 void SparseDeterministicVisitingTimesHelper<ValueType>::createBackwardTransitions() {
-    if (!this->_backwardTransitions) {
-        this->_computedBackwardTransitions =
-            std::make_unique<storm::storage::SparseMatrix<ValueType>>(_transitionMatrix.transpose(true, false));  // will drop zeroes
-        this->_backwardTransitions = this->_computedBackwardTransitions.get();
+    if (!this->backwardTransitions) {
+        this->computedBackwardTransitions =
+            std::make_unique<storm::storage::SparseMatrix<ValueType>>(transitionMatrix.transpose(true, false));  // will drop zeroes
+        this->backwardTransitions = this->computedBackwardTransitions.get();
     }
 }
 
 template<typename ValueType>
 void SparseDeterministicVisitingTimesHelper<ValueType>::createDecomposition(Environment const& env) {
-    if (this->_sccDecomposition && !this->_sccDecomposition->hasSccDepth() && env.solver().isForceSoundness()) {
+    if (this->sccDecomposition && !this->sccDecomposition->hasSccDepth() && env.solver().isForceSoundness()) {
         // We are missing SCCDepths in the given decomposition.
         STORM_LOG_WARN("Recomputing SCC Decomposition because the currently available decomposition is computed without SCCDepths.");
-        this->_computedSccDecomposition.reset();
-        this->_sccDecomposition = nullptr;
+        this->computedSccDecomposition.reset();
+        this->sccDecomposition = nullptr;
     }
 
-    if (!this->_sccDecomposition) {
+    if (!this->sccDecomposition) {
         // The decomposition has not been provided or computed, yet.
         auto options =
             storm::storage::StronglyConnectedComponentDecompositionOptions().forceTopologicalSort().computeSccDepths(env.solver().isForceSoundness());
-        this->_computedSccDecomposition =
-            std::make_unique<storm::storage::StronglyConnectedComponentDecomposition<ValueType>>(this->_transitionMatrix, options);
-        this->_sccDecomposition = this->_computedSccDecomposition.get();
+        this->computedSccDecomposition = std::make_unique<storm::storage::StronglyConnectedComponentDecomposition<ValueType>>(this->transitionMatrix, options);
+        this->sccDecomposition = this->computedSccDecomposition.get();
     }
 }
 
 template<typename ValueType>
-storm::Environment SparseDeterministicVisitingTimesHelper<ValueType>::getEnvironmentForSccSolver(storm::Environment const& env) const {
+void SparseDeterministicVisitingTimesHelper<ValueType>::createNonBsccStateVector() {
+    // Create auxiliary data and lambdas
+    storm::storage::BitVector sccAsBitVector(transitionMatrix.getRowCount(), false);
+    auto isLeavingTransition = [&sccAsBitVector](auto const& e) { return !sccAsBitVector.get(e.getColumn()); };
+    auto isExitState = [this, &isLeavingTransition](uint64_t state) {
+        auto row = this->transitionMatrix.getRow(state);
+        return std::any_of(row.begin(), row.end(), isLeavingTransition);
+    };
+
+    auto sccItEnd = std::make_reverse_iterator(sccDecomposition->begin());
+    for (auto sccIt = std::make_reverse_iterator(sccDecomposition->end()); sccIt != sccItEnd; ++sccIt) {
+        auto const& scc = *sccIt;
+        sccAsBitVector.set(scc.begin(), scc.end(), true);
+        if (std::any_of(sccAsBitVector.begin(), sccAsBitVector.end(), isExitState)) {
+            // This is not a BSCC, mark the states correspondingly.
+            nonBsccStates = nonBsccStates | sccAsBitVector;
+        }
+        sccAsBitVector.clear();
+    }
+}
+
+template<>
+std::vector<storm::RationalFunction> SparseDeterministicVisitingTimesHelper<storm::RationalFunction>::computeUpperBounds(
+    storm::storage::BitVector const& stateSetAsBitvector) const {
+    STORM_LOG_THROW(false, storm::exceptions::NotSupportedException,
+                    "Computing upper bounds for expected visiting times over rational functions is not supported.");
+}
+
+template<typename ValueType>
+std::vector<ValueType> SparseDeterministicVisitingTimesHelper<ValueType>::computeUpperBounds(storm::storage::BitVector const& stateSetAsBitvector) const {
+    // Compute the one-step probabilities that lead to states outside stateSetAsBitvector
+    std::vector<ValueType> leavingTransitions = transitionMatrix.getConstrainedRowGroupSumVector(stateSetAsBitvector, ~stateSetAsBitvector);
+
+    // Build the submatrix that only has the transitions between states in the state set.
+    storm::storage::SparseMatrix<ValueType> subTransitionMatrix = transitionMatrix.getSubmatrix(false, stateSetAsBitvector, stateSetAsBitvector);
+
+    // Compute the upper bounds on EVTs for non-BSCC states (using the same state-to-scc mapping).
+    std::vector<ValueType> upperBounds = storm::modelchecker::helper::BaierUpperRewardBoundsComputer<ValueType>::computeUpperBoundOnExpectedVisitingTimes(
+        subTransitionMatrix, leavingTransitions);
+    return upperBounds;
+}
+
+template<typename ValueType>
+storm::Environment SparseDeterministicVisitingTimesHelper<ValueType>::getEnvironmentForSolver(storm::Environment const& env, bool topological) const {
+    storm::Environment newEnv(env);
+
+    if (topological) {
+        // Overwrite the environment with the environment for the underlying solver.
+        newEnv = getEnvironmentForTopologicalSolver(env);
+    }
+
+    // Adjust precision for CTMCs, because the EVTs are divided by the exit rates at the end.
+    if (isContinuousTime()) {
+        auto prec = newEnv.solver().getPrecisionOfLinearEquationSolver(newEnv.solver().getLinearEquationSolverType());
+
+        bool needAdaptPrecision =
+            env.solver().isForceSoundness() && prec.first.is_initialized() && prec.second.is_initialized() &&
+            !newEnv.solver().getPrecisionOfLinearEquationSolver(newEnv.solver().getLinearEquationSolverType()).second.get();  // only for the absolute criterion
+
+        // Assert that we only adapt the precision for native solvers
+        STORM_LOG_ASSERT(
+            !needAdaptPrecision || env.solver().getLinearEquationSolverType() == storm::solver::EquationSolverType::Native,
+            "The precision for the current solver type is not adjusted for this solving method. Ensure that this is correct for topological computation.");
+
+        if (needAdaptPrecision) {
+            // the precision is relevant (e.g. not the case for elimination, sparselu etc.)
+            ValueType min = *std::min_element(exitRates->begin(), exitRates->end());
+            STORM_LOG_THROW(!storm::utility::isZero(min), storm::exceptions::InvalidOperationException,
+                            "An error occurred during the adjustment of the precision. Min. rate = " << min);
+            newEnv.solver().setLinearEquationSolverPrecision(
+                static_cast<storm::RationalNumber>(prec.first.get() * storm::utility::convertNumber<storm::RationalNumber>(min)));
+        }
+    }
+
+    auto prec = newEnv.solver().getPrecisionOfLinearEquationSolver(newEnv.solver().getLinearEquationSolverType());
+    if (prec.first.is_initialized()) {
+        STORM_PRINT("Precision for EVTs computation: " << storm::utility::convertNumber<double>(prec.first.get()) << " (exact: " << prec.first.get() << ")"
+                                                       << '\n');
+    }
+
+    return newEnv;
+}
+
+template<typename ValueType>
+storm::Environment SparseDeterministicVisitingTimesHelper<ValueType>::getEnvironmentForTopologicalSolver(storm::Environment const& env) const {
     storm::Environment subEnv(env);
-    if (env.solver().getLinearEquationSolverType() == storm::solver::EquationSolverType::Topological) {
-        subEnv.solver().setLinearEquationSolverType(env.solver().topological().getUnderlyingEquationSolverType(),
-                                                    env.solver().topological().isUnderlyingEquationSolverTypeSetFromDefault());
+    subEnv.solver().setLinearEquationSolverType(env.solver().topological().getUnderlyingEquationSolverType(),
+                                                env.solver().topological().isUnderlyingEquationSolverTypeSetFromDefault());
+
+    // To guarantee soundness for OVI, II, SVI we need to increase the precision in each SCC.
+    auto subEnvPrec = subEnv.solver().getPrecisionOfLinearEquationSolver(subEnv.solver().getLinearEquationSolverType());
+
+    bool singletonSCCs = true;  // true if each SCC is a singleton (self-loops are allowed)
+    storm::storage::BitVector sccAsBitVector(transitionMatrix.getRowCount(), false);
+    auto sccItEnd = std::make_reverse_iterator(sccDecomposition->begin());
+    for (auto sccIt = std::make_reverse_iterator(sccDecomposition->end()); sccIt != sccItEnd; ++sccIt) {
+        auto const& scc = *sccIt;
+        sccAsBitVector.set(scc.begin(), scc.end(), true);
+        if (sccAsBitVector.isSubsetOf(nonBsccStates)) {
+            // This is not a BSCC, mark the states correspondingly.
+            if (sccAsBitVector.getNumberOfSetBits() > 1) {
+                singletonSCCs = false;
+                break;
+            }
+        }
+        sccAsBitVector.clear();
     }
-    if (env.solver().isForceSoundness()) {
-        STORM_LOG_ASSERT(_sccDecomposition->hasSccDepth(), "Did not compute the longest SCC chain size although it is needed.");
+
+    bool needAdaptPrecision = env.solver().isForceSoundness() && subEnvPrec.first.is_initialized() && subEnvPrec.second.is_initialized() &&
+                              !singletonSCCs;  // singleton sccs are solved directly
+
+    // Assert that we only adapt the precision for native solvers
+    STORM_LOG_ASSERT(
+        !needAdaptPrecision || subEnv.solver().getLinearEquationSolverType() == storm::solver::EquationSolverType::Native,
+        "The precision for the current solver type is not adjusted for this solving method. Ensure that this is correct for topological computation.");
+
+    if (needAdaptPrecision && subEnvPrec.second.get()) {
+        STORM_LOG_ASSERT(sccDecomposition->hasSccDepth(), "Did not compute the longest SCC chain size although it is needed.");
+        // Sound computations wrt. relative precision:
+        // We need to increase the solver's relative precision that is used in an SCC depending on the maximal SCC chain length.
         auto subEnvPrec = subEnv.solver().getPrecisionOfLinearEquationSolver(subEnv.solver().getLinearEquationSolverType());
-        subEnv.solver().setLinearEquationSolverPrecision(static_cast<storm::RationalNumber>(
-            subEnvPrec.first.get() / storm::utility::convertNumber<storm::RationalNumber>(_sccDecomposition->getMaxSccDepth())));
+
+        double scaledPrecision1 = 1 - std::pow(1 - storm::utility::convertNumber<double>(subEnvPrec.first.get()), 1.0 / sccDecomposition->getMaxSccDepth());
+
+        // set new precision
+        subEnv.solver().setLinearEquationSolverPrecision(storm::utility::convertNumber<storm::RationalNumber>(scaledPrecision1));
+
+    } else if (needAdaptPrecision && !subEnv.solver().getPrecisionOfLinearEquationSolver(subEnv.solver().getLinearEquationSolverType()).second.get()) {
+        // Sound computations wrt. absolute precision:
+        // STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Sound computations of EVTs wrt. absolute precision is not supported.");
+
+        // TODO: there is probably a better way to implement this
+        if (sccDecomposition->getMaxSccDepth() > 1) {
+            // The chain length exceeds one, we need to adjust the precision
+            // The adjustment of the precision used in each SCC depends on the maximal SCC chain length,
+            // the maximal number of incoming transitions, and the maximal probability <1 to reach another states in an SCC.
+
+            storm::storage::BitVector sccAsBitVector(transitionMatrix.getRowCount(), false);
+
+            // maxNumInc: the maximal number of incoming transitions to an SCC.
+            uint_fast64_t maxNumInc = 0;
+
+            // maxEVT: the maximal value of 1/(1-p), where p is the recurrence probability within an SCC (this value stays 0 if there are no cycles)
+            ValueType boundEVT = storm::utility::zero<ValueType>();
+
+            auto sccItEnd = std::make_reverse_iterator(sccDecomposition->begin());
+            for (auto sccIt = std::make_reverse_iterator(sccDecomposition->end()); sccIt != sccItEnd; ++sccIt) {
+                auto const& scc = *sccIt;
+                sccAsBitVector.set(scc.begin(), scc.end(), true);
+                if (sccAsBitVector.isSubsetOf(nonBsccStates)) {
+                    // This is NOT a BSCC.
+
+                    // Get number of incoming transitions to this scc (from different sccs)
+                    auto toSccMatrix = transitionMatrix.getSubmatrix(false, ~sccAsBitVector, sccAsBitVector);
+                    uint_fast64_t localNumInc =
+                        std::count_if(toSccMatrix.begin(), toSccMatrix.end(), [](auto const& e) { return !storm::utility::isZero(e.getValue()); });
+                    maxNumInc = std::max(maxNumInc, localNumInc);
+
+                    // Compute the upper bounds on 1/(1-p) within the SCC
+                    // p is the maximal recurrence probability, i.e., 1/(1-p) is an upperBound on the EVTs of the DTMC restricted to the SCC (Baier)
+                    std::vector<ValueType> upperBounds = computeUpperBounds(sccAsBitVector);
+                    boundEVT = std::max(boundEVT, (*std::max_element(upperBounds.begin(), upperBounds.end())));
+
+                    sccAsBitVector.clear();
+                }
+            }
+
+            storm::RationalNumber one = storm::RationalNumber(1);
+            storm::RationalNumber scale = one;
+
+            if (maxNumInc != 0) {
+                // As the maximal number of incoming transitions is greater than one, adjustment is necessary.
+                // For this, we need the number of SCCs in the longest SCC chain -1, i.e., sccDecomposition->getMaxSccDepth() -1
+                for (int i = 1; i < sccDecomposition->getMaxSccDepth(); i++) {
+                    scale = scale + storm::utility::pow(storm::utility::convertNumber<storm::RationalNumber>(maxNumInc), i) *
+                                        storm::utility::convertNumber<storm::RationalNumber>(boundEVT);
+                }
+            }
+            subEnv.solver().setLinearEquationSolverPrecision(static_cast<storm::RationalNumber>(subEnvPrec.first.get() / scale));
+        }
     }
+
     return subEnv;
 }
 
 template<typename ValueType>
 void SparseDeterministicVisitingTimesHelper<ValueType>::processSingletonScc(uint64_t sccState, std::vector<ValueType>& stateValues) const {
     auto& stateVal = stateValues[sccState];
-    auto forwardRow = _transitionMatrix.getRow(sccState);
-    auto backwardRow = _backwardTransitions->getRow(sccState);
+    auto forwardRow = transitionMatrix.getRow(sccState);
+    auto backwardRow = backwardTransitions->getRow(sccState);
     if (forwardRow.getNumberOfEntries() == 1 && forwardRow.begin()->getColumn() == sccState) {
         // This is a BSCC. We only have to check if there is some non-zero "input"
         if (!storm::utility::isZero(stateVal) || std::any_of(backwardRow.begin(), backwardRow.end(),
@@ -222,38 +431,47 @@ void SparseDeterministicVisitingTimesHelper<ValueType>::processSingletonScc(uint
 }
 
 template<typename ValueType>
-std::vector<ValueType> SparseDeterministicVisitingTimesHelper<ValueType>::computeValueForNonTrivialScc(storm::Environment const& env,
-                                                                                                       storm::storage::BitVector const& sccAsBitVector,
-                                                                                                       std::vector<ValueType> const& stateValues) const {
-    // Here we assume that the SCC is not a BSCC
-    // Let P be the SCC matrix. We solve the equation system
-    //       x * P + b = x
-    // <=> P^T * x + b = x   <- fixpoint system
-    // <=> (1-P^T) * x = b   <- equation system
-
-    // We need to check if our sound methods like SVI work on this kind of equation system. Most likely not.
-    STORM_LOG_WARN_COND(!env.solver().isForceSoundness(),
-                        "Sound computations are not properly implemented for the computation of expected number of visits in non-trival SCCs. You might get "
-                        "incorrect results.");
-    storm::solver::GeneralLinearEquationSolverFactory<ValueType> linearEquationSolverFactory;
-    bool isFixpointFormat = linearEquationSolverFactory.getEquationProblemFormat(env) == storm::solver::LinearEquationSolverProblemFormat::FixedPointSystem;
-
-    // Get the matrix for the equation system
-    auto sccMatrix = _backwardTransitions->getSubmatrix(false, sccAsBitVector, sccAsBitVector, !isFixpointFormat);
-    if (!isFixpointFormat) {
-        sccMatrix.convertToEquationSystem();
-    }
-
+std::vector<ValueType> SparseDeterministicVisitingTimesHelper<ValueType>::computeValueForStateSet(storm::Environment const& env,
+                                                                                                  storm::storage::BitVector const& stateSetAsBitvector,
+                                                                                                  std::vector<ValueType> const& stateValues) const {
     // Get the vector for the equation system
-    auto sccVector = storm::utility::vector::filterVector(stateValues, sccAsBitVector);
+    auto sccVector = storm::utility::vector::filterVector(stateValues, stateSetAsBitvector);
     auto valIt = sccVector.begin();
-    for (auto sccState : sccAsBitVector) {
-        for (auto const& entry : _backwardTransitions->getRow(sccState)) {
-            if (!sccAsBitVector.get(entry.getColumn())) {
+    for (auto sccState : stateSetAsBitvector) {
+        for (auto const& entry : backwardTransitions->getRow(sccState)) {
+            if (!stateSetAsBitvector.get(entry.getColumn())) {
                 (*valIt) += entry.getValue() * stateValues[entry.getColumn()];
             }
         }
         ++valIt;
+    }
+    return computeExpectedVisitingTimes(env, stateSetAsBitvector, sccVector);
+}
+
+template<typename ValueType>
+std::vector<ValueType> SparseDeterministicVisitingTimesHelper<ValueType>::computeExpectedVisitingTimes(Environment const& env,
+                                                                                                       storm::storage::BitVector const& subsystem,
+                                                                                                       std::vector<ValueType> const& initialValues) const {
+    STORM_LOG_ASSERT(subsystem.getNumberOfSetBits() == initialValues.size(), "Inconsistent size of subsystem.");
+
+    if (initialValues.empty()) {  // Catch the case where the subsystem is empty.
+        return {};
+    }
+
+    // Here we assume that the subsystem does not contain a BSCC
+    // Let P be the subsystem matrix. We solve the equation system
+    //       x * P + b = x
+    // <=> P^T * x + b = x   <- fixpoint system
+    // <=> (1-P^T) * x = b   <- equation system
+
+    // TODO We need to check if SVI works on this kind of equation system (OVI and II are correct)
+    storm::solver::GeneralLinearEquationSolverFactory<ValueType> linearEquationSolverFactory;
+    bool isFixpointFormat = linearEquationSolverFactory.getEquationProblemFormat(env) == storm::solver::LinearEquationSolverProblemFormat::FixedPointSystem;
+
+    // Get the matrix for the equation system
+    auto sccMatrix = backwardTransitions->getSubmatrix(false, subsystem, subsystem, !isFixpointFormat);
+    if (!isFixpointFormat) {
+        sccMatrix.convertToEquationSystem();
     }
 
     // Get the solver object and satisfy requirements
@@ -261,19 +479,29 @@ std::vector<ValueType> SparseDeterministicVisitingTimesHelper<ValueType>::comput
     solver->setLowerBound(storm::utility::zero<ValueType>());
     auto req = solver->getRequirements(env);
     req.clearLowerBounds();
-    // We could compute upper bounds at this point using techniques from Baier et al. [CAV'17] (https://doi.org/10.1007/978-3-319-63387-9_8)
-    // However, all relevant solvers for this kind of equation system do not require upper bounds.
+    if (req.upperBounds().isCritical()) {
+        // Compute upper bounds on EVTs using techniques from Baier et al. [CAV'17] (https://doi.org/10.1007/978-3-319-63387-9_8)
+        std::vector<ValueType> upperBounds = computeUpperBounds(subsystem);
+        solver->setUpperBounds(upperBounds);
+        req.clearUpperBounds();
+    }
+
+    if (req.acyclic().isCritical()) {
+        STORM_LOG_THROW(!storm::utility::graph::hasCycle(sccMatrix), storm::exceptions::UnmetRequirementException,
+                        "The solver requires an acyclic model, but the model is not acyclic.");
+        req.clearAcyclic();
+    }
+
     STORM_LOG_THROW(!req.hasEnabledCriticalRequirement(), storm::exceptions::UnmetRequirementException,
                     "Solver requirements " + req.getEnabledRequirementsAsString() + " not checked.");
-    std::vector<ValueType> eqSysValues(sccVector.size());
-    solver->solveEquations(env, eqSysValues, sccVector);
+    std::vector<ValueType> eqSysValues(initialValues.size());
+    solver->solveEquations(env, eqSysValues, initialValues);
     return eqSysValues;
 }
 
 template class SparseDeterministicVisitingTimesHelper<double>;
 template class SparseDeterministicVisitingTimesHelper<storm::RationalNumber>;
 template class SparseDeterministicVisitingTimesHelper<storm::RationalFunction>;
-
 }  // namespace helper
 }  // namespace modelchecker
 }  // namespace storm

--- a/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.cpp
+++ b/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.cpp
@@ -392,7 +392,7 @@ storm::Environment SparseDeterministicVisitingTimesHelper<ValueType>::getEnviron
             if (maxNumInc != 0) {
                 // As the maximal number of incoming transitions is greater than one, adjustment is necessary.
                 // For this, we need the number of SCCs in the longest SCC chain -1, i.e., sccDecomposition->getMaxSccDepth() -1
-                for (int i = 1; i < sccDecomposition->getMaxSccDepth(); i++) {
+                for (uint64_t i = 1; i < sccDecomposition->getMaxSccDepth(); i++) {
                     scale = scale + storm::utility::pow(storm::utility::convertNumber<storm::RationalNumber>(maxNumInc), i) *
                                         storm::utility::convertNumber<storm::RationalNumber>(boundEVT);
                 }

--- a/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.h
+++ b/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.h
@@ -5,6 +5,7 @@
 #include "storm/storage/BitVector.h"
 #include "storm/storage/SparseMatrix.h"
 #include "storm/storage/StronglyConnectedComponentDecomposition.h"
+#include "storm/utility/OptionalRef.h"
 
 namespace storm {
 class Environment;
@@ -154,12 +155,12 @@ class SparseDeterministicVisitingTimesHelper : public SingleValueModelCheckerHel
                                                    std::vector<ValueType> const& stateValues) const;
 
     storm::storage::SparseMatrix<ValueType> const& transitionMatrix;
-    std::vector<ValueType> const* exitRates;
+    storm::OptionalRef<std::vector<ValueType> const> exitRates;
 
-    storm::storage::SparseMatrix<ValueType> const* backwardTransitions;
+    storm::OptionalRef<storm::storage::SparseMatrix<ValueType> const> backwardTransitions;
     std::unique_ptr<storm::storage::SparseMatrix<ValueType>> computedBackwardTransitions;
 
-    storm::storage::StronglyConnectedComponentDecomposition<ValueType> const* sccDecomposition;
+    storm::OptionalRef<storm::storage::StronglyConnectedComponentDecomposition<ValueType> const> sccDecomposition;
     std::unique_ptr<storm::storage::StronglyConnectedComponentDecomposition<ValueType>> computedSccDecomposition;
 
     storm::storage::BitVector nonBsccStates;

--- a/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.h
+++ b/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.h
@@ -15,6 +15,7 @@ namespace helper {
 
 /*!
  * Helper class for computing for each state the expected number of times to visit that state assuming a given initial distribution.
+ * @see https://arxiv.org/abs/2401.10638 for theoretical background of this.
  * @tparam ValueType the type a value can have
  */
 template<typename ValueType>

--- a/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.h
+++ b/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.h
@@ -83,6 +83,22 @@ class SparseDeterministicVisitingTimesHelper : public SingleValueModelCheckerHel
      */
     void computeExpectedVisitingTimes(Environment const& env, std::vector<ValueType>& stateValues);
 
+    /*!
+     * Computes for each selected state the expected number of times we are visiting that state assuming the given initial state probabilities
+     * The interpretation of the subsystem is that once a path has exited the subsystem, all subsequent visits will be ignored.
+     * All states within the subsystem must reach a state outside of the subsystem almost surely. In other words, the subsystem shall not contain a BSCC.
+     *
+     * @param subsystem the set of states for which visiting times are computed.
+     * @param initialValues contains for each subsystem state the initial value (probability) for that state.
+     *        The values can actually sum up to something different than 1 but should be non-negative.
+     * @return the expected visiting times for the states in the subsystem.
+     *
+     * @pre subsystem.getNumberOfSetBits() == initialValues.size()
+     * @post result.size() == initialValues.size()
+     */
+    std::vector<ValueType> computeExpectedVisitingTimes(Environment const& env, storm::storage::BitVector const& subsystem,
+                                                        std::vector<ValueType> const& initialValues) const;
+
    private:
     /*!
      * @return true iff this is a computation on a continuous time model (i.e. CTMC, MA)
@@ -100,9 +116,30 @@ class SparseDeterministicVisitingTimesHelper : public SingleValueModelCheckerHel
     void createDecomposition(Environment const& env);
 
     /*!
-     * @return the environment used when solving non-trivial SCCs.
+     * @post _nonBsccStates points to the vector of non-BSCC states
      */
-    storm::Environment getEnvironmentForSccSolver(storm::Environment const& env) const;
+    void createNonBsccStateVector();
+
+    /*!
+     * Computes for each state an upper bound on the expected number of times we are visiting that state.
+     * @note The upper bounds are computed using techniques from by Baier et al. [CAV'17] (https://doi.org/10.1007/978-3-319-63387-9_8)
+     * @param stateSetAsBitVector the states for which the upper bounds are computed.
+     * @return for each state the upper bound on the expected number of times that state is visited.
+     */
+    std::vector<ValueType> computeUpperBounds(storm::storage::BitVector const& stateSetAsBitVector) const;
+
+    /*!
+     * Adapts the precision of the solving method if necessary (i.e., if the model is a CTMC or when a topological solving method is used).
+     * @param env The environment, containing information on the precision that should be achieved.
+     * @param topological If set to true, the environment when solving non-trivial SCCs for topological solving method is returned.
+     * @return the environment used when solving the equation system(s) for EVTs with adapted precision for a topological solving method or CTMCs.
+     */
+    storm::Environment getEnvironmentForSolver(storm::Environment const& env, bool topological = false) const;
+
+    /*!
+     * @return the environment used when solving non-trivial SCCs for topological solving method.
+     */
+    storm::Environment getEnvironmentForTopologicalSolver(storm::Environment const& env) const;
 
     /*!
      * Processes (bottom or non-bottom SCCs consisting of a single state). The resulting value is directly inserted into stateValues
@@ -110,20 +147,22 @@ class SparseDeterministicVisitingTimesHelper : public SingleValueModelCheckerHel
     void processSingletonScc(uint64_t sccState, std::vector<ValueType>& stateValues) const;
 
     /*!
-     * Solves the equation system for non-trivial SCCs (i.e. non-bottom SCCs with more than 1 state).
-     * @return for each state of the given SCC the expected number of times that state is visited.
+     * Solves the equation system for non-singleton (subs)sets of the chain's non-bottom states.
+     * @return for each state of the given set the expected number of times that state is visited.
      */
-    std::vector<ValueType> computeValueForNonTrivialScc(storm::Environment const& env, storm::storage::BitVector const& sccAsBitVector,
-                                                        std::vector<ValueType> const& stateValues) const;
+    std::vector<ValueType> computeValueForStateSet(storm::Environment const& env, storm::storage::BitVector const& stateSetAsBitVector,
+                                                   std::vector<ValueType> const& stateValues) const;
 
-    storm::storage::SparseMatrix<ValueType> const& _transitionMatrix;
-    std::vector<ValueType> const* _exitRates;
+    storm::storage::SparseMatrix<ValueType> const& transitionMatrix;
+    std::vector<ValueType> const* exitRates;
 
-    storm::storage::SparseMatrix<ValueType> const* _backwardTransitions;
-    std::unique_ptr<storm::storage::SparseMatrix<ValueType>> _computedBackwardTransitions;
+    storm::storage::SparseMatrix<ValueType> const* backwardTransitions;
+    std::unique_ptr<storm::storage::SparseMatrix<ValueType>> computedBackwardTransitions;
 
-    storm::storage::StronglyConnectedComponentDecomposition<ValueType> const* _sccDecomposition;
-    std::unique_ptr<storm::storage::StronglyConnectedComponentDecomposition<ValueType>> _computedSccDecomposition;
+    storm::storage::StronglyConnectedComponentDecomposition<ValueType> const* sccDecomposition;
+    std::unique_ptr<storm::storage::StronglyConnectedComponentDecomposition<ValueType>> computedSccDecomposition;
+
+    storm::storage::BitVector nonBsccStates;
 };
 
 }  // namespace helper

--- a/src/storm/modelchecker/helper/infinitehorizon/SparseDeterministicInfiniteHorizonHelper.cpp
+++ b/src/storm/modelchecker/helper/infinitehorizon/SparseDeterministicInfiniteHorizonHelper.cpp
@@ -1,5 +1,7 @@
 #include "SparseDeterministicInfiniteHorizonHelper.h"
 
+#include <numeric>
+
 #include "storm/adapters/RationalFunctionAdapter.h"
 #include "storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.h"
 #include "storm/modelchecker/helper/infinitehorizon/internal/ComponentUtility.h"
@@ -16,6 +18,7 @@
 #include "storm/utility/solver.h"
 #include "storm/utility/vector.h"
 
+#include "storm/environment/modelchecker/ModelCheckerEnvironment.h"
 #include "storm/environment/solver/LongRunAverageSolverEnvironment.h"
 #include "storm/environment/solver/TopologicalSolverEnvironment.h"
 
@@ -244,20 +247,10 @@ std::pair<ValueType, std::vector<ValueType>> SparseDeterministicInfiniteHorizonH
 template<typename ValueType>
 std::vector<ValueType> SparseDeterministicInfiniteHorizonHelper<ValueType>::computeSteadyStateDistrForBscc(
     Environment const& env, storm::storage::StronglyConnectedComponent const& bscc) {
-    // We want that the returned values are sorted properly. Let's assert that strongly connected components use a sorted container type
-    STORM_LOG_ASSERT(std::is_sorted(bscc.begin(), bscc.end()), "Expected that bsccs are sorted.");
-
-    // Let A be ab auxiliary Matrix with A[s,s] =  R(s,s) - r(s) & A[s,s'] = R(s,s') for s,s' in BSCC and s!=s'.
-    // We build and solve the equation system for
-    // x*A=0 &  x_0+...+x_n=1  <=>  A^t*x=0=x-x & x_0+...+x_n=1  <=> (1+A^t)*x = x & 1-x_0-...-x_n-1=x_n
-    // Then, x[i] will be the fraction of the time we are in state i.
-
-    // This method assumes that this BSCC consist of more than one state.
-    // We therefore catch the (easy) case where the BSCC is a singleton.
+    // We catch the (easy) case where the BSCC is a singleton.
     if (bscc.size() == 1) {
         return {storm::utility::one<ValueType>()};
     }
-
     // Prepare an environment for the underlying linear equation solver
     auto subEnv = env;
     if (subEnv.solver().getLinearEquationSolverType() == storm::solver::EquationSolverType::Topological) {
@@ -265,9 +258,106 @@ std::vector<ValueType> SparseDeterministicInfiniteHorizonHelper<ValueType>::comp
         subEnv.solver().setLinearEquationSolverType(subEnv.solver().topological().getUnderlyingEquationSolverType(),
                                                     subEnv.solver().topological().isUnderlyingEquationSolverTypeSetFromDefault());
     }
-    subEnv.solver().setLinearEquationSolverPrecision(env.solver().lra().getPrecision(), env.solver().lra().getRelativeTerminationCriterion());
-    STORM_LOG_WARN_COND(!subEnv.solver().isForceSoundness(),
+
+    auto alg = subEnv.modelchecker().getSteadyStateDistributionAlgorithm();
+    if (alg == storm::SteadyStateDistributionAlgorithm::Automatic) {
+        if (subEnv.solver().isForceSoundness()) {
+            alg = storm::SteadyStateDistributionAlgorithm::ExpectedVisitingTimes;
+        } else {
+            alg = storm::SteadyStateDistributionAlgorithm::EquationSystem;
+        }
+    }
+    if (alg == storm::SteadyStateDistributionAlgorithm::Classic) {
+        alg = storm::SteadyStateDistributionAlgorithm::EquationSystem;
+    }
+
+    if (alg == storm::SteadyStateDistributionAlgorithm::EquationSystem) {
+        return computeSteadyStateDistrForBsccEqSys(subEnv, bscc);
+    } else {
+        STORM_LOG_ASSERT(alg == storm::SteadyStateDistributionAlgorithm::ExpectedVisitingTimes,
+                         "Unexpected algorithm for steady state distribution computation.");
+        return computeSteadyStateDistrForBsccEVTs(subEnv, bscc);
+    }
+}
+
+template<typename ValueType>
+std::vector<ValueType> SparseDeterministicInfiniteHorizonHelper<ValueType>::computeSteadyStateDistrForBsccEVTs(
+    Environment const& env, storm::storage::StronglyConnectedComponent const& bscc) {
+    storm::storage::BitVector bsccAsBitVector(this->_transitionMatrix.getColumnCount(), false);
+    bsccAsBitVector.set(bscc.begin(), bscc.end(), true);
+
+    // Remove one state from the BSCC (so it becomes an SCC) and compute visiting times on that SCC.
+    uint64_t const proxyState = *bsccAsBitVector.rbegin();
+    bsccAsBitVector.set(proxyState, false);
+    auto visittimesHelper = this->isContinuousTime() ? SparseDeterministicVisitingTimesHelper<ValueType>(this->_transitionMatrix, *this->_exitRates)
+                                                     : SparseDeterministicVisitingTimesHelper<ValueType>(this->_transitionMatrix);
+    this->createBackwardTransitions();
+    visittimesHelper.provideBackwardTransitions(*this->_backwardTransitions);
+    std::vector<ValueType> initialValues;
+    initialValues.reserve(bscc.size() - 1);
+    auto row = this->_transitionMatrix.getRow(proxyState);
+    auto entryIt = row.begin();
+    auto const entryItEnd = row.end();
+    for (auto state : bsccAsBitVector) {
+        if (entryIt != entryItEnd && state == entryIt->getColumn()) {
+            initialValues.push_back(entryIt->getValue());
+            ++entryIt;
+        } else {
+            initialValues.push_back(storm::utility::zero<ValueType>());
+        }
+    }
+    STORM_LOG_ASSERT(entryIt == entryItEnd || entryIt->getColumn() == proxyState, "Unexpected matrix row.");
+    auto evtEnv = env;
+    if (evtEnv.solver().isForceSoundness()) {
+        auto prec = evtEnv.solver().getPrecisionOfLinearEquationSolver(evtEnv.solver().getLinearEquationSolverType());
+        if (prec.first.is_initialized()) {
+            auto requiredPrecision = *prec.first;
+            // We need to adapt the precision. We focus on propagation of relative errors. Absolut precision is then also fine as we're computing with values in
+            // [0,1].
+            //
+            // We are going to normalize a vector of EVTs. Assuming that the EVT vector has been computed with relative precision eps, the sum of all
+            // EVTs still is eps-precise w.r.t. the exact (unknown) sum of the EVTs. Let x and y be the computed EVT of a given state and the sum of all
+            // computed EVTs, respectively. We have relative errors of delta_x = (x-x')/x' and delta_y = (y-y')/y' respectively, where x' and y' are the exact
+            // values. Note that x = x' * (1+delta_x) and |delta_x| <= eps.
+            //
+            // The relative error in the normalized value x/y = (x'/y')*((1+delta_x)/(1+delta_y)) = (x'/y')*(1+((delta_x-delta_y)/(1+\delta_y))) can be upper
+            // bounded by 2*eps/(1-eps). We set eps so that this term is equal to requiredPrecision
+            storm::RationalNumber eps = requiredPrecision / (storm::utility::convertNumber<storm::RationalNumber, uint64_t>(2) + requiredPrecision);
+            evtEnv.solver().setLinearEquationSolverPrecision(eps, prec.second);
+        }
+    }
+    auto visitingTimes = visittimesHelper.computeExpectedVisitingTimes(evtEnv, bsccAsBitVector, initialValues);
+    visitingTimes.push_back(storm::utility::one<ValueType>());  // Add the value for the proxy state
+    bsccAsBitVector.set(proxyState, true);
+
+    ValueType sumOfVisitingTimes = storm::utility::zero<ValueType>();
+    if (this->isContinuousTime()) {
+        auto resultIt = visitingTimes.begin();
+        for (auto state : bsccAsBitVector) {
+            *resultIt /= (*this->_exitRates)[state];
+            sumOfVisitingTimes += *resultIt;
+            ++resultIt;
+        }
+    } else {
+        sumOfVisitingTimes = std::accumulate(visitingTimes.begin(), visitingTimes.end(), storm::utility::zero<ValueType>());
+    }
+    storm::utility::vector::scaleVectorInPlace(visitingTimes, storm::utility::one<ValueType>() / sumOfVisitingTimes);
+    return visitingTimes;
+}
+
+template<typename ValueType>
+std::vector<ValueType> SparseDeterministicInfiniteHorizonHelper<ValueType>::computeSteadyStateDistrForBsccEqSys(
+    Environment const& env, storm::storage::StronglyConnectedComponent const& bscc) {
+    // We want that the returned values are sorted properly. Let's assert that strongly connected components use a sorted container type
+    STORM_LOG_ASSERT(std::is_sorted(bscc.begin(), bscc.end()), "Expected that bsccs are sorted.");
+
+    STORM_LOG_WARN_COND(!env.solver().isForceSoundness(),
                         "Sound computations are not properly implemented for this computation. You might get incorrect results.");
+
+    // Let A be ab auxiliary Matrix with A[s,s] =  R(s,s) - r(s) & A[s,s'] = R(s,s') for s,s' in BSCC and s!=s'.
+    // We build and solve the equation system for
+    // x*A=0 &  x_0+...+x_n=1  <=>  A^t*x=0=x-x & x_0+...+x_n=1  <=> (1+A^t)*x = x & 1-x_0-...-x_n-1=x_n
+    // Then, x[i] will be the fraction of the time we are in state i.
 
     // Get a mapping from global state indices to local ones as well as a bitvector containing states within the BSCC.
     std::unordered_map<uint64_t, uint64_t> toLocalIndexMap;
@@ -301,7 +391,7 @@ std::vector<ValueType> SparseDeterministicInfiniteHorizonHelper<ValueType>::comp
 
     // Check whether we need the fixpoint characterization
     storm::solver::GeneralLinearEquationSolverFactory<ValueType> linearEquationSolverFactory;
-    bool isFixpointFormat = linearEquationSolverFactory.getEquationProblemFormat(subEnv) == storm::solver::LinearEquationSolverProblemFormat::FixedPointSystem;
+    bool isFixpointFormat = linearEquationSolverFactory.getEquationProblemFormat(env) == storm::solver::LinearEquationSolverProblemFormat::FixedPointSystem;
     if (isFixpointFormat) {
         // Add a 1 on the diagonal
         for (row = 0; row < auxMatrix.getRowCount(); ++row) {
@@ -346,21 +436,21 @@ std::vector<ValueType> SparseDeterministicInfiniteHorizonHelper<ValueType>::comp
     bsccEquationSystemRightSide.back() = storm::utility::one<ValueType>();
 
     // Create a linear equation solver
-    auto solver = linearEquationSolverFactory.create(subEnv, builder.build());
+    auto solver = linearEquationSolverFactory.create(env, builder.build());
     solver->setBounds(storm::utility::zero<ValueType>(), storm::utility::one<ValueType>());
     // Check solver requirements.
-    auto requirements = solver->getRequirements(subEnv);
+    auto requirements = solver->getRequirements(env);
     requirements.clearLowerBounds();
     requirements.clearUpperBounds();
     STORM_LOG_THROW(!requirements.hasEnabledCriticalRequirement(), storm::exceptions::UnmetRequirementException,
                     "Solver requirements " + requirements.getEnabledRequirementsAsString() + " not checked.");
 
     std::vector<ValueType> steadyStateDistr(bscc.size(), storm::utility::one<ValueType>() / storm::utility::convertNumber<ValueType, uint64_t>(bscc.size()));
-    solver->solveEquations(subEnv, steadyStateDistr, bsccEquationSystemRightSide);
+    solver->solveEquations(env, steadyStateDistr, bsccEquationSystemRightSide);
 
     // As a last step, we normalize these values to counter numerical inaccuracies a bit.
     // This is only reasonable in non-exact mode.
-    if (!subEnv.solver().isForceExact()) {
+    if (!env.solver().isForceExact()) {
         ValueType sum = std::accumulate(steadyStateDistr.begin(), steadyStateDistr.end(), storm::utility::zero<ValueType>());
         storm::utility::vector::scaleVectorInPlace<ValueType, ValueType>(steadyStateDistr, storm::utility::one<ValueType>() / sum);
     }
@@ -504,14 +594,32 @@ std::vector<ValueType> SparseDeterministicInfiniteHorizonHelper<ValueType>::comp
     Environment const& env, ValueGetter const& initialDistributionGetter) {
     createDecomposition();
 
+    Environment subEnv = env;
+    if (subEnv.solver().isForceSoundness()) {
+        // We need to adapt the precision. We focus on propagation of relative errors. Absolut precision is then also fine as we're dealing with values in
+        // [0,1]
+        auto prec = subEnv.solver().getPrecisionOfLinearEquationSolver(subEnv.solver().getLinearEquationSolverType());
+        if (prec.first.is_initialized()) {
+            auto requiredPrecision = *prec.first;
+            // We are going to multiply two numbers x and y that each have relative errors of delta_x = (x-x')/x' and delta_y = (y-y')/y' respectively.
+            // Here, x' and y' are the exact values. Note that x = x' * (1+delta_x) and |delta_x| <= eps
+            // The result x*y= x' * y' * (1+delta_x) * (1+delta_y) will have a relative error of delta_x + delta_y + delta_x*\delta_y  <= (2eps * eps^2)
+            // We set eps such that (2eps * eps^2) <= requiredPrecision
+            storm::RationalNumber eps = storm::utility::sqrt<RationalNumber>(storm::utility::one<storm::RationalNumber>() + requiredPrecision) -
+                                        storm::utility::one<storm::RationalNumber>();
+            subEnv.solver().setLinearEquationSolverPrecision(eps, prec.second);
+            STORM_LOG_INFO("Precision for BSCC reachability and BSCC steady state distribution analysis set to " << storm::utility::convertNumber<double>(eps)
+                                                                                                                 << ".");
+        }
+    }
     // Compute for each BSCC get the probability with which we reach that BSCC
-    auto bsccReachProbs = computeBsccReachabilityProbabilities(env, initialDistributionGetter);
+    auto bsccReachProbs = computeBsccReachabilityProbabilities(subEnv, initialDistributionGetter);
     // We are now ready to compute the resulting lra distribution
     std::vector<ValueType> steadyStateDistr(this->_transitionMatrix.getRowGroupCount(), storm::utility::zero<ValueType>());
     for (uint64_t currentComponentIndex = 0; currentComponentIndex < this->_longRunComponentDecomposition->size(); ++currentComponentIndex) {
         auto const& component = (*this->_longRunComponentDecomposition)[currentComponentIndex];
         // Compute distribution for current bscc
-        auto bsccDistr = this->computeSteadyStateDistrForBscc(env, component);
+        auto bsccDistr = this->computeSteadyStateDistrForBscc(subEnv, component);
         // Scale with probability to reach that bscc
         auto const& scalingFactor = bsccReachProbs[currentComponentIndex];
         if (!storm::utility::isOne(scalingFactor)) {
@@ -546,47 +654,126 @@ template<typename ValueType>
 std::vector<ValueType> SparseDeterministicInfiniteHorizonHelper<ValueType>::computeBsccReachabilityProbabilities(Environment const& env,
                                                                                                                  ValueGetter const& initialDistributionGetter) {
     STORM_LOG_ASSERT(this->_longRunComponentDecomposition != nullptr, "Decomposition not computed, yet.");
-    uint64_t numBSCCs = this->_longRunComponentDecomposition->size();
-    STORM_LOG_ASSERT(numBSCCs > 0, "Found 0 BSCCs in a Markov chain. This should not be possible.");
 
     // Compute for each BSCC get the probability with which we reach that BSCC
-    std::vector<ValueType> bsccReachProbs(numBSCCs, storm::utility::zero<ValueType>());
-    if (numBSCCs == 1) {
-        bsccReachProbs.front() = storm::utility::one<ValueType>();
+    std::vector<ValueType> bsccReachProbs;
+    if (auto numBSCCs = this->_longRunComponentDecomposition->size(); numBSCCs <= 1) {
+        STORM_LOG_ASSERT(numBSCCs == 1, "Found 0 BSCCs in a Markov chain. This should not be possible.");
+        bsccReachProbs = std::vector<ValueType>({storm::utility::one<ValueType>()});
     } else {
-        // Get the expected number of times we visit each non-BSCC state
-        // We deliberately exclude the exit rates here as we want to make this computation on the induced DTMC to get the expected number of times
-        // that a successor state is chosen probabilistically.
-        auto visittimesHelper = SparseDeterministicVisitingTimesHelper<ValueType>(this->_transitionMatrix);
-        this->createBackwardTransitions();
-        visittimesHelper.provideBackwardTransitions(*this->_backwardTransitions);
-        auto expVisitTimes = visittimesHelper.computeExpectedVisitingTimes(env, initialDistributionGetter);
-        // Then use the expected visiting times to compute BSCC reachability probabilities
-        storm::storage::BitVector nonBsccStates(this->_transitionMatrix.getRowCount(), true);
-        for (uint64_t currentComponentIndex = 0; currentComponentIndex < this->_longRunComponentDecomposition->size(); ++currentComponentIndex) {
-            for (auto const& element : (*this->_longRunComponentDecomposition)[currentComponentIndex]) {
-                nonBsccStates.set(internal::getComponentElementState(element), false);
-            }
-        }
-        for (uint64_t currentComponentIndex = 0; currentComponentIndex < this->_longRunComponentDecomposition->size(); ++currentComponentIndex) {
-            auto& bsccVal = bsccReachProbs[currentComponentIndex];
-            for (auto const& element : (*this->_longRunComponentDecomposition)[currentComponentIndex]) {
-                uint64_t state = internal::getComponentElementState(element);
-                bsccVal += initialDistributionGetter(state);
-                for (auto const& pred : this->_backwardTransitions->getRow(state)) {
-                    if (nonBsccStates.get(pred.getColumn())) {
-                        bsccVal += pred.getValue() * expVisitTimes[pred.getColumn()];
-                    }
-                }
-            }
+        if (env.modelchecker().getSteadyStateDistributionAlgorithm() == SteadyStateDistributionAlgorithm::Classic) {
+            bsccReachProbs = computeBsccReachabilityProbabilitiesClassic(env, initialDistributionGetter);
+        } else {
+            bsccReachProbs = computeBsccReachabilityProbabilitiesEVTs(env, initialDistributionGetter);
         }
     }
 
-    // As a last step, we normalize these values to counter numerical inaccuracies a bit.
-    // This is only reasonable in non-exact mode.
-    if (!env.solver().isForceExact()) {
+    // As a last step, we normalize these values to counter inaccuracies a bit.
+    // This is only reasonable in non-exact mode and can invalidate accuracy guarantees in sound mode.
+    if (!env.solver().isForceExact() && !env.solver().isForceSoundness()) {
         ValueType sum = std::accumulate(bsccReachProbs.begin(), bsccReachProbs.end(), storm::utility::zero<ValueType>());
         storm::utility::vector::scaleVectorInPlace<ValueType, ValueType>(bsccReachProbs, storm::utility::one<ValueType>() / sum);
+    }
+    return bsccReachProbs;
+}
+
+template<typename ValueType>
+std::vector<ValueType> SparseDeterministicInfiniteHorizonHelper<ValueType>::computeBsccReachabilityProbabilitiesClassic(
+    Environment const& env, ValueGetter const& initialDistributionGetter) {
+    // Solve a linear equation system for each BSCC
+
+    // Get the states that do not lie on any BSCC
+    storm::storage::BitVector nonBsccStates(this->_transitionMatrix.getRowCount(), true);
+    for (uint64_t currentComponentIndex = 0; currentComponentIndex < this->_longRunComponentDecomposition->size(); ++currentComponentIndex) {
+        for (auto const& element : (*this->_longRunComponentDecomposition)[currentComponentIndex]) {
+            nonBsccStates.set(internal::getComponentElementState(element), false);
+        }
+    }
+    bool const hasNonBsccStates = !nonBsccStates.empty();
+
+    // Set-up a linear equation solver (unless all states are on a BSCC)
+    std::unique_ptr<storm::solver::LinearEquationSolver<ValueType>> solver;
+    if (hasNonBsccStates) {
+        storm::solver::GeneralLinearEquationSolverFactory<ValueType> linearEquationSolverFactory;
+        bool isEquationSystemFormat =
+            linearEquationSolverFactory.getEquationProblemFormat(env) == storm::solver::LinearEquationSolverProblemFormat::EquationSystem;
+        auto subMatrix = this->_transitionMatrix.getSubmatrix(false, nonBsccStates, nonBsccStates, isEquationSystemFormat);
+        if (isEquationSystemFormat) {
+            subMatrix.convertToEquationSystem();
+        }
+        solver = linearEquationSolverFactory.create(env, std::move(subMatrix));
+        solver->setBounds(storm::utility::zero<ValueType>(), storm::utility::one<ValueType>());
+        // Check solver requirements.
+        auto requirements = solver->getRequirements(env);
+        requirements.clearLowerBounds();
+        requirements.clearUpperBounds();
+        STORM_LOG_THROW(!requirements.hasEnabledCriticalRequirement(), storm::exceptions::UnmetRequirementException,
+                        "Solver requirements " + requirements.getEnabledRequirementsAsString() + " not checked.");
+        solver->setCachingEnabled(true);
+    }
+
+    // Run over all BSCCs
+    std::vector<ValueType> bsccReachProbs(this->_longRunComponentDecomposition->size(), storm::utility::zero<ValueType>());
+    for (uint64_t currentComponentIndex = 0; currentComponentIndex < this->_longRunComponentDecomposition->size(); ++currentComponentIndex) {
+        auto const& bscc = (*this->_longRunComponentDecomposition)[currentComponentIndex];
+        auto& bsccVal = bsccReachProbs[currentComponentIndex];
+        // Deal with initial states within the BSCC
+        for (auto const& element : (*this->_longRunComponentDecomposition)[currentComponentIndex]) {
+            uint64_t state = internal::getComponentElementState(element);
+            bsccVal += initialDistributionGetter(state);
+        }
+        // Add reachability probabilities for initial states outside of this BSCC
+        if (hasNonBsccStates) {
+            storm::storage::BitVector bsccAsBitVector(this->_transitionMatrix.getColumnCount(), false);
+            bsccAsBitVector.set(bscc.begin(), bscc.end(), true);
+            // set up and solve the equation system for this BSCC
+            std::vector<ValueType> eqSysRhs;
+            eqSysRhs.reserve(nonBsccStates.getNumberOfSetBits());
+            for (auto state : nonBsccStates) {
+                eqSysRhs.push_back(this->_transitionMatrix.getConstrainedRowSum(state, bsccAsBitVector));
+            }
+            std::vector<ValueType> eqSysSolution(eqSysRhs.size());
+            solver->solveEquations(env, eqSysSolution, eqSysRhs);
+            // Sum up reachability probabilities over initial states
+            uint64_t subsysState = 0;
+            for (auto globalState : nonBsccStates) {
+                bsccVal += initialDistributionGetter(globalState) * eqSysSolution[subsysState];
+                ++subsysState;
+            }
+        }
+    }
+    return bsccReachProbs;
+}
+
+template<typename ValueType>
+std::vector<ValueType> SparseDeterministicInfiniteHorizonHelper<ValueType>::computeBsccReachabilityProbabilitiesEVTs(
+    Environment const& env, ValueGetter const& initialDistributionGetter) {
+    // Get the expected number of times we visit each non-BSCC state
+    // We deliberately exclude the exit rates here as we want to make this computation on the induced DTMC to get the expected number of times
+    // that a successor state is chosen probabilistically.
+    auto visittimesHelper = SparseDeterministicVisitingTimesHelper<ValueType>(this->_transitionMatrix);
+    this->createBackwardTransitions();
+    visittimesHelper.provideBackwardTransitions(*this->_backwardTransitions);
+    auto expVisitTimes = visittimesHelper.computeExpectedVisitingTimes(env, initialDistributionGetter);
+    // Then use the expected visiting times to compute BSCC reachability probabilities
+    storm::storage::BitVector nonBsccStates(this->_transitionMatrix.getRowCount(), true);
+    for (uint64_t currentComponentIndex = 0; currentComponentIndex < this->_longRunComponentDecomposition->size(); ++currentComponentIndex) {
+        for (auto const& element : (*this->_longRunComponentDecomposition)[currentComponentIndex]) {
+            nonBsccStates.set(internal::getComponentElementState(element), false);
+        }
+    }
+    std::vector<ValueType> bsccReachProbs(this->_longRunComponentDecomposition->size(), storm::utility::zero<ValueType>());
+    for (uint64_t currentComponentIndex = 0; currentComponentIndex < this->_longRunComponentDecomposition->size(); ++currentComponentIndex) {
+        auto& bsccVal = bsccReachProbs[currentComponentIndex];
+        for (auto const& element : (*this->_longRunComponentDecomposition)[currentComponentIndex]) {
+            uint64_t state = internal::getComponentElementState(element);
+            bsccVal += initialDistributionGetter(state);
+            for (auto const& pred : this->_backwardTransitions->getRow(state)) {
+                if (nonBsccStates.get(pred.getColumn())) {
+                    bsccVal += pred.getValue() * expVisitTimes[pred.getColumn()];
+                }
+            }
+        }
     }
     return bsccReachProbs;
 }

--- a/src/storm/modelchecker/helper/infinitehorizon/SparseDeterministicInfiniteHorizonHelper.cpp
+++ b/src/storm/modelchecker/helper/infinitehorizon/SparseDeterministicInfiniteHorizonHelper.cpp
@@ -283,6 +283,7 @@ std::vector<ValueType> SparseDeterministicInfiniteHorizonHelper<ValueType>::comp
 template<typename ValueType>
 std::vector<ValueType> SparseDeterministicInfiniteHorizonHelper<ValueType>::computeSteadyStateDistrForBsccEVTs(
     Environment const& env, storm::storage::StronglyConnectedComponent const& bscc) {
+    //  Computes steady state distributions by computing EVTs on a slightly modified system. See https://arxiv.org/abs/2401.10638 for more information.
     storm::storage::BitVector bsccAsBitVector(this->_transitionMatrix.getColumnCount(), false);
     bsccAsBitVector.set(bscc.begin(), bscc.end(), true);
 
@@ -749,6 +750,7 @@ template<typename ValueType>
 std::vector<ValueType> SparseDeterministicInfiniteHorizonHelper<ValueType>::computeBsccReachabilityProbabilitiesEVTs(
     Environment const& env, ValueGetter const& initialDistributionGetter) {
     // Get the expected number of times we visit each non-BSCC state
+    // See  https://arxiv.org/abs/2401.10638 for more information.
     // We deliberately exclude the exit rates here as we want to make this computation on the induced DTMC to get the expected number of times
     // that a successor state is chosen probabilistically.
     auto visittimesHelper = SparseDeterministicVisitingTimesHelper<ValueType>(this->_transitionMatrix);

--- a/src/storm/modelchecker/helper/infinitehorizon/SparseDeterministicInfiniteHorizonHelper.h
+++ b/src/storm/modelchecker/helper/infinitehorizon/SparseDeterministicInfiniteHorizonHelper.h
@@ -59,11 +59,15 @@ class SparseDeterministicInfiniteHorizonHelper : public SparseInfiniteHorizonHel
      * Computes for each BSCC the probability to reach that SCC assuming the given distribution over initial states.
      */
     std::vector<ValueType> computeBsccReachabilityProbabilities(Environment const& env, ValueGetter const& initialDistributionGetter);
+    std::vector<ValueType> computeBsccReachabilityProbabilitiesClassic(Environment const& env, ValueGetter const& initialDistributionGetter);
+    std::vector<ValueType> computeBsccReachabilityProbabilitiesEVTs(Environment const& env, ValueGetter const& initialDistributionGetter);
 
     /*!
      * Computes the long run average (steady state) distribution for the given BSCC.
      */
     std::vector<ValueType> computeSteadyStateDistrForBscc(Environment const& env, storm::storage::StronglyConnectedComponent const& bscc);
+    std::vector<ValueType> computeSteadyStateDistrForBsccEqSys(Environment const& env, storm::storage::StronglyConnectedComponent const& bscc);
+    std::vector<ValueType> computeSteadyStateDistrForBsccEVTs(Environment const& env, storm::storage::StronglyConnectedComponent const& bscc);
 
     std::pair<bool, ValueType> computeLraForTrivialBscc(Environment const& env, ValueGetter const& stateValuesGetter, ValueGetter const& actionValuesGetter,
                                                         storm::storage::StronglyConnectedComponent const& bscc);

--- a/src/storm/modelchecker/helper/infinitehorizon/SteadyStateDistributionAlgorithm.h
+++ b/src/storm/modelchecker/helper/infinitehorizon/SteadyStateDistributionAlgorithm.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace storm {
+enum class SteadyStateDistributionAlgorithm { Automatic, EquationSystem, ExpectedVisitingTimes, Classic };
+}

--- a/src/storm/settings/modules/IOSettings.h
+++ b/src/storm/settings/modules/IOSettings.h
@@ -5,6 +5,7 @@
 
 #include "storm-config.h"
 #include "storm/builder/ExplorationOrder.h"
+#include "storm/environment/modelchecker/ModelCheckerEnvironment.h"
 #include "storm/io/ModelExportFormat.h"
 #include "storm/settings/modules/ModuleSettings.h"
 
@@ -332,6 +333,11 @@ class IOSettings : public ModuleSettings {
      * Retrieves whether the steady-state distribution is to be computed.
      */
     bool isComputeSteadyStateDistributionSet() const;
+
+    /*!
+     * @return the algorithm used for computing steady state distributions
+     */
+    storm::SteadyStateDistributionAlgorithm getSteadyStateDistributionAlgorithm() const;
 
     /*!
      * Retrieves whether the expected visiting times are to be computed.

--- a/src/storm/settings/modules/IOSettings.h
+++ b/src/storm/settings/modules/IOSettings.h
@@ -5,8 +5,8 @@
 
 #include "storm-config.h"
 #include "storm/builder/ExplorationOrder.h"
-#include "storm/environment/modelchecker/ModelCheckerEnvironment.h"
 #include "storm/io/ModelExportFormat.h"
+#include "storm/modelchecker/helper/infinitehorizon/SteadyStateDistributionAlgorithm.h"
 #include "storm/settings/modules/ModuleSettings.h"
 
 namespace storm {

--- a/src/test/storm/modelchecker/csl/ExpectedVisitingTimesCtmcCslModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/csl/ExpectedVisitingTimesCtmcCslModelCheckerTest.cpp
@@ -33,6 +33,19 @@ class SparseGmmxxGmresIluEnvironment {
     }
 };
 
+class SparseSoundEnvironment {
+   public:
+    static const CtmcEngine engine = CtmcEngine::JaniSparse;
+    static const bool isExact = false;
+    typedef double ValueType;
+    typedef storm::models::sparse::Ctmc<ValueType> ModelType;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.solver().setForceSoundness(true);
+        return env;
+    }
+};
+
 class SparseEigenRationalLuEnvironment {
    public:
     static const CtmcEngine engine = CtmcEngine::JaniSparse;
@@ -92,7 +105,7 @@ class ExpectedVisitingTimesCtmcCslModelCheckerTest : public ::testing::Test {
     storm::Environment _environment;
 };
 
-typedef ::testing::Types<SparseGmmxxGmresIluEnvironment, SparseEigenRationalLuEnvironment> TestingTypes;
+typedef ::testing::Types<SparseGmmxxGmresIluEnvironment, SparseSoundEnvironment, SparseEigenRationalLuEnvironment> TestingTypes;
 
 TYPED_TEST_SUITE(ExpectedVisitingTimesCtmcCslModelCheckerTest, TestingTypes, );
 

--- a/src/test/storm/modelchecker/csl/SteadyStateCtmcCslModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/csl/SteadyStateCtmcCslModelCheckerTest.cpp
@@ -3,6 +3,7 @@
 
 #include "storm-parsers/api/model_descriptions.h"
 #include "storm/api/builder.h"
+#include "storm/environment/modelchecker/ModelCheckerEnvironment.h"
 #include "storm/environment/solver/EigenSolverEnvironment.h"
 #include "storm/environment/solver/GmmxxSolverEnvironment.h"
 #include "storm/environment/solver/NativeSolverEnvironment.h"
@@ -29,6 +30,33 @@ class SparseGmmxxGmresIluEnvironment {
         env.solver().gmmxx().setPreconditioner(storm::solver::GmmxxLinearEquationSolverPreconditioner::Ilu);
         // env.solver().gmmxx().setPrecision(storm::utility::convertNumber<storm::RationalNumber>(1e-6)); // Need to increase precision because eq sys yields
         // incorrect results
+        return env;
+    }
+};
+
+class SparseSoundEvtEnvironment {
+   public:
+    static const CtmcEngine engine = CtmcEngine::JaniSparse;
+    static const bool isExact = false;
+    typedef double ValueType;
+    typedef storm::models::sparse::Ctmc<ValueType> ModelType;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.modelchecker().setSteadyStateDistributionAlgorithm(storm::SteadyStateDistributionAlgorithm::ExpectedVisitingTimes);
+        env.solver().setForceSoundness(true);
+        return env;
+    }
+};
+
+class SparseClassicEnvironment {
+   public:
+    static const CtmcEngine engine = CtmcEngine::JaniSparse;
+    static const bool isExact = false;
+    typedef double ValueType;
+    typedef storm::models::sparse::Ctmc<ValueType> ModelType;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.modelchecker().setSteadyStateDistributionAlgorithm(storm::SteadyStateDistributionAlgorithm::Classic);
         return env;
     }
 };
@@ -92,7 +120,7 @@ class SteadyStateCtmcCslModelCheckerTest : public ::testing::Test {
     storm::Environment _environment;
 };
 
-typedef ::testing::Types<SparseGmmxxGmresIluEnvironment, SparseEigenRationalLuEnvironment> TestingTypes;
+typedef ::testing::Types<SparseGmmxxGmresIluEnvironment, SparseSoundEvtEnvironment, SparseClassicEnvironment, SparseEigenRationalLuEnvironment> TestingTypes;
 
 TYPED_TEST_SUITE(SteadyStateCtmcCslModelCheckerTest, TestingTypes, );
 


### PR DESCRIPTION
This PR incorporates the result of our TACAS'24 Paper "Accurately Computing Expected Visiting Times and Stationary Distributions in Markov Chains"  Preprint available [here](https://arxiv.org/abs/2401.10638).

`--sound` mode now works properly with correct accuracy using OVI and II for EVTs.
Steady-state distributions can now be computed using a reduction to EVT-based computations.

Using `--expvisittimes --prop 'Phi'` now restricts the result to states satisfying qualitative formula Phi. 
`--steadystate --prop 'Phi'` works similarly.


Co-authored-by: @m-hannah