### PR TITLE
Save memory when doing bounded checking for sparse DTMCs

### DIFF
--- a/src/storm/modelchecker/helper/finitehorizon/SparseDeterministicStepBoundedHorizonHelper.cpp
+++ b/src/storm/modelchecker/helper/finitehorizon/SparseDeterministicStepBoundedHorizonHelper.cpp
@@ -27,7 +27,6 @@ SparseDeterministicStepBoundedHorizonHelper<ValueType>::SparseDeterministicStepB
 template<typename ValueType>
 std::vector<ValueType> SparseDeterministicStepBoundedHorizonHelper<ValueType>::compute(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
                                                                                        storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-                                                                                       storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                                        storm::storage::BitVector const& phiStates,
                                                                                        storm::storage::BitVector const& psiStates, uint64_t lowerBound,
                                                                                        uint64_t upperBound, ModelCheckerHint const& hint) {
@@ -40,6 +39,7 @@ std::vector<ValueType> SparseDeterministicStepBoundedHorizonHelper<ValueType>::c
     if (hint.isExplicitModelCheckerHint() && hint.template asExplicitModelCheckerHint<ValueType>().getComputeOnlyMaybeStates()) {
         maybeStates = hint.template asExplicitModelCheckerHint<ValueType>().getMaybeStates();
     } else {
+        auto backwardTransitions = transitionMatrix.transpose(true);
         maybeStates = storm::utility::graph::performProbGreater0(backwardTransitions, phiStates, psiStates, true, upperBound);
         if (lowerBound == 0) {
             maybeStates &= ~psiStates;

--- a/src/storm/modelchecker/helper/finitehorizon/SparseDeterministicStepBoundedHorizonHelper.h
+++ b/src/storm/modelchecker/helper/finitehorizon/SparseDeterministicStepBoundedHorizonHelper.h
@@ -15,8 +15,7 @@ class SparseDeterministicStepBoundedHorizonHelper {
    public:
     SparseDeterministicStepBoundedHorizonHelper();
     std::vector<ValueType> compute(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
-                                   storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-                                   storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& phiStates,
+                                   storm::storage::SparseMatrix<ValueType> const& transitionMatrix, storm::storage::BitVector const& phiStates,
                                    storm::storage::BitVector const& psiStates, uint64_t lowerBound, uint64_t upperBound,
                                    ModelCheckerHint const& hint = ModelCheckerHint());
 

--- a/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
+++ b/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
@@ -101,8 +101,8 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
         storm::modelchecker::helper::SparseDeterministicStepBoundedHorizonHelper<ValueType> helper;
         std::vector<ValueType> numericResult =
             helper.compute(env, storm::solver::SolveGoal<ValueType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
-                           this->getModel().getBackwardTransitions(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(),
-                           pathFormula.getNonStrictLowerBound<uint64_t>(), pathFormula.getNonStrictUpperBound<uint64_t>(), checkTask.getHint());
+                           leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(), pathFormula.getNonStrictLowerBound<uint64_t>(),
+                           pathFormula.getNonStrictUpperBound<uint64_t>(), checkTask.getHint());
         std::unique_ptr<CheckResult> result = std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<ValueType>(std::move(numericResult)));
         return result;
     }


### PR DESCRIPTION
Currently, Storm produces many copies of the transition matrix for the sparse engine. Concretely, there are 2 copies of the original matrix and 2 copies of the P=? submatrix resident at peak RSS.

These are

1. The original constructed matrix
2. The transpose of (1) which is used to find which states are P=?
3. The submatrix in Storm's native format
4. The submatrix in GMM++'s format.

By deferring the creation of (2), it is freed earlier (its scope is closed earlier), which allows the operating system to reuse its memory for (3) and (4). As such, peak memory usage is determined by `max(m1+m2, m1+m3+m4)` instead of `m1+m2+m3+m4`.

(Addtionally, (4) can be omitted entirely by using the Storm native solver, which is already a setting that can be changed.)

Other sparse model checking functions have the same weakness, but I only did it for this one as a proof-of-concept. Applying this patch and using the native solver nearly halves Storm's memory usage for the factories problem (f=12) from the Rubicon paper, from 1 GB to circa 0.5 GB. Either of these by themselves reduce it to 0.75 GB. This is because for this problem the submatrix has nearly the same size as the original matrix.

An alternative that could be considered is to keep the backwards transitions around in the original model. Currently, I believe that Storm recalculates the transpose over and over. Keeping it around would reduce time usage slightly, whereas dropping it early reduces memory usage.