### PR TITLE
Fixes for explicit jani model builder

### DIFF
--- a/src/storm/storage/jani/Model.cpp
+++ b/src/storm/storage/jani/Model.cpp
@@ -1008,9 +1008,11 @@ void Model::simplifyComposition() {
         }
     }
 
-    // Traverse the system composition and exchange automata by their copy
-    auto newComposition = CompositionSimplificationVisitor(automatonToCopiesMap).simplify(getSystemComposition());
-    this->setSystemComposition(newComposition);
+    if (!automatonToCopiesMap.empty()) {
+        // Traverse the system composition and exchange automata by their copy
+        auto newComposition = CompositionSimplificationVisitor(automatonToCopiesMap).simplify(getSystemComposition());
+        this->setSystemComposition(newComposition);
+    }
 }
 
 void Model::setSystemComposition(std::shared_ptr<Composition> const& composition) {


### PR DESCRIPTION
- Fixed building JANI models that use the same automaton multiple times in their system composition. Previously, the different instances referred to the same expression variables for the automaton location and its local variables.

- Fixed building JaniChoiceOrigins which previously referred to internal automata indices and not the ones from the JANI model.