### PR TITLE
Jani: Support for rates in DTMCs

### DIFF
--- a/resources/examples/testfiles/dtmc/rates.jani
+++ b/resources/examples/testfiles/dtmc/rates.jani
@@ -1,0 +1,133 @@
+{
+  "jani-version": 1,
+  "name": "dtmc-weight-test",
+  "type": "dtmc",
+  "comment": "",
+  "features": [
+    "derived-operators"
+  ],
+  "constants": [],
+  "variables": [],
+  "functions": [],
+  "restrict-initial": {
+    "exp": true,
+    "comment": ""
+  },
+  "automata": [
+    {
+      "name": "aut",
+      "comment": "",
+      "variables": [],
+      "restrict-initial": {
+        "exp": true,
+        "comment": ""
+      },
+      "initial-locations": [
+        "l0"
+      ],
+      "locations": [
+        {
+          "name": "l0",
+          "comment": "",
+          "transient-values": []
+        },
+        {
+          "name": "l1",
+          "comment": "",
+          "transient-values": []
+        },
+        {
+          "name": "l2",
+          "comment": "",
+          "transient-values": []
+        }
+      ],
+      "edges": [
+          {
+            "location": "l0",
+            "rate": {
+              "exp": 2
+            },
+            "guard": {
+              "exp": true
+            },
+            "destinations": [
+              {
+                "location": "l0",
+                "assignments": [],
+                "probability": {
+                  "exp": 0.3
+                }
+              },
+              {
+                "location": "l1",
+                "assignments": [],
+                "probability": {
+                  "exp": 0.7
+                }
+              }
+            ]
+          },
+          {
+            "location": "l1",
+            "rate": {
+              "exp": 3
+            },
+            "guard": {
+              "exp": true
+            },
+            "destinations": [
+              {
+                "location": "l0",
+                "assignments": [],
+                "probability": {
+                  "exp": 0.4
+                }
+              },
+              {
+                "location": "l1",
+                "assignments": [],
+                "probability": {
+                  "exp": 0.6
+                }
+              }
+            ]
+          },
+          {
+            "location": "l1",
+            "rate": {
+              "exp": 7
+            },
+            "guard": {
+              "exp": true
+            },
+            "destinations": [
+              {
+                "location": "l1",
+                "assignments": [],
+                "probability": {
+                  "exp": 0.9
+                }
+              },
+              {
+                "location": "l2",
+                "assignments": [],
+                "probability": {
+                  "exp": 0.1
+                }
+              }
+            ]
+          }
+      ]
+    }
+  ],
+  "system": {
+    "elements": [
+      {
+        "automaton": "aut"
+      }
+    ],
+    "syncs": []
+  },
+  "actions": []
+}

--- a/src/storm-dft/builder/ExplicitDFTModelBuilder.cpp
+++ b/src/storm-dft/builder/ExplicitDFTModelBuilder.cpp
@@ -149,7 +149,7 @@ void ExplicitDFTModelBuilder<ValueType, StateType>::buildModel(size_t iteration,
             matrixBuilder.setRemapping(0);
             STORM_LOG_ASSERT(!behavior.empty(), "Behavior is empty.");
             matrixBuilder.newRowGroup();
-            setMarkovian(behavior.begin()->isMarkovian());
+            setMarkovian(behavior.begin()->hasRate());
 
             // Now add self loop.
             // TODO: maybe use general method.
@@ -418,7 +418,7 @@ void ExplicitDFTModelBuilder<ValueType, StateType>::exploreStateSpace(double app
             storm::generator::StateBehavior<ValueType, StateType> behavior =
                 generator.expand(std::bind(&ExplicitDFTModelBuilder::getOrAddStateIndex, this, std::placeholders::_1));
             STORM_LOG_ASSERT(!behavior.empty(), "Behavior is empty.");
-            setMarkovian(behavior.begin()->isMarkovian());
+            setMarkovian(behavior.begin()->hasRate());
 
             // Now add all choices.
             for (auto const& choice : behavior) {

--- a/src/storm-parsers/parser/ImcaMarkovAutomatonParserGrammar.cpp
+++ b/src/storm-parsers/parser/ImcaMarkovAutomatonParserGrammar.cpp
@@ -178,7 +178,7 @@ storm::storage::sparse::ModelComponents<ValueType> ImcaParserGrammar<ValueType, 
             // For Markovian states, the Markovian choice has to be the first one in the resulting transition matrix.
             bool markovianChoiceFound = false;
             for (auto const& choice : behavior) {
-                if (choice.isMarkovian()) {
+                if (choice.hasRate()) {
                     STORM_LOG_THROW(!markovianChoiceFound, storm::exceptions::WrongFormatException,
                                     "Multiple Markovian choices defined for state " << state << ".");
                     markovianChoiceFound = true;
@@ -206,7 +206,7 @@ storm::storage::sparse::ModelComponents<ValueType> ImcaParserGrammar<ValueType, 
         }
         // Now add all probabilistic choices.
         for (auto const& choice : behavior) {
-            if (!choice.isMarkovian()) {
+            if (!choice.hasRate()) {
                 if (!choice.getRewards().empty()) {
                     assert(choice.getRewards().size() == 1);
                     actionRewards.value()[row] = choice.getRewards().front();

--- a/src/storm/builder/ExplicitModelBuilder.cpp
+++ b/src/storm/builder/ExplicitModelBuilder.cpp
@@ -269,7 +269,7 @@ void ExplicitModelBuilder<ValueType, RewardModelType, StateType>::buildMatrices(
                         stateAndChoiceInformationBuilder.addStatePlayerIndication(choice.getPlayerIndex(), currentRowGroup);
                     }
                 }
-                if (stateAndChoiceInformationBuilder.isBuildMarkovianStates() && choice.isMarkovian()) {
+                if (stateAndChoiceInformationBuilder.isBuildMarkovianStates() && choice.hasRate()) {
                     stateAndChoiceInformationBuilder.addMarkovianState(currentRowGroup);
                 }
 

--- a/src/storm/generator/Choice.cpp
+++ b/src/storm/generator/Choice.cpp
@@ -13,14 +13,14 @@ namespace storm {
 namespace generator {
 
 template<typename ValueType, typename StateType>
-Choice<ValueType, StateType>::Choice(uint_fast64_t actionIndex, bool markovian)
-    : markovian(markovian), actionIndex(actionIndex), distribution(), totalMass(storm::utility::zero<ValueType>()), rewards(), labels() {
+Choice<ValueType, StateType>::Choice(uint_fast64_t actionIndex, bool hasRate)
+    : rate(hasRate), actionIndex(actionIndex), distribution(), totalMass(storm::utility::zero<ValueType>()), rewards(), labels() {
     // Intentionally left empty.
 }
 
 template<typename ValueType, typename StateType>
 void Choice<ValueType, StateType>::add(Choice const& other) {
-    STORM_LOG_THROW(this->markovian == other.markovian, storm::exceptions::InvalidOperationException, "Type of choices do not match.");
+    STORM_LOG_THROW(this->rate == other.rate, storm::exceptions::InvalidOperationException, "Type of choices do not match.");
     STORM_LOG_THROW(this->actionIndex == other.actionIndex, storm::exceptions::InvalidOperationException, "Action index of choices do not match.");
     STORM_LOG_THROW(this->rewards.size() == other.rewards.size(), storm::exceptions::InvalidOperationException, "Reward value sizes of choices do not match.");
 
@@ -161,6 +161,15 @@ void Choice<ValueType, StateType>::addProbability(StateType const& state, ValueT
 }
 
 template<typename ValueType, typename StateType>
+void Choice<ValueType, StateType>::normalizeDistribution() {
+    STORM_LOG_ASSERT(!storm::utility::isZero(totalMass), "Normalizing a distribution with total mass 0 is not allowed.");
+    for (auto& entry : distribution) {
+        entry.second /= totalMass;
+    }
+    totalMass = storm::utility::one<ValueType>();
+}
+
+template<typename ValueType, typename StateType>
 void Choice<ValueType, StateType>::addReward(ValueType const& value) {
     rewards.push_back(value);
 }
@@ -176,8 +185,8 @@ std::vector<ValueType> const& Choice<ValueType, StateType>::getRewards() const {
 }
 
 template<typename ValueType, typename StateType>
-bool Choice<ValueType, StateType>::isMarkovian() const {
-    return markovian;
+bool Choice<ValueType, StateType>::hasRate() const {
+    return rate;
 }
 
 template<typename ValueType, typename StateType>

--- a/src/storm/generator/Choice.h
+++ b/src/storm/generator/Choice.h
@@ -18,7 +18,7 @@ namespace generator {
 template<typename ValueType, typename StateType = uint32_t>
 struct Choice {
    public:
-    Choice(uint_fast64_t actionIndex = 0, bool markovian = false);
+    Choice(uint_fast64_t actionIndex = 0, bool rate = false);
 
     Choice(Choice const& other) = default;
     Choice& operator=(Choice const& other) = default;
@@ -27,6 +27,7 @@ struct Choice {
 
     /*!
      * Adds the given choice to the current one.
+     * @pre The type of the choices match, i.e., either both have a rate or none.
      */
     void add(Choice const& other);
 
@@ -157,6 +158,12 @@ struct Choice {
     void addProbability(StateType const& state, ValueType const& value);
 
     /*!
+     * Normalizes the underlying distribution such that getTotalMass() is 1 afterwards.
+     * @pre The total mass is not zero.
+     */
+    void normalizeDistribution();
+
+    /*!
      * Adds the given value to the reward associated with this choice.
      */
     void addReward(ValueType const& value);
@@ -172,9 +179,11 @@ struct Choice {
     std::vector<ValueType> const& getRewards() const;
 
     /*!
-     * Retrieves whether the choice is Markovian.
+     * Retrieves whether the choice has a rate.
+     * For continuous time models, this means that the choice is Markovian.
+     * For DTMCs, this means that the choice is weighted
      */
-    bool isMarkovian() const;
+    bool hasRate() const;
 
     /*!
      * Retrieves the size of the distribution associated with this choice.
@@ -187,8 +196,8 @@ struct Choice {
     void reserve(std::size_t const& size);
 
    private:
-    // A flag indicating whether this choice is Markovian or not.
-    bool markovian;
+    // A flag indicating whether this choice has a rate or not.
+    bool rate;
 
     // The action index associated with this choice.
     uint_fast64_t actionIndex;

--- a/src/storm/generator/NextStateGenerator.cpp
+++ b/src/storm/generator/NextStateGenerator.cpp
@@ -260,7 +260,7 @@ void NextStateGenerator<ValueType, StateType>::postprocess(StateBehavior<ValueTy
         for (uint_fast64_t index = 0; index + numberOfChoicesToDelete < result.getNumberOfChoices();) {
             Choice<ValueType>& choice = result.getChoices()[index];
 
-            if (choice.isMarkovian()) {
+            if (choice.hasRate()) {
                 if (foundPreviousMarkovianChoice) {
                     // If there was a previous Markovian choice, we need to sum them. Note that we can assume
                     // that the previous Markovian choice is the very first one in the choices vector.

--- a/src/test/storm/builder/ExplicitJaniModelBuilderTest.cpp
+++ b/src/test/storm/builder/ExplicitJaniModelBuilderTest.cpp
@@ -59,6 +59,11 @@ TEST(ExplicitJaniModelBuilderTest, Dtmc) {
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(1728ul, model->getNumberOfStates());
     EXPECT_EQ(2505ul, model->getNumberOfTransitions());
+
+    janiModel = storm::api::parseJaniModel(STORM_TEST_RESOURCES_DIR "/dtmc/rates.jani").first;
+    model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
+    EXPECT_EQ(3ul, model->getNumberOfStates());
+    EXPECT_EQ(6ul, model->getNumberOfTransitions());
 }
 
 TEST(ExplicitJaniModelBuilderTest, pdtmc) {


### PR DESCRIPTION
The jani specification allows rates to occur at edges in DTMCs which are then interpreted as weights. Previously, this case was not handled properly.

This implements the weighting for explicit (sparse) model building and throws an error for symbolic model building.