### PR TITLE
Optimization of robust VI

### DIFF
--- a/src/storm/solver/helper/ValueIterationOperator.h
+++ b/src/storm/solver/helper/ValueIterationOperator.h
@@ -411,18 +411,21 @@ class ValueIterationOperator {
      */
     bool auxiliaryVectorUsedExternally{false};
 
-    template<typename ApplyValueType>
+    // Due to a GCC bug we have to add this dummy template type here
+    // https://stackoverflow.com/questions/49707184/explicit-specialization-in-non-namespace-scope-does-not-compile-in-gcc
+    template<typename ApplyValueType, typename Dummy>
     struct ApplyCache{};
 
-    template<>
-    struct ApplyCache<storm::Interval> {
+    template<typename Dummy>
+    struct ApplyCache<storm::Interval, Dummy> {
         mutable std::vector<std::pair<SolutionType, SolutionType>> robustOrder;
+        Dummy x;
     };
 
     /*!
      * Cache for robust value iteration, empty struct for other ValueTypes than storm::Interval.
      */
-    ApplyCache<ValueType> applyCache;
+    ApplyCache<ValueType, int> applyCache;
 
     /*!
      * Bitmask that indicates the start of a row in the 'matrixColumns' vector

--- a/src/storm/solver/helper/ValueIterationOperator.h
+++ b/src/storm/solver/helper/ValueIterationOperator.h
@@ -414,12 +414,11 @@ class ValueIterationOperator {
     // Due to a GCC bug we have to add this dummy template type here
     // https://stackoverflow.com/questions/49707184/explicit-specialization-in-non-namespace-scope-does-not-compile-in-gcc
     template<typename ApplyValueType, typename Dummy>
-    struct ApplyCache{};
+    struct ApplyCache {};
 
     template<typename Dummy>
     struct ApplyCache<storm::Interval, Dummy> {
         mutable std::vector<std::pair<SolutionType, SolutionType>> robustOrder;
-        Dummy x;
     };
 
     /*!


### PR DESCRIPTION
This PR contains small adjustments to robust VI that significantly speed up the computations (at least 10x). Profiling revealed that re-allocating the vector is costly (already pointed out by the comment) and `diameter()` changes the rounding mode on each call, which is very expensive. I could not manage to get faster sorting than `std::sort`, although I haven't tried using `boost::container::flatmap`. I will try that in a private branch later :) for now it's a good improvement.