### PR TITLE
Fixed DdPrismModelBuilder

### DIFF
--- a/resources/examples/testfiles/mdp/sync.nm
+++ b/resources/examples/testfiles/mdp/sync.nm
@@ -1,0 +1,15 @@
+mdp
+
+module m1
+
+    s1 : [0..2] init 0;
+
+    [decide] s1=0 -> 0.5 : (s1'=1) + 0.5 : (s1'=2);
+    [decide] s1=0 -> 0.2 : (s1'=1) + 0.8 : (s1'=2);
+    [] s1>0 -> true;
+
+endmodule
+
+module m2 = m1 [ s1=s2 ] endmodule
+
+label "target" = s1>1 & s2>1;

--- a/src/storm/builder/DdPrismModelBuilder.cpp
+++ b/src/storm/builder/DdPrismModelBuilder.cpp
@@ -911,11 +911,11 @@ storm::dd::Add<Type, ValueType> DdPrismModelBuilder<Type, ValueType>::encodeChoi
                                 << ".");
 
     std::map<storm::expressions::Variable, int_fast64_t> metaVariableNameToValueMap;
-    for (uint_fast64_t i = nondeterminismVariableOffset; i < nondeterminismVariableOffset + numberOfBinaryVariables; ++i) {
+    for (uint_fast64_t i = 0; i < numberOfBinaryVariables; ++i) {
         if (value & (1ull << (numberOfBinaryVariables - i - 1))) {
-            metaVariableNameToValueMap.emplace(generationInfo.nondeterminismMetaVariables[i], 1);
+            metaVariableNameToValueMap.emplace(generationInfo.nondeterminismMetaVariables[nondeterminismVariableOffset + i], 1);
         } else {
-            metaVariableNameToValueMap.emplace(generationInfo.nondeterminismMetaVariables[i], 0);
+            metaVariableNameToValueMap.emplace(generationInfo.nondeterminismMetaVariables[nondeterminismVariableOffset + i], 0);
         }
     }
 

--- a/src/test/storm/builder/DdJaniModelBuilderTest.cpp
+++ b/src/test/storm/builder/DdJaniModelBuilderTest.cpp
@@ -222,6 +222,17 @@ TEST(DdJaniModelBuilderTest_Sylvan, Mdp) {
     EXPECT_EQ(37ul, mdp->getNumberOfStates());
     EXPECT_EQ(59ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(59ul, mdp->getNumberOfChoices());
+
+    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/sync.nm");
+    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    model = builder.build(janiModel);
+
+    EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
+    mdp = model->as<storm::models::symbolic::Mdp<storm::dd::DdType::Sylvan>>();
+
+    EXPECT_EQ(5ul, mdp->getNumberOfStates());
+    EXPECT_EQ(24ul, mdp->getNumberOfTransitions());
+    EXPECT_EQ(12ul, mdp->getNumberOfChoices());
 }
 
 TEST(DdJaniModelBuilderTest_Cudd, Mdp) {
@@ -291,6 +302,17 @@ TEST(DdJaniModelBuilderTest_Cudd, Mdp) {
     EXPECT_EQ(37ul, mdp->getNumberOfStates());
     EXPECT_EQ(59ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(59ul, mdp->getNumberOfChoices());
+
+    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/sync.nm");
+    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    model = builder.build(janiModel);
+
+    EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
+    mdp = model->as<storm::models::symbolic::Mdp<storm::dd::DdType::CUDD>>();
+
+    EXPECT_EQ(5ul, mdp->getNumberOfStates());
+    EXPECT_EQ(24ul, mdp->getNumberOfTransitions());
+    EXPECT_EQ(12ul, mdp->getNumberOfChoices());
 }
 
 TEST(DdJaniModelBuilderTest_Cudd, SynchronizationVectors) {

--- a/src/test/storm/builder/DdPrismModelBuilderTest.cpp
+++ b/src/test/storm/builder/DdPrismModelBuilderTest.cpp
@@ -210,6 +210,16 @@ TEST(DdPrismModelBuilderTest_Sylvan, Mdp) {
     EXPECT_EQ(37ul, mdp->getNumberOfStates());
     EXPECT_EQ(59ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(59ul, mdp->getNumberOfChoices());
+
+    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/sync.nm");
+    program = modelDescription.preprocess().asPrismProgram();
+    model = storm::builder::DdPrismModelBuilder<storm::dd::DdType::Sylvan>().build(program);
+    EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
+    mdp = model->as<storm::models::symbolic::Mdp<storm::dd::DdType::Sylvan>>();
+
+    EXPECT_EQ(5ul, mdp->getNumberOfStates());
+    EXPECT_EQ(24ul, mdp->getNumberOfTransitions());
+    EXPECT_EQ(12ul, mdp->getNumberOfChoices());
 }
 
 TEST(DdPrismModelBuilderTest_Cudd, Mdp) {
@@ -274,6 +284,16 @@ TEST(DdPrismModelBuilderTest_Cudd, Mdp) {
     EXPECT_EQ(37ul, mdp->getNumberOfStates());
     EXPECT_EQ(59ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(59ul, mdp->getNumberOfChoices());
+
+    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/sync.nm");
+    program = modelDescription.preprocess().asPrismProgram();
+    model = storm::builder::DdPrismModelBuilder<storm::dd::DdType::CUDD>().build(program);
+    EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
+    mdp = model->as<storm::models::symbolic::Mdp<storm::dd::DdType::CUDD>>();
+
+    EXPECT_EQ(5ul, mdp->getNumberOfStates());
+    EXPECT_EQ(24ul, mdp->getNumberOfTransitions());
+    EXPECT_EQ(12ul, mdp->getNumberOfChoices());
 }
 
 TEST(DdPrismModelBuilderTest_Sylvan, Composition) {

--- a/src/test/storm/builder/ExplicitJaniModelBuilderTest.cpp
+++ b/src/test/storm/builder/ExplicitJaniModelBuilderTest.cpp
@@ -146,6 +146,13 @@ TEST(ExplicitJaniModelBuilderTest, Mdp) {
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(37ul, model->getNumberOfStates());
     EXPECT_EQ(59ul, model->getNumberOfTransitions());
+
+    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/sync.nm");
+    janiModel = program.toJani().substituteConstantsFunctions();
+    model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
+    EXPECT_EQ(5ul, model->getNumberOfStates());
+    EXPECT_EQ(24ul, model->getNumberOfTransitions());
+    EXPECT_EQ(12ul, model->getNumberOfChoices());
 }
 
 TEST(ExplicitJaniModelBuilderTest, Ma) {

--- a/src/test/storm/builder/ExplicitPrismModelBuilderTest.cpp
+++ b/src/test/storm/builder/ExplicitPrismModelBuilderTest.cpp
@@ -106,6 +106,12 @@ TEST(ExplicitPrismModelBuilderTest, Mdp) {
     EXPECT_EQ(36ul, model->getNumberOfStates());
     EXPECT_EQ(66ul, model->getNumberOfTransitions());
     EXPECT_EQ(36ul, model->getInitialStates().getNumberOfSetBits());
+
+    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/sync.nm");
+    model = storm::builder::ExplicitModelBuilder<double>(program).build();
+    EXPECT_EQ(5ul, model->getNumberOfStates());
+    EXPECT_EQ(24ul, model->getNumberOfTransitions());
+    EXPECT_EQ(12ul, model->getNumberOfChoices());
 }
 
 TEST(ExplicitPrismModelBuilderTest, Ma) {


### PR DESCRIPTION
The bug could occur when the same action appeared in multiple modules and multiple commands.

The revised code is now similar to the analogous code in the [DdJaniModelBuilder](https://github.com/tquatmann/storm/blob/fb047739d71d38f4e8b9e008696e0d927e5f84bd/src/storm/builder/DdJaniModelBuilder.cpp#L666)

Thanks @volkm for reporting this