### PR TITLE
Better automatic detection of available threads (fixes #495)

### DIFF
--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -45,6 +45,7 @@
 #include "storm/settings/modules/IOSettings.h"
 #include "storm/settings/modules/ModelCheckerSettings.h"
 #include "storm/settings/modules/ResourceSettings.h"
+#include "storm/settings/modules/SylvanSettings.h"
 #include "storm/settings/modules/TransformationSettings.h"
 #include "storm/storage/Qvbs.h"
 #include "storm/storage/jani/localeliminator/AutomaticAction.h"
@@ -1423,6 +1424,8 @@ void processInputWithValueType(SymbolicInput const& input, ModelProcessingInform
         processInputWithValueTypeAndDdlib<storm::dd::DdType::CUDD, double>(input, mpi);
     } else {
         STORM_LOG_ASSERT(mpi.ddType == storm::dd::DdType::Sylvan, "Unknown DD library.");
+        STORM_PRINT_AND_LOG("Using Sylvan with " << storm::settings::getModule<storm::settings::modules::SylvanSettings>().getNumberOfThreads()
+                                                 << " parallel threads.\n");
         if (mpi.buildValueType == mpi.verificationValueType) {
             processInputWithValueTypeAndDdlib<storm::dd::DdType::Sylvan, ValueType>(input, mpi);
         } else {

--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -436,6 +436,10 @@ inline std::vector<std::shared_ptr<storm::logic::Formula const>> createFormulasT
 
 template<storm::dd::DdType DdType, typename ValueType>
 std::shared_ptr<storm::models::ModelBase> buildModelDd(SymbolicInput const& input) {
+    if (DdType == storm::dd::DdType::Sylvan) {
+        auto numThreads = storm::settings::getModule<storm::settings::modules::SylvanSettings>().getNumberOfThreads();
+        STORM_PRINT_AND_LOG("Using Sylvan with " << numThreads << " parallel threads.\n");
+    }
     auto buildSettings = storm::settings::getModule<storm::settings::modules::BuildSettings>();
     return storm::api::buildSymbolicModel<DdType, ValueType>(input.model.get(), createFormulasToRespect(input.properties), buildSettings.isBuildFullModelSet(),
                                                              !buildSettings.isApplyNoMaximumProgressAssumptionSet());
@@ -1424,8 +1428,6 @@ void processInputWithValueType(SymbolicInput const& input, ModelProcessingInform
         processInputWithValueTypeAndDdlib<storm::dd::DdType::CUDD, double>(input, mpi);
     } else {
         STORM_LOG_ASSERT(mpi.ddType == storm::dd::DdType::Sylvan, "Unknown DD library.");
-        STORM_PRINT_AND_LOG("Using Sylvan with " << storm::settings::getModule<storm::settings::modules::SylvanSettings>().getNumberOfThreads()
-                                                 << " parallel threads.\n");
         if (mpi.buildValueType == mpi.verificationValueType) {
             processInputWithValueTypeAndDdlib<storm::dd::DdType::Sylvan, ValueType>(input, mpi);
         } else {

--- a/src/storm/settings/modules/SylvanSettings.cpp
+++ b/src/storm/settings/modules/SylvanSettings.cpp
@@ -6,6 +6,7 @@
 #include "storm/settings/ArgumentBuilder.h"
 #include "storm/settings/Option.h"
 #include "storm/settings/OptionBuilder.h"
+#include "storm/utility/threads.h"
 
 namespace storm {
 namespace settings {
@@ -39,7 +40,15 @@ bool SylvanSettings::isNumberOfThreadsSet() const {
 }
 
 uint_fast64_t SylvanSettings::getNumberOfThreads() const {
-    return this->getOption(threadCountOptionName).getArgumentByName("value").getValueAsUnsignedInteger();
+    uint64_t numThreads = std::max(1u, storm::utility::getNumberOfThreads());
+    if (isNumberOfThreadsSet()) {
+        auto numberFromSettings = this->getOption(threadCountOptionName).getArgumentByName("value").getValueAsUnsignedInteger();
+        STORM_LOG_WARN_COND(numberFromSettings <= numThreads, "Setting the number of sylvan threads to "
+                                                                  << numberFromSettings << " which exceeds the recommended number for your system ("
+                                                                  << numThreads << ").");
+        numThreads = numberFromSettings;
+    }
+    return numThreads;
 }
 
 }  // namespace modules

--- a/src/storm/settings/modules/SylvanSettings.cpp
+++ b/src/storm/settings/modules/SylvanSettings.cpp
@@ -40,15 +40,25 @@ bool SylvanSettings::isNumberOfThreadsSet() const {
 }
 
 uint_fast64_t SylvanSettings::getNumberOfThreads() const {
-    uint64_t numThreads = std::max(1u, storm::utility::getNumberOfThreads());
     if (isNumberOfThreadsSet()) {
         auto numberFromSettings = this->getOption(threadCountOptionName).getArgumentByName("value").getValueAsUnsignedInteger();
-        STORM_LOG_WARN_COND(numberFromSettings <= numThreads, "Setting the number of sylvan threads to "
-                                                                  << numberFromSettings << " which exceeds the recommended number for your system ("
-                                                                  << numThreads << ").");
-        numThreads = numberFromSettings;
+        if (numberFromSettings != 0u) {
+            return numberFromSettings;
+        }
     }
-    return numThreads;
+    // Automatic detection
+    return std::max(1u, storm::utility::getNumberOfThreads());
+}
+
+bool SylvanSettings::check() const {
+    if (isNumberOfThreadsSet()) {
+        auto const autoDetectThreads = std::max(1u, storm::utility::getNumberOfThreads());
+        auto const numberFromSettings = getNumberOfThreads();
+        STORM_LOG_WARN_COND(numberFromSettings <= autoDetectThreads, "Setting the number of sylvan threads to "
+                                                                         << numberFromSettings << " which exceeds the recommended number for your system ("
+                                                                         << autoDetectThreads << ").");
+    }
+    return true;
 }
 
 }  // namespace modules

--- a/src/storm/settings/modules/SylvanSettings.h
+++ b/src/storm/settings/modules/SylvanSettings.h
@@ -37,6 +37,8 @@ class SylvanSettings : public ModuleSettings {
      */
     bool isNumberOfThreadsSet() const;
 
+    bool check() const override;
+
     // The name of the module.
     static const std::string moduleName;
 

--- a/src/storm/storage/dd/sylvan/InternalSylvanDdManager.cpp
+++ b/src/storm/storage/dd/sylvan/InternalSylvanDdManager.cpp
@@ -68,14 +68,8 @@ InternalDdManager<DdType::Sylvan>::InternalDdManager() {
         size_t const task_deque_size = 1024 * 1024;
 
         lace_set_stacksize(1024 * 1024 * 16);  // 16 MiB
-        uint64_t numThreads = std::max(1u, lace_get_pu_count());
-        if (settings.isNumberOfThreadsSet()) {
-            STORM_LOG_WARN_COND(settings.getNumberOfThreads() <= numThreads,
-                                "Setting the number of sylvan threads to " << settings.getNumberOfThreads()
-                                                                           << " which exceeds the recommended number for your system (" << numThreads << ").");
-            numThreads = settings.getNumberOfThreads();
-        }
-        lace_start(numThreads, task_deque_size);
+
+        lace_start(settings.getNumberOfThreads(), task_deque_size);
 
         sylvan_set_limits(storm::settings::getModule<storm::settings::modules::SylvanSettings>().getMaximalMemory() * 1024 * 1024, 0, 0);
         sylvan_init_package();

--- a/src/storm/storage/dd/sylvan/InternalSylvanDdManager.h
+++ b/src/storm/storage/dd/sylvan/InternalSylvanDdManager.h
@@ -38,6 +38,8 @@ class InternalDdManager<DdType::Sylvan> {
      */
     ~InternalDdManager();
 
+    static std::size_t getNumberOfThreads(std::size_t numberFromSettings = 0);
+
     /*!
      * Retrieves a BDD representing the constant one function.
      *

--- a/src/storm/storage/dd/sylvan/InternalSylvanDdManager.h
+++ b/src/storm/storage/dd/sylvan/InternalSylvanDdManager.h
@@ -38,8 +38,6 @@ class InternalDdManager<DdType::Sylvan> {
      */
     ~InternalDdManager();
 
-    static std::size_t getNumberOfThreads(std::size_t numberFromSettings = 0);
-
     /*!
      * Retrieves a BDD representing the constant one function.
      *

--- a/src/storm/utility/threads.cpp
+++ b/src/storm/utility/threads.cpp
@@ -1,0 +1,68 @@
+#include "storm/utility/threads.h"
+
+#include <cstdlib>
+#include <thread>
+
+#include "storm/io/file.h"
+
+namespace storm::utility {
+
+namespace detail {
+static uint num_threads = 0u;
+
+uint tryReadFromSlurm() {
+    auto val = std::getenv("SLURM_CPUS_PER_TASK");
+    if (val != nullptr) {
+        char* end;
+        auto i = std::strtoul(val, &end, 10);
+        if (val != end) {
+            STORM_LOG_WARN("Detected thread limitation via Slurm (max. " << i << " threads.");
+            return static_cast<uint>(i);
+        }
+    }
+    return 0;
+}
+
+uint tryReadFromCgroups() {
+    std::string const filename = "/sys/fs/cgroup/cpu.max";
+    if (storm::utility::fileExistsAndIsReadable(filename)) {
+        std::ifstream inputFileStream;
+        storm::utility::openFile(filename, inputFileStream);
+        std::string contents;
+        storm::utility::getline(inputFileStream, contents);
+        storm::utility::closeFile(inputFileStream);
+
+        auto pos1 = contents.data();
+        char* pos2;
+        double quota = std::strtod(pos1, &pos2);
+        if (pos1 != pos2 && quota > 0.0) {
+            pos1 = pos2;
+            double period = std::strtod(pos1, &pos2);
+            if (pos1 != pos2 && period > 0.0) {
+                auto res = static_cast<uint>(std::ceil(quota / period));
+                STORM_LOG_WARN("Detected thread limitation via cgroup (max. " << res << " threads, quota=" << quota << ", period=" << period << ".");
+                return res;
+            }
+        }
+    }
+    return 0u;
+}
+
+}  // namespace detail
+
+uint getNumberOfThreads() {
+    if (detail::num_threads == 0) {
+        // try to obtain a sensible number of threads we can use
+        auto numHardwareThreads = std::max(1u, std::thread::hardware_concurrency());
+        auto numSlurmThreads = detail::tryReadFromSlurm();
+        auto numCgroupsThreads = detail::tryReadFromCgroups();
+        detail::num_threads = numHardwareThreads;
+        for (auto i : {numSlurmThreads, numCgroupsThreads}) {
+            if (i > 0 && i < detail::num_threads) {
+                detail::num_threads = i;
+            }
+        }
+    }
+    return detail::num_threads;
+}
+}  // namespace storm::utility

--- a/src/storm/utility/threads.cpp
+++ b/src/storm/utility/threads.cpp
@@ -16,7 +16,7 @@ uint tryReadFromSlurm() {
         char* end;
         auto i = std::strtoul(val, &end, 10);
         if (val != end) {
-            STORM_LOG_WARN("Detected thread limitation via Slurm (max. " << i << " threads.");
+            STORM_LOG_WARN("Detected thread limitation via Slurm (max. " << i << " threads.)");
             return static_cast<uint>(i);
         }
     }
@@ -40,7 +40,7 @@ uint tryReadFromCgroups() {
             double period = std::strtod(pos1, &pos2);
             if (pos1 != pos2 && period > 0.0) {
                 auto res = static_cast<uint>(std::ceil(quota / period));
-                STORM_LOG_WARN("Detected thread limitation via cgroup (max. " << res << " threads, quota=" << quota << ", period=" << period << ".");
+                STORM_LOG_WARN("Detected thread limitation via cgroup (max. " << res << " threads, quota=" << quota << ", period=" << period << ").");
                 return res;
             }
         }

--- a/src/storm/utility/threads.h
+++ b/src/storm/utility/threads.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace storm {
+namespace utility {
+uint getNumberOfThreads();
+}
+}  // namespace storm


### PR DESCRIPTION
* consider limit imposed by SLURM
* consider limit imposed by cgroups (e.g. Docker)
* print how many threads are used by sylvan