### PR TITLE
interval model checking fix for postprocessing results

### DIFF
--- a/resources/examples/testfiles/imdp/tiny-05.drn
+++ b/resources/examples/testfiles/imdp/tiny-05.drn
@@ -1,0 +1,18 @@
+// Exported by storm
+// Original model type: MDP
+@type: MDP
+@nr_states
+3
+@nr_choices
+3
+@model
+state 0 target
+    action 0
+        0 : [1, 1]
+state 1
+    action 0
+        1 : [1, 1]
+state 2 init
+    action 0
+        0 : [0.3, 0.4]
+        1 : [0.4, 0.9]

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -759,7 +759,14 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
                 }
             } else {
                 // Set values of resulting vector according to result.
-                storm::utility::vector::setVectorValues<SolutionType>(result, qualitativeStateSets.maybeStates, resultForMaybeStates.getValues());
+                if constexpr (!std::is_same_v<ValueType, storm::Interval>) {
+                    // For non-interval models, we only operated on the maybe states, and we must recover the qualitative values for the other state.
+                    storm::utility::vector::setVectorValues<SolutionType>(result, qualitativeStateSets.maybeStates, resultForMaybeStates.getValues());
+                } else {
+                    // For interval models, the result for maybe states indeed also holds values for all qualitative states.
+                    STORM_LOG_ASSERT(resultForMaybeStates.getValues().size() == transitionMatrix.getColumnCount(), "Dimensions do not match");
+                    result = resultForMaybeStates.getValues();
+                }
                 if (produceScheduler) {
                     extractSchedulerChoices<SolutionType, !std::is_same_v<ValueType, storm::Interval>>(*scheduler, resultForMaybeStates.getScheduler(),
                                                                                                        qualitativeStateSets.maybeStates);

--- a/src/test/storm/modelchecker/prctl/mdp/RobustMdpPrctlModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/prctl/mdp/RobustMdpPrctlModelCheckerTest.cpp
@@ -131,6 +131,10 @@ TEST(RobustMDPModelCheckingTest, Tiny04maxmin) {
     checkModel(STORM_TEST_RESOURCES_DIR "/imdp/tiny-04.drn", "Pmax=? [ F \"target\"];Pmin=? [ F \"target\"]", 1, 1, 0.42857, 0.42, false);
 }
 
+TEST(RobustMDPModelCheckingTest, Tiny05maxmin) {
+    checkModel(STORM_TEST_RESOURCES_DIR "/imdp/tiny-05.drn", "Pmax=? [ F \"target\"];Pmin=? [ F \"target\"]", 0.3, 0.4, 0.4, 0.3, false);
+}
+
 TEST(RobustMDPModelCheckingTest, Tiny04maxmin_rewards) {
     expectThrow(STORM_TEST_RESOURCES_DIR "/imdp/tiny-04.drn", "Rmin=? [ F \"target\"]");
 }


### PR DESCRIPTION
For interval models, the model checking result actually contains values for every state. So we do not need to merge it with the qualitative state results. 