### PR TITLE
replace print with logging when computing expected visits

### DIFF
--- a/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.cpp
+++ b/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.cpp
@@ -295,7 +295,7 @@ storm::Environment SparseDeterministicVisitingTimesHelper<ValueType>::getEnviron
 
     auto prec = newEnv.solver().getPrecisionOfLinearEquationSolver(newEnv.solver().getLinearEquationSolverType());
     if (prec.first.is_initialized()) {
-        STORM_PRINT("Precision for EVTs computation: " << storm::utility::convertNumber<double>(prec.first.get()) << " (exact: " << prec.first.get() << ")"
+        STORM_LOG_INFO("Precision for EVTs computation: " << storm::utility::convertNumber<double>(prec.first.get()) << " (exact: " << prec.first.get() << ")"
                                                        << '\n');
     }
 

--- a/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.cpp
+++ b/src/storm/modelchecker/helper/indefinitehorizon/visitingtimes/SparseDeterministicVisitingTimesHelper.cpp
@@ -296,7 +296,7 @@ storm::Environment SparseDeterministicVisitingTimesHelper<ValueType>::getEnviron
     auto prec = newEnv.solver().getPrecisionOfLinearEquationSolver(newEnv.solver().getLinearEquationSolverType());
     if (prec.first.is_initialized()) {
         STORM_LOG_INFO("Precision for EVTs computation: " << storm::utility::convertNumber<double>(prec.first.get()) << " (exact: " << prec.first.get() << ")"
-                                                       << '\n');
+                                                          << '\n');
     }
 
     return newEnv;


### PR DESCRIPTION
STORM_PRINT produces unwanted messages when computing expected visits multiple times, and (as far as I know) cannot be disabled.