### PR TITLE
Fix jani functions in properties

### DIFF
--- a/src/storm/storage/SymbolicModelDescription.cpp
+++ b/src/storm/storage/SymbolicModelDescription.cpp
@@ -167,7 +167,9 @@ SymbolicModelDescription SymbolicModelDescription::preprocess(std::string const&
 SymbolicModelDescription SymbolicModelDescription::preprocess(
     std::map<storm::expressions::Variable, storm::expressions::Expression> const& constantDefinitions) const {
     if (this->isJaniModel()) {
-        storm::jani::Model preparedModel = this->asJaniModel().defineUndefinedConstants(constantDefinitions).substituteConstantsFunctions();
+        storm::jani::Model preparedModel = this->asJaniModel().defineUndefinedConstants(constantDefinitions).substituteConstants();
+        // We intentionally do not eliminate function expressions in jani models at this point because that would also remove the function
+        // declarations from the model. However, those might still be needed to, e.g., process properties that refer to functions.
         return SymbolicModelDescription(preparedModel);
     } else if (this->isPrismProgram()) {
         return SymbolicModelDescription(

--- a/src/storm/storage/jani/Model.cpp
+++ b/src/storm/storage/jani/Model.cpp
@@ -1135,6 +1135,7 @@ Model& Model::substituteConstantsInPlace() {
 
 Model Model::substituteConstants() const {
     Model result(*this);
+    result.replaceUnassignedVariablesWithConstants();
     result.substituteConstantsInPlace();
     return result;
 }
@@ -1617,8 +1618,7 @@ Model Model::createModelFromAutomaton(Automaton const& automaton) const {
 
 std::string filterName(std::string const& text) {
     std::string result = text;
-    std::replace_if(
-        result.begin(), result.end(), [](const char& c) { return std::ispunct(c); }, '_');
+    std::replace_if(result.begin(), result.end(), [](const char& c) { return std::ispunct(c); }, '_');
     return result;
 }
 

--- a/src/storm/storage/jani/Model.cpp
+++ b/src/storm/storage/jani/Model.cpp
@@ -1618,7 +1618,8 @@ Model Model::createModelFromAutomaton(Automaton const& automaton) const {
 
 std::string filterName(std::string const& text) {
     std::string result = text;
-    std::replace_if(result.begin(), result.end(), [](const char& c) { return std::ispunct(c); }, '_');
+    std::replace_if(
+        result.begin(), result.end(), [](const char& c) { return std::ispunct(c); }, '_');
     return result;
 }
 

--- a/src/test/storm/builder/DdJaniModelBuilderTest.cpp
+++ b/src/test/storm/builder/DdJaniModelBuilderTest.cpp
@@ -17,38 +17,41 @@
 
 #include "storm-parsers/api/model_descriptions.h"
 #include "storm/exceptions/WrongFormatException.h"
-#include "storm/settings/SettingMemento.h"
-#include "storm/settings/SettingsManager.h"
+
+namespace {
+
+storm::jani::Model getJaniModelFromPrism(std::string const& pathInTestResourcesDir, bool prismCompatability = false) {
+    storm::storage::SymbolicModelDescription modelDescription =
+        storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/" + pathInTestResourcesDir, prismCompatability);
+    auto m = modelDescription.toJani(true).preprocess().asJaniModel();
+    auto unsupportedFeatures = m.restrictToFeatures(storm::builder::DdJaniModelBuilder<storm::dd::DdType::Sylvan, double>::getSupportedJaniFeatures());
+    EXPECT_TRUE(unsupportedFeatures.empty()) << "Model '" << pathInTestResourcesDir << "' uses unsupported feature(s) " << unsupportedFeatures.toString();
+    return m;
+}
 
 TEST(DdJaniModelBuilderTest_Sylvan, Dtmc) {
-    storm::storage::SymbolicModelDescription modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/die.pm");
-    storm::jani::Model janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
-
+    auto janiModel = getJaniModelFromPrism("dtmc/die.pm");
     storm::builder::DdJaniModelBuilder<storm::dd::DdType::Sylvan, double> builder;
     std::shared_ptr<storm::models::symbolic::Model<storm::dd::DdType::Sylvan>> model = builder.build(janiModel);
     EXPECT_EQ(13ul, model->getNumberOfStates());
     EXPECT_EQ(20ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/brp-16-2.pm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("dtmc/brp-16-2.pm");
     model = builder.build(janiModel);
     EXPECT_EQ(677ul, model->getNumberOfStates());
     EXPECT_EQ(867ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/crowds-5-5.pm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/dtmc/crowds-5-5.pm");
     model = builder.build(janiModel);
     EXPECT_EQ(8607ul, model->getNumberOfStates());
     EXPECT_EQ(15113ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/leader-3-5.pm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/dtmc/leader-3-5.pm");
     model = builder.build(janiModel);
     EXPECT_EQ(273ul, model->getNumberOfStates());
     EXPECT_EQ(397ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/nand-5-2.pm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/dtmc/nand-5-2.pm");
 
     model = builder.build(janiModel);
     EXPECT_EQ(1728ul, model->getNumberOfStates());
@@ -56,108 +59,92 @@ TEST(DdJaniModelBuilderTest_Sylvan, Dtmc) {
 }
 
 TEST(DdJaniModelBuilderTest_Cudd, Dtmc) {
-    storm::storage::SymbolicModelDescription modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/die.pm");
-    storm::jani::Model janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    auto janiModel = getJaniModelFromPrism("/dtmc/die.pm");
 
     storm::builder::DdJaniModelBuilder<storm::dd::DdType::CUDD, double> builder;
     std::shared_ptr<storm::models::symbolic::Model<storm::dd::DdType::CUDD>> model = builder.build(janiModel);
     EXPECT_EQ(13ul, model->getNumberOfStates());
     EXPECT_EQ(20ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/brp-16-2.pm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/dtmc/brp-16-2.pm");
     model = builder.build(janiModel);
     EXPECT_EQ(677ul, model->getNumberOfStates());
     EXPECT_EQ(867ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/crowds-5-5.pm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/dtmc/crowds-5-5.pm");
     model = builder.build(janiModel);
     EXPECT_EQ(8607ul, model->getNumberOfStates());
     EXPECT_EQ(15113ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/leader-3-5.pm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/dtmc/leader-3-5.pm");
     model = builder.build(janiModel);
     EXPECT_EQ(273ul, model->getNumberOfStates());
     EXPECT_EQ(397ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/nand-5-2.pm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/dtmc/nand-5-2.pm");
     model = builder.build(janiModel);
     EXPECT_EQ(1728ul, model->getNumberOfStates());
     EXPECT_EQ(2505ul, model->getNumberOfTransitions());
 }
 
 TEST(DdJaniModelBuilderTest_Sylvan, Ctmc) {
-    storm::storage::SymbolicModelDescription modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ctmc/cluster2.sm", true);
-    storm::jani::Model janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    auto janiModel = getJaniModelFromPrism("/ctmc/cluster2.sm", true);
     storm::builder::DdJaniModelBuilder<storm::dd::DdType::Sylvan, double> builder;
     std::shared_ptr<storm::models::symbolic::Model<storm::dd::DdType::Sylvan>> model = builder.build(janiModel);
     EXPECT_EQ(276ul, model->getNumberOfStates());
     EXPECT_EQ(1120ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ctmc/embedded2.sm", true);
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/ctmc/embedded2.sm", true);
     model = builder.build(janiModel);
     EXPECT_EQ(3478ul, model->getNumberOfStates());
     EXPECT_EQ(14639ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ctmc/polling2.sm", true);
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/ctmc/polling2.sm", true);
     model = builder.build(janiModel);
     EXPECT_EQ(12ul, model->getNumberOfStates());
     EXPECT_EQ(22ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ctmc/fms2.sm", true);
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/ctmc/fms2.sm", true);
     model = builder.build(janiModel);
     EXPECT_EQ(810ul, model->getNumberOfStates());
     EXPECT_EQ(3699ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ctmc/tandem5.sm", true);
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/ctmc/tandem5.sm", true);
     model = builder.build(janiModel);
     EXPECT_EQ(66ul, model->getNumberOfStates());
     EXPECT_EQ(189ul, model->getNumberOfTransitions());
 }
 
 TEST(DdJaniModelBuilderTest_Cudd, Ctmc) {
-    storm::storage::SymbolicModelDescription modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ctmc/cluster2.sm", true);
-    storm::jani::Model janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    auto janiModel = getJaniModelFromPrism("/ctmc/cluster2.sm", true);
     storm::builder::DdJaniModelBuilder<storm::dd::DdType::CUDD, double> builder;
     std::shared_ptr<storm::models::symbolic::Model<storm::dd::DdType::CUDD>> model = builder.build(janiModel);
     EXPECT_EQ(276ul, model->getNumberOfStates());
     EXPECT_EQ(1120ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ctmc/embedded2.sm", true);
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/ctmc/embedded2.sm", true);
     model = builder.build(janiModel);
     EXPECT_EQ(3478ul, model->getNumberOfStates());
     EXPECT_EQ(14639ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ctmc/polling2.sm", true);
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/ctmc/polling2.sm", true);
     model = builder.build(janiModel);
     EXPECT_EQ(12ul, model->getNumberOfStates());
     EXPECT_EQ(22ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ctmc/fms2.sm", true);
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/ctmc/fms2.sm", true);
     model = builder.build(janiModel);
     EXPECT_EQ(810ul, model->getNumberOfStates());
     EXPECT_EQ(3699ul, model->getNumberOfTransitions());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ctmc/tandem5.sm", true);
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/ctmc/tandem5.sm", true);
     model = builder.build(janiModel);
     EXPECT_EQ(66ul, model->getNumberOfStates());
     EXPECT_EQ(189ul, model->getNumberOfTransitions());
 }
 
 TEST(DdJaniModelBuilderTest_Sylvan, Mdp) {
-    storm::storage::SymbolicModelDescription modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/two_dice.nm");
-    storm::jani::Model janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    auto janiModel = getJaniModelFromPrism("/mdp/two_dice.nm");
     storm::builder::DdJaniModelBuilder<storm::dd::DdType::Sylvan, double> builder;
     std::shared_ptr<storm::models::symbolic::Model<storm::dd::DdType::Sylvan>> model = builder.build(janiModel);
 
@@ -168,8 +155,7 @@ TEST(DdJaniModelBuilderTest_Sylvan, Mdp) {
     EXPECT_EQ(436ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(254ul, mdp->getNumberOfChoices());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/leader3.nm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/mdp/leader3.nm");
     model = builder.build(janiModel);
 
     EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
@@ -179,8 +165,7 @@ TEST(DdJaniModelBuilderTest_Sylvan, Mdp) {
     EXPECT_EQ(654ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(573ul, mdp->getNumberOfChoices());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/coin2-2.nm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/mdp/coin2-2.nm");
     model = builder.build(janiModel);
 
     EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
@@ -190,8 +175,7 @@ TEST(DdJaniModelBuilderTest_Sylvan, Mdp) {
     EXPECT_EQ(492ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(400ul, mdp->getNumberOfChoices());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/csma2-2.nm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/mdp/csma2-2.nm");
     model = builder.build(janiModel);
 
     EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
@@ -201,8 +185,7 @@ TEST(DdJaniModelBuilderTest_Sylvan, Mdp) {
     EXPECT_EQ(1282ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(1054ul, mdp->getNumberOfChoices());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/firewire3-0.5.nm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/mdp/firewire3-0.5.nm");
     model = builder.build(janiModel);
 
     EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
@@ -212,8 +195,7 @@ TEST(DdJaniModelBuilderTest_Sylvan, Mdp) {
     EXPECT_EQ(5585ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(5519ul, mdp->getNumberOfChoices());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/wlan0-2-2.nm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/mdp/wlan0-2-2.nm");
     model = builder.build(janiModel);
 
     EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
@@ -223,8 +205,7 @@ TEST(DdJaniModelBuilderTest_Sylvan, Mdp) {
     EXPECT_EQ(59ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(59ul, mdp->getNumberOfChoices());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/sync.nm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/mdp/sync.nm");
     model = builder.build(janiModel);
 
     EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
@@ -236,8 +217,7 @@ TEST(DdJaniModelBuilderTest_Sylvan, Mdp) {
 }
 
 TEST(DdJaniModelBuilderTest_Cudd, Mdp) {
-    storm::storage::SymbolicModelDescription modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/two_dice.nm");
-    storm::jani::Model janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    auto janiModel = getJaniModelFromPrism("/mdp/two_dice.nm");
     storm::builder::DdJaniModelBuilder<storm::dd::DdType::CUDD, double> builder;
     std::shared_ptr<storm::models::symbolic::Model<storm::dd::DdType::CUDD>> model = builder.build(janiModel);
 
@@ -248,8 +228,7 @@ TEST(DdJaniModelBuilderTest_Cudd, Mdp) {
     EXPECT_EQ(436ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(254ul, mdp->getNumberOfChoices());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/leader3.nm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/mdp/leader3.nm");
     model = builder.build(janiModel);
 
     EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
@@ -259,8 +238,7 @@ TEST(DdJaniModelBuilderTest_Cudd, Mdp) {
     EXPECT_EQ(654ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(573ul, mdp->getNumberOfChoices());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/coin2-2.nm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/mdp/coin2-2.nm");
     model = builder.build(janiModel);
 
     EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
@@ -270,8 +248,7 @@ TEST(DdJaniModelBuilderTest_Cudd, Mdp) {
     EXPECT_EQ(492ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(400ul, mdp->getNumberOfChoices());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/csma2-2.nm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/mdp/csma2-2.nm");
     model = builder.build(janiModel);
 
     EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
@@ -281,8 +258,7 @@ TEST(DdJaniModelBuilderTest_Cudd, Mdp) {
     EXPECT_EQ(1282ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(1054ul, mdp->getNumberOfChoices());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/firewire3-0.5.nm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/mdp/firewire3-0.5.nm");
     model = builder.build(janiModel);
 
     EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
@@ -292,8 +268,7 @@ TEST(DdJaniModelBuilderTest_Cudd, Mdp) {
     EXPECT_EQ(5585ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(5519ul, mdp->getNumberOfChoices());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/wlan0-2-2.nm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/mdp/wlan0-2-2.nm");
     model = builder.build(janiModel);
 
     EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
@@ -303,8 +278,7 @@ TEST(DdJaniModelBuilderTest_Cudd, Mdp) {
     EXPECT_EQ(59ul, mdp->getNumberOfTransitions());
     EXPECT_EQ(59ul, mdp->getNumberOfChoices());
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/sync.nm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/mdp/sync.nm");
     model = builder.build(janiModel);
 
     EXPECT_TRUE(model->getType() == storm::models::ModelType::Mdp);
@@ -316,8 +290,7 @@ TEST(DdJaniModelBuilderTest_Cudd, Mdp) {
 }
 
 TEST(DdJaniModelBuilderTest_Cudd, SynchronizationVectors) {
-    storm::storage::SymbolicModelDescription modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/SmallPrismTest.nm");
-    storm::jani::Model janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    auto janiModel = getJaniModelFromPrism("/mdp/SmallPrismTest.nm");
 
     storm::builder::DdJaniModelBuilder<storm::dd::DdType::CUDD, double> builder;
 
@@ -453,8 +426,7 @@ TEST(DdJaniModelBuilderTest_Cudd, SynchronizationVectors) {
 }
 
 TEST(DdJaniModelBuilderTest_Sylvan, SynchronizationVectors) {
-    storm::storage::SymbolicModelDescription modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/SmallPrismTest.nm");
-    storm::jani::Model janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    auto janiModel = getJaniModelFromPrism("/mdp/SmallPrismTest.nm");
 
     storm::builder::DdJaniModelBuilder<storm::dd::DdType::Sylvan, double> builder;
 
@@ -590,36 +562,31 @@ TEST(DdJaniModelBuilderTest_Sylvan, SynchronizationVectors) {
 }
 
 TEST(DdJaniModelBuilderTest_Sylvan, Composition) {
-    storm::storage::SymbolicModelDescription modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/system_composition.nm");
-    storm::jani::Model janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    auto janiModel = getJaniModelFromPrism("/mdp/system_composition.nm");
 
     storm::builder::DdJaniModelBuilder<storm::dd::DdType::Sylvan, double> builder;
     STORM_SILENT_EXPECT_THROW(std::shared_ptr<storm::models::symbolic::Model<storm::dd::DdType::Sylvan>> model = builder.build(janiModel),
                               storm::exceptions::WrongFormatException);
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/system_composition2.nm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/mdp/system_composition2.nm");
     STORM_SILENT_EXPECT_THROW(std::shared_ptr<storm::models::symbolic::Model<storm::dd::DdType::Sylvan>> model = builder.build(janiModel),
                               storm::exceptions::WrongFormatException);
 }
 
 TEST(DdJaniModelBuilderTest_Cudd, Composition) {
-    storm::storage::SymbolicModelDescription modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/system_composition.nm");
-    storm::jani::Model janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    auto janiModel = getJaniModelFromPrism("/mdp/system_composition.nm");
 
     storm::builder::DdJaniModelBuilder<storm::dd::DdType::CUDD, double> builder;
     STORM_SILENT_EXPECT_THROW(std::shared_ptr<storm::models::symbolic::Model<storm::dd::DdType::CUDD>> model = builder.build(janiModel),
                               storm::exceptions::WrongFormatException);
 
-    modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/system_composition2.nm");
-    janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    janiModel = getJaniModelFromPrism("/mdp/system_composition2.nm");
     STORM_SILENT_EXPECT_THROW(std::shared_ptr<storm::models::symbolic::Model<storm::dd::DdType::CUDD>> model = builder.build(janiModel),
                               storm::exceptions::WrongFormatException);
 }
 
 TEST(DdJaniModelBuilderTest_Cudd, InputEnabling) {
-    storm::storage::SymbolicModelDescription modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/SmallPrismTest2.nm");
-    storm::jani::Model janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    auto janiModel = getJaniModelFromPrism("/mdp/SmallPrismTest2.nm");
 
     storm::builder::DdJaniModelBuilder<storm::dd::DdType::CUDD, double> builder;
 
@@ -655,8 +622,7 @@ TEST(DdJaniModelBuilderTest_Cudd, InputEnabling) {
 }
 
 TEST(DdJaniModelBuilderTest_Sylvan, InputEnabling) {
-    storm::storage::SymbolicModelDescription modelDescription = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/SmallPrismTest2.nm");
-    storm::jani::Model janiModel = modelDescription.toJani(true).preprocess().asJaniModel();
+    auto janiModel = getJaniModelFromPrism("/mdp/SmallPrismTest2.nm");
 
     storm::builder::DdJaniModelBuilder<storm::dd::DdType::Sylvan, double> builder;
 
@@ -690,3 +656,4 @@ TEST(DdJaniModelBuilderTest_Sylvan, InputEnabling) {
     EXPECT_EQ(4ul, model->getNumberOfStates());
     EXPECT_EQ(5ul, model->getNumberOfTransitions());
 }
+}  // namespace

--- a/src/test/storm/builder/ExplicitJaniModelBuilderTest.cpp
+++ b/src/test/storm/builder/ExplicitJaniModelBuilderTest.cpp
@@ -12,9 +12,19 @@
 #include "storm/utility/cli.h"
 #include "test/storm_gtest.h"
 
+namespace {
+
+storm::jani::Model getJaniModelFromPrism(std::string const& pathInTestResourcesDir, bool prismCompatability = false) {
+    storm::storage::SymbolicModelDescription modelDescription =
+        storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/" + pathInTestResourcesDir, prismCompatability);
+    auto m = modelDescription.toJani().preprocess().asJaniModel();
+    auto unsupportedFeatures = m.restrictToFeatures(storm::generator::JaniNextStateGenerator<double>::getSupportedJaniFeatures());
+    EXPECT_TRUE(unsupportedFeatures.empty()) << "Model '" << pathInTestResourcesDir << "' uses unsupported feature(s) " << unsupportedFeatures.toString();
+    return m;
+}
+
 TEST(ExplicitJaniModelBuilderTest, Dtmc) {
-    storm::prism::Program program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/die.pm");
-    storm::jani::Model janiModel = program.toJani().substituteConstantsFunctions();
+    auto janiModel = getJaniModelFromPrism("/dtmc/die.pm");
 
     std::shared_ptr<storm::models::sparse::Model<double>> model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(13ul, model->getNumberOfStates());
@@ -30,34 +40,29 @@ TEST(ExplicitJaniModelBuilderTest, Dtmc) {
     EXPECT_EQ(13ul, model->getNumberOfStates());
     EXPECT_EQ(20ul, model->getNumberOfTransitions());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/brp-16-2.pm");
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/dtmc/brp-16-2.pm");
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(677ul, model->getNumberOfStates());
     EXPECT_EQ(867ul, model->getNumberOfTransitions());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/crowds-5-5.pm");
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/dtmc/crowds-5-5.pm");
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(8607ul, model->getNumberOfStates());
     EXPECT_EQ(15113ul, model->getNumberOfTransitions());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/leader-3-5.pm");
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/dtmc/leader-3-5.pm");
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(273ul, model->getNumberOfStates());
     EXPECT_EQ(397ul, model->getNumberOfTransitions());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/dtmc/nand-5-2.pm");
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/dtmc/nand-5-2.pm");
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(1728ul, model->getNumberOfStates());
     EXPECT_EQ(2505ul, model->getNumberOfTransitions());
 }
 
 TEST(ExplicitJaniModelBuilderTest, pdtmc) {
-    storm::prism::Program program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/pdtmc/parametric_die.pm");
-    storm::jani::Model janiModel = program.toJani().substituteConstantsFunctions();
+    auto janiModel = getJaniModelFromPrism("/pdtmc/parametric_die.pm");
     std::shared_ptr<storm::models::sparse::Model<storm::RationalFunction>> model =
         storm::builder::ExplicitModelBuilder<storm::RationalFunction>(janiModel).build();
     EXPECT_EQ(13ul, model->getNumberOfStates());
@@ -69,86 +74,73 @@ TEST(ExplicitJaniModelBuilderTest, pdtmc) {
     EXPECT_EQ(13ul, model->getNumberOfStates());
     EXPECT_EQ(20ul, model->getNumberOfTransitions());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/pdtmc/brp16_2.pm");
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/pdtmc/brp16_2.pm");
     model = storm::builder::ExplicitModelBuilder<storm::RationalFunction>(janiModel).build();
     EXPECT_EQ(677ul, model->getNumberOfStates());
     EXPECT_EQ(867ul, model->getNumberOfTransitions());
 }
 
 TEST(ExplicitJaniModelBuilderTest, Ctmc) {
-    storm::prism::Program program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ctmc/cluster2.sm", true);
-    storm::jani::Model janiModel = program.toJani().substituteConstantsFunctions();
+    auto janiModel = getJaniModelFromPrism("/ctmc/cluster2.sm", true);
 
     std::shared_ptr<storm::models::sparse::Model<double>> model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(276ul, model->getNumberOfStates());
     EXPECT_EQ(1120ul, model->getNumberOfTransitions());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ctmc/embedded2.sm", true);
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/ctmc/embedded2.sm", true);
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(3478ul, model->getNumberOfStates());
     EXPECT_EQ(14639ul, model->getNumberOfTransitions());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ctmc/polling2.sm", true);
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/ctmc/polling2.sm", true);
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(12ul, model->getNumberOfStates());
     EXPECT_EQ(22ul, model->getNumberOfTransitions());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ctmc/fms2.sm", true);
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/ctmc/fms2.sm", true);
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(810ul, model->getNumberOfStates());
     EXPECT_EQ(3699ul, model->getNumberOfTransitions());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ctmc/tandem5.sm", true);
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/ctmc/tandem5.sm", true);
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(66ul, model->getNumberOfStates());
     EXPECT_EQ(189ul, model->getNumberOfTransitions());
 }
 
 TEST(ExplicitJaniModelBuilderTest, Mdp) {
-    storm::prism::Program program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/two_dice.nm");
-    storm::jani::Model janiModel = program.toJani().substituteConstantsFunctions();
+    auto janiModel = getJaniModelFromPrism("/mdp/two_dice.nm");
 
     std::shared_ptr<storm::models::sparse::Model<double>> model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(169ul, model->getNumberOfStates());
     EXPECT_EQ(436ul, model->getNumberOfTransitions());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/leader3.nm");
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/mdp/leader3.nm");
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(364ul, model->getNumberOfStates());
     EXPECT_EQ(654ul, model->getNumberOfTransitions());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/coin2-2.nm");
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/mdp/coin2-2.nm");
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(272ul, model->getNumberOfStates());
     EXPECT_EQ(492ul, model->getNumberOfTransitions());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/csma2-2.nm");
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/mdp/csma2-2.nm");
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(1038ul, model->getNumberOfStates());
     EXPECT_EQ(1282ul, model->getNumberOfTransitions());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/firewire3-0.5.nm");
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/mdp/firewire3-0.5.nm");
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(4093ul, model->getNumberOfStates());
     EXPECT_EQ(5585ul, model->getNumberOfTransitions());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/wlan0-2-2.nm");
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/mdp/wlan0-2-2.nm");
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(37ul, model->getNumberOfStates());
     EXPECT_EQ(59ul, model->getNumberOfTransitions());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/sync.nm");
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/mdp/sync.nm");
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(5ul, model->getNumberOfStates());
     EXPECT_EQ(24ul, model->getNumberOfTransitions());
@@ -156,8 +148,7 @@ TEST(ExplicitJaniModelBuilderTest, Mdp) {
 }
 
 TEST(ExplicitJaniModelBuilderTest, Ma) {
-    storm::prism::Program program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ma/simple.ma");
-    storm::jani::Model janiModel = program.toJani().substituteConstantsFunctions();
+    auto janiModel = getJaniModelFromPrism("/ma/simple.ma");
 
     std::shared_ptr<storm::models::sparse::Model<double>> model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(5ul, model->getNumberOfStates());
@@ -165,16 +156,14 @@ TEST(ExplicitJaniModelBuilderTest, Ma) {
     ASSERT_TRUE(model->isOfType(storm::models::ModelType::MarkovAutomaton));
     EXPECT_EQ(4ul, model->as<storm::models::sparse::MarkovAutomaton<double>>()->getMarkovianStates().getNumberOfSetBits());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ma/hybrid_states.ma");
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/ma/hybrid_states.ma");
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(5ul, model->getNumberOfStates());
     EXPECT_EQ(13ul, model->getNumberOfTransitions());
     ASSERT_TRUE(model->isOfType(storm::models::ModelType::MarkovAutomaton));
     EXPECT_EQ(5ul, model->as<storm::models::sparse::MarkovAutomaton<double>>()->getMarkovianStates().getNumberOfSetBits());
 
-    program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/ma/stream2.ma");
-    janiModel = program.toJani().substituteConstantsFunctions();
+    janiModel = getJaniModelFromPrism("/ma/stream2.ma");
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(12ul, model->getNumberOfStates());
     EXPECT_EQ(14ul, model->getNumberOfTransitions());
@@ -192,8 +181,7 @@ TEST(ExplicitJaniModelBuilderTest, Ma) {
 }
 
 TEST(ExplicitJaniModelBuilderTest, FailComposition) {
-    storm::prism::Program program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/system_composition.nm");
-    storm::jani::Model janiModel = program.toJani().substituteConstantsFunctions();
+    auto janiModel = getJaniModelFromPrism("/mdp/system_composition.nm");
 
     STORM_SILENT_ASSERT_THROW(storm::builder::ExplicitModelBuilder<double>(janiModel).build(), storm::exceptions::WrongFormatException);
 }
@@ -212,3 +200,4 @@ TEST(ExplicitJaniModelBuilderTest, enumerateInitial) {
     EXPECT_EQ(145ul, model->getNumberOfTransitions());
     EXPECT_EQ(72ul, model->getInitialStates().getNumberOfSetBits());
 }
+}  // namespace


### PR DESCRIPTION
Previously, functions occurring in properties were not handled correctly. This was the case because all functions declared in the model were eliminated before simplifying the properties. See `preprocessSymbolicInput` in model-handling.h, where the SymbolicModelDescription is [preprocessed](https://github.com/moves-rwth/storm/blob/24cb52a9959cb11d55c525cf5dab31e94cfb6390/src/storm-cli-utilities/model-handling.h#L371) before [the Jani model is simplified](https://github.com/moves-rwth/storm/blob/24cb52a9959cb11d55c525cf5dab31e94cfb6390/src/storm-cli-utilities/model-handling.h#L401).

Since the `preprocess()` method was used in the `DdJaniModelBuilderTest` to (also) eliminate functions, I reworked this (and for consistency, the `ExplicitJaniModelBuilderTest` as well).