### PR TITLE
Added option to limit the number of explored states

### DIFF
--- a/src/storm/builder/ExplicitModelBuilder.h
+++ b/src/storm/builder/ExplicitModelBuilder.h
@@ -76,6 +76,12 @@ class ExplicitModelBuilder {
 
         // The order in which to explore the model.
         ExplorationOrder explorationOrder;
+
+        // If set, deadlocks states will be fixed by adding a self-loop with probability 1.
+        bool fixDeadlocks;
+
+        // If set, no further states will be explored once the given number is exceeded.
+        std::optional<StateType> explorationStateLimit;
     };
 
     /*!

--- a/src/storm/generator/JaniNextStateGenerator.cpp
+++ b/src/storm/generator/JaniNextStateGenerator.cpp
@@ -119,7 +119,8 @@ JaniNextStateGenerator<ValueType, StateType>::JaniNextStateGenerator(storm::jani
                 this->terminalStates.emplace_back(expressionOrLabelAndBool.first.getExpression(), expressionOrLabelAndBool.second);
             } else {
                 // If it's a label, i.e. refers to a transient boolean variable we do some sanity checks first
-                if (expressionOrLabelAndBool.first.getLabel() != "init" && expressionOrLabelAndBool.first.getLabel() != "deadlock") {
+                if (expressionOrLabelAndBool.first.getLabel() != "init" && expressionOrLabelAndBool.first.getLabel() != "deadlock" &&
+                    expressionOrLabelAndBool.first.getLabel() != "unexplored") {
                     STORM_LOG_THROW(this->model.getGlobalVariables().hasVariable(expressionOrLabelAndBool.first.getLabel()),
                                     storm::exceptions::InvalidArgumentException,
                                     "Terminal states refer to illegal label '" << expressionOrLabelAndBool.first.getLabel() << "'.");
@@ -1213,7 +1214,8 @@ storm::builder::RewardModelInformation JaniNextStateGenerator<ValueType, StateTy
 template<typename ValueType, typename StateType>
 storm::models::sparse::StateLabeling JaniNextStateGenerator<ValueType, StateType>::label(storm::storage::sparse::StateStorage<StateType> const& stateStorage,
                                                                                          std::vector<StateType> const& initialStateIndices,
-                                                                                         std::vector<StateType> const& deadlockStateIndices) {
+                                                                                         std::vector<StateType> const& deadlockStateIndices,
+                                                                                         std::vector<StateType> const& unexploredStateIndices) {
     // As in JANI we can use transient boolean variable assignments in locations to identify states, we need to
     // create a list of boolean transient variables and the expressions that define them.
     std::vector<std::pair<std::string, storm::expressions::Expression>> transientVariableExpressions;
@@ -1224,7 +1226,8 @@ storm::models::sparse::StateLabeling JaniNextStateGenerator<ValueType, StateType
             }
         }
     }
-    return NextStateGenerator<ValueType, StateType>::label(stateStorage, initialStateIndices, deadlockStateIndices, transientVariableExpressions);
+    return NextStateGenerator<ValueType, StateType>::label(stateStorage, initialStateIndices, deadlockStateIndices, unexploredStateIndices,
+                                                           transientVariableExpressions);
 }
 
 template<typename ValueType, typename StateType>

--- a/src/storm/generator/JaniNextStateGenerator.cpp
+++ b/src/storm/generator/JaniNextStateGenerator.cpp
@@ -119,8 +119,7 @@ JaniNextStateGenerator<ValueType, StateType>::JaniNextStateGenerator(storm::jani
                 this->terminalStates.emplace_back(expressionOrLabelAndBool.first.getExpression(), expressionOrLabelAndBool.second);
             } else {
                 // If it's a label, i.e. refers to a transient boolean variable we do some sanity checks first
-                if (expressionOrLabelAndBool.first.getLabel() != "init" && expressionOrLabelAndBool.first.getLabel() != "deadlock" &&
-                    expressionOrLabelAndBool.first.getLabel() != "unexplored") {
+                if (!this->isSpecialLabel(expressionOrLabelAndBool.first.getLabel())) {
                     STORM_LOG_THROW(this->model.getGlobalVariables().hasVariable(expressionOrLabelAndBool.first.getLabel()),
                                     storm::exceptions::InvalidArgumentException,
                                     "Terminal states refer to illegal label '" << expressionOrLabelAndBool.first.getLabel() << "'.");

--- a/src/storm/generator/JaniNextStateGenerator.h
+++ b/src/storm/generator/JaniNextStateGenerator.h
@@ -59,7 +59,8 @@ class JaniNextStateGenerator : public NextStateGenerator<ValueType, StateType> {
 
     virtual storm::models::sparse::StateLabeling label(storm::storage::sparse::StateStorage<StateType> const& stateStorage,
                                                        std::vector<StateType> const& initialStateIndices = {},
-                                                       std::vector<StateType> const& deadlockStateIndices = {}) override;
+                                                       std::vector<StateType> const& deadlockStateIndices = {},
+                                                       std::vector<StateType> const& unexploredStateIndices = {}) override;
 
     virtual std::shared_ptr<storm::storage::sparse::ChoiceOrigins> generateChoiceOrigins(std::vector<boost::any>& dataForChoiceOrigins) const override;
 

--- a/src/storm/generator/NextStateGenerator.cpp
+++ b/src/storm/generator/NextStateGenerator.cpp
@@ -174,7 +174,8 @@ storm::storage::sparse::StateValuations NextStateGenerator<ValueType, StateType>
 template<typename ValueType, typename StateType>
 storm::models::sparse::StateLabeling NextStateGenerator<ValueType, StateType>::label(
     storm::storage::sparse::StateStorage<StateType> const& stateStorage, std::vector<StateType> const& initialStateIndices,
-    std::vector<StateType> const& deadlockStateIndices, std::vector<std::pair<std::string, storm::expressions::Expression>> labelsAndExpressions) {
+    std::vector<StateType> const& deadlockStateIndices, std::vector<StateType> const& unexploredStateIndices,
+    std::vector<std::pair<std::string, storm::expressions::Expression>> labelsAndExpressions) {
     labelsAndExpressions.insert(labelsAndExpressions.end(), this->options.getExpressionLabels().begin(), this->options.getExpressionLabels().end());
 
     // Make the labels unique.
@@ -220,6 +221,12 @@ storm::models::sparse::StateLabeling NextStateGenerator<ValueType, StateType>::l
         result.addLabel("deadlock");
         for (auto index : deadlockStateIndices) {
             result.addLabelToState("deadlock", index);
+        }
+    }
+    if (!result.containsLabel("unexplored") && !unexploredStateIndices.empty()) {
+        result.addLabel("unexplored");
+        for (auto index : unexploredStateIndices) {
+            result.addLabelToState("unexplored", index);
         }
     }
 

--- a/src/storm/generator/NextStateGenerator.h
+++ b/src/storm/generator/NextStateGenerator.h
@@ -123,7 +123,8 @@ class NextStateGenerator {
 
     virtual storm::models::sparse::StateLabeling label(storm::storage::sparse::StateStorage<StateType> const& stateStorage,
                                                        std::vector<StateType> const& initialStateIndices = {},
-                                                       std::vector<StateType> const& deadlockStateIndices = {}) = 0;
+                                                       std::vector<StateType> const& deadlockStateIndices = {},
+                                                       std::vector<StateType> const& unexploredStateIndices = {}) = 0;
 
     NextStateGeneratorOptions const& getOptions() const;
 
@@ -144,6 +145,7 @@ class NextStateGenerator {
      */
     storm::models::sparse::StateLabeling label(storm::storage::sparse::StateStorage<StateType> const& stateStorage,
                                                std::vector<StateType> const& initialStateIndices, std::vector<StateType> const& deadlockStateIndices,
+                                               std::vector<StateType> const& unexploredStateIndices,
                                                std::vector<std::pair<std::string, storm::expressions::Expression>> labelsAndExpressions);
 
     /*!

--- a/src/storm/generator/NextStateGenerator.h
+++ b/src/storm/generator/NextStateGenerator.h
@@ -141,6 +141,11 @@ class NextStateGenerator {
 
    protected:
     /*!
+     * Checks if the input label has a special purpose (e.g. "init", "deadlock", "unexplored", "overlap_guards", "out_of_bounds").
+     */
+    bool isSpecialLabel(std::string const& label) const;
+
+    /*!
      * Creates the state labeling for the given states using the provided labels and expressions.
      */
     storm::models::sparse::StateLabeling label(storm::storage::sparse::StateStorage<StateType> const& stateStorage,

--- a/src/storm/generator/PrismNextStateGenerator.cpp
+++ b/src/storm/generator/PrismNextStateGenerator.cpp
@@ -90,7 +90,8 @@ PrismNextStateGenerator<ValueType, StateType>::PrismNextStateGenerator(storm::pr
                         std::make_pair(this->program.getLabelExpression(expressionOrLabelAndBool.first.getLabel()), expressionOrLabelAndBool.second));
                 } else {
                     // If the label is not present in the program and is not a special one, we raise an error.
-                    STORM_LOG_THROW(expressionOrLabelAndBool.first.getLabel() == "init" || expressionOrLabelAndBool.first.getLabel() == "deadlock",
+                    STORM_LOG_THROW(expressionOrLabelAndBool.first.getLabel() == "init" || expressionOrLabelAndBool.first.getLabel() == "deadlock" ||
+                                        expressionOrLabelAndBool.first.getLabel() == "unexplored",
                                     storm::exceptions::InvalidArgumentException,
                                     "Terminal states refer to illegal label '" << expressionOrLabelAndBool.first.getLabel() << "'.");
                 }
@@ -815,7 +816,8 @@ std::map<std::string, storm::storage::PlayerIndex> PrismNextStateGenerator<Value
 template<typename ValueType, typename StateType>
 storm::models::sparse::StateLabeling PrismNextStateGenerator<ValueType, StateType>::label(storm::storage::sparse::StateStorage<StateType> const& stateStorage,
                                                                                           std::vector<StateType> const& initialStateIndices,
-                                                                                          std::vector<StateType> const& deadlockStateIndices) {
+                                                                                          std::vector<StateType> const& deadlockStateIndices,
+                                                                                          std::vector<StateType> const& unexploredStateIndices) {
     // Gather a vector of labels and their expressions.
     std::vector<std::pair<std::string, storm::expressions::Expression>> labels;
     if (this->options.isBuildAllLabelsSet()) {
@@ -827,13 +829,13 @@ storm::models::sparse::StateLabeling PrismNextStateGenerator<ValueType, StateTyp
             if (program.hasLabel(labelName)) {
                 labels.push_back(std::make_pair(labelName, program.getLabelExpression(labelName)));
             } else {
-                STORM_LOG_THROW(labelName == "init" || labelName == "deadlock", storm::exceptions::InvalidArgumentException,
+                STORM_LOG_THROW(labelName == "init" || labelName == "deadlock" || labelName == "unexplored", storm::exceptions::InvalidArgumentException,
                                 "Cannot build labeling for unknown label '" << labelName << "'.");
             }
         }
     }
 
-    return NextStateGenerator<ValueType, StateType>::label(stateStorage, initialStateIndices, deadlockStateIndices, labels);
+    return NextStateGenerator<ValueType, StateType>::label(stateStorage, initialStateIndices, deadlockStateIndices, unexploredStateIndices, labels);
 }
 
 template<typename ValueType, typename StateType>

--- a/src/storm/generator/PrismNextStateGenerator.cpp
+++ b/src/storm/generator/PrismNextStateGenerator.cpp
@@ -90,9 +90,7 @@ PrismNextStateGenerator<ValueType, StateType>::PrismNextStateGenerator(storm::pr
                         std::make_pair(this->program.getLabelExpression(expressionOrLabelAndBool.first.getLabel()), expressionOrLabelAndBool.second));
                 } else {
                     // If the label is not present in the program and is not a special one, we raise an error.
-                    STORM_LOG_THROW(expressionOrLabelAndBool.first.getLabel() == "init" || expressionOrLabelAndBool.first.getLabel() == "deadlock" ||
-                                        expressionOrLabelAndBool.first.getLabel() == "unexplored",
-                                    storm::exceptions::InvalidArgumentException,
+                    STORM_LOG_THROW(this->isSpecialLabel(expressionOrLabelAndBool.first.getLabel()), storm::exceptions::InvalidArgumentException,
                                     "Terminal states refer to illegal label '" << expressionOrLabelAndBool.first.getLabel() << "'.");
                 }
             }
@@ -829,7 +827,7 @@ storm::models::sparse::StateLabeling PrismNextStateGenerator<ValueType, StateTyp
             if (program.hasLabel(labelName)) {
                 labels.push_back(std::make_pair(labelName, program.getLabelExpression(labelName)));
             } else {
-                STORM_LOG_THROW(labelName == "init" || labelName == "deadlock" || labelName == "unexplored", storm::exceptions::InvalidArgumentException,
+                STORM_LOG_THROW(this->isSpecialLabel(labelName), storm::exceptions::InvalidArgumentException,
                                 "Cannot build labeling for unknown label '" << labelName << "'.");
             }
         }

--- a/src/storm/generator/PrismNextStateGenerator.h
+++ b/src/storm/generator/PrismNextStateGenerator.h
@@ -43,7 +43,8 @@ class PrismNextStateGenerator : public NextStateGenerator<ValueType, StateType> 
 
     virtual storm::models::sparse::StateLabeling label(storm::storage::sparse::StateStorage<StateType> const& stateStorage,
                                                        std::vector<StateType> const& initialStateIndices = {},
-                                                       std::vector<StateType> const& deadlockStateIndices = {}) override;
+                                                       std::vector<StateType> const& deadlockStateIndices = {},
+                                                       std::vector<StateType> const& unexploredStateIndices = {}) override;
 
     virtual std::shared_ptr<storm::storage::sparse::ChoiceOrigins> generateChoiceOrigins(std::vector<boost::any>& dataForChoiceOrigins) const override;
 

--- a/src/storm/settings/modules/BuildSettings.cpp
+++ b/src/storm/settings/modules/BuildSettings.cpp
@@ -39,6 +39,7 @@ const std::string buildOverlappingGuardsLabelOptionName = "build-overlapping-gua
 const std::string noSimplifyOptionName = "no-simplify";
 const std::string bitsForUnboundedVariablesOptionName = "int-bits";
 const std::string performLocationElimination = "location-elimination";
+const std::string explorationStateLimitOptionName = "state-limit";
 
 BuildSettings::BuildSettings() : ModuleSettings(moduleName) {
     this->addOption(storm::settings::OptionBuilder(moduleName, prismCompatibilityOptionName, false,
@@ -114,6 +115,12 @@ BuildSettings::BuildSettings() : ModuleSettings(moduleName) {
                                          .setDefaultValueUnsignedInteger(10000)
                                          .makeOptional()
                                          .build())
+                        .build());
+
+    this->addOption(storm::settings::OptionBuilder(moduleName, explorationStateLimitOptionName, false,
+                                                   "Potentially stopped exploration once the specified number of states is exceeded.")
+                        .setIsAdvanced()
+                        .addArgument(storm::settings::ArgumentBuilder::createUnsignedIntegerArgument("number", "states to explore before stopping.").build())
                         .build());
 }
 
@@ -206,6 +213,15 @@ uint64_t BuildSettings::getLocationEliminationLocationHeuristic() const {
 uint64_t BuildSettings::getLocationEliminationEdgesHeuristic() const {
     return this->getOption(performLocationElimination).getArgumentByName("edges-heuristic").getValueAsUnsignedInteger();
 }
+
+bool BuildSettings::isExplorationStateLimitSet() const {
+    return this->getOption(explorationStateLimitOptionName).getHasOptionBeenSet();
+}
+
+uint64_t BuildSettings::getExplorationStateLimit() const {
+    return this->getOption(explorationStateLimitOptionName).getArgumentByName("number").getValueAsUnsignedInteger();
+}
+
 }  // namespace modules
 
 }  // namespace settings

--- a/src/storm/settings/modules/BuildSettings.h
+++ b/src/storm/settings/modules/BuildSettings.h
@@ -139,6 +139,16 @@ class BuildSettings : public ModuleSettings {
      */
     uint64_t getLocationEliminationEdgesHeuristic() const;
 
+    /*!
+     * Retrieves whether an exploration state limit has been set in which case state space exploration might be stopped once the specified number is exceeded.
+     */
+    bool isExplorationStateLimitSet() const;
+
+    /*!
+     * Retrieves the state limit (if set). State space exploration might be stopped once the specified number is exceeded.
+     */
+    uint64_t getExplorationStateLimit() const;
+
     // The name of the module.
     static const std::string moduleName;
 };

--- a/src/storm/storage/sparse/StateStorage.cpp
+++ b/src/storm/storage/sparse/StateStorage.cpp
@@ -5,8 +5,7 @@ namespace storage {
 namespace sparse {
 
 template<typename StateType>
-StateStorage<StateType>::StateStorage(uint64_t bitsPerState)
-    : stateToId(bitsPerState, 100000), initialStateIndices(), deadlockStateIndices(), bitsPerState(bitsPerState) {
+StateStorage<StateType>::StateStorage(uint64_t bitsPerState) : stateToId(bitsPerState, 100000), bitsPerState(bitsPerState) {
     // Intentionally left empty.
 }
 

--- a/src/storm/storage/sparse/StateStorage.h
+++ b/src/storm/storage/sparse/StateStorage.h
@@ -23,6 +23,9 @@ struct StateStorage {
     // A list of deadlock states.
     std::vector<StateType> deadlockStateIndices;
 
+    // A list of unexplored states.
+    std::vector<StateType> unexploredStateIndices;
+
     // The number of bits of each state.
     uint64_t bitsPerState;
 


### PR DESCRIPTION
Added option `--build:state limit <number>` which, if set, stops expanding new states once the given `<number>` of states has been found. 

This is useful for, e.g., debugging models that normally would be too large.
If there are unexplored states, a label `"unexplored"` is added and assigned to them. This even allows to calculate the probability to exit the fraction of the explored state space.

```console
$ storm --prism resources/examples/testfiles/dtmc/crowds-5-5.pm --state-limit 8500 --prop 'P=? [F "unexplored"]' 
Storm 1.8.2 (dev)
DEBUG BUILD

Date: Fri Apr 12 13:51:26 2024
Command line arguments: --prism ../resources/examples/testfiles/dtmc/crowds-5-5.pm --state-limit 8500 --prop 'P=? [F "unexplored"]'
Current working directory: /Users/tim/storm/build

Time for model input parsing: 0.010s.

Time for model construction: 0.060s.

-------------------------------------------------------------- 
Model type: 	DTMC (sparse)
States: 	8500
Transitions: 	15006
Reward Models:  none
State Labels: 	3 labels
   * unexplored -> 140 item(s)
   * deadlock -> 1120 item(s)
   * init -> 1 item(s)
Choice Labels: 	none
-------------------------------------------------------------- 

Model checking property "1": P=? [F "unexplored"] ...
Result (for initial states): 0.001353870181
Time for model checking: 0.016s.
```

Note: the "unexplored" label does not exist if all states are explored.