### PR TITLE
Added `--permute` option to re-order the states after building.

### DIFF
--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -591,6 +591,15 @@ std::pair<std::shared_ptr<storm::models::sparse::Model<ValueType>>, bool> prepro
 
     std::pair<std::shared_ptr<storm::models::sparse::Model<ValueType>>, bool> result = std::make_pair(model, false);
 
+    if (auto order = transformationSettings.getModelPermutation(); order.has_value()) {
+        auto seed = transformationSettings.getModelPermutationSeed();
+        STORM_PRINT_AND_LOG("Permuting model states using " << storm::utility::permutation::orderKindtoString(order.value()) << " order"
+                                                            << (seed.has_value() ? " with seed " + std::to_string(seed.value()) : "") << ".\n");
+        result.first = storm::api::permuteModelStates(result.first, order.value(), seed);
+        result.second = true;
+        STORM_PRINT_AND_LOG("Transition matrix hash after permuting: " << result.first->getTransitionMatrix().hash() << ".\n");
+    }
+
     if (result.first->isOfType(storm::models::ModelType::MarkovAutomaton)) {
         result.first = preprocessSparseMarkovAutomaton(result.first->template as<storm::models::sparse::MarkovAutomaton<ValueType>>());
         result.second = true;

--- a/src/storm/api/transformation.h
+++ b/src/storm/api/transformation.h
@@ -149,7 +149,8 @@ std::shared_ptr<storm::models::sparse::Model<ValueType>> transformToNondetermini
 }
 
 /*!
- * Permutes the model according to the given order.
+ * Permutes the order of the states of the model according to the given order.
+ * The order of the available choices at a state (of a nondeterministic model) is not changed.
  * A seed can be given which will be respected if a random permutation is requested.
  */
 template<typename ValueType>

--- a/src/storm/api/transformation.h
+++ b/src/storm/api/transformation.h
@@ -2,12 +2,14 @@
 
 #include "storm/transformer/ContinuousToDiscreteTimeModelTransformer.h"
 #include "storm/transformer/NonMarkovianChainTransformer.h"
+#include "storm/transformer/StatePermuter.h"
 #include "storm/transformer/SymbolicToSparseTransformer.h"
 
 #include "storm/exceptions/InvalidOperationException.h"
 #include "storm/exceptions/NotSupportedException.h"
 #include "storm/utility/builder.h"
 #include "storm/utility/macros.h"
+#include "storm/utility/permutation.h"
 
 namespace storm {
 namespace api {
@@ -144,6 +146,23 @@ std::shared_ptr<storm::models::sparse::Model<ValueType>> transformToNondetermini
         STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException,
                         "Cannot transform model of type " << model.getType() << " to a nondeterministic model.");
     }
+}
+
+/*!
+ * Permutes the model according to the given order.
+ * A seed can be given which will be respected if a random permutation is requested.
+ */
+template<typename ValueType>
+std::shared_ptr<storm::models::sparse::Model<ValueType>> permuteModelStates(std::shared_ptr<storm::models::sparse::Model<ValueType>> const& model,
+                                                                            storm::utility::permutation::OrderKind order,
+                                                                            std::optional<uint64_t> seed = std::nullopt) {
+    std::vector<storm::utility::permutation::index_type> permutation;
+    if (order == storm::utility::permutation::OrderKind::Random && seed.has_value()) {
+        permutation = storm::utility::permutation::createRandomPermutation(model->getNumberOfStates(), seed.value());
+    } else {
+        permutation = storm::utility::permutation::createPermutation(order, model->getTransitionMatrix(), model->getInitialStates());
+    }
+    return storm::transformer::permuteStates(*model, permutation);
 }
 
 }  // namespace api

--- a/src/storm/models/sparse/StandardRewardModel.h
+++ b/src/storm/models/sparse/StandardRewardModel.h
@@ -6,6 +6,7 @@
 
 #include "storm/adapters/RationalFunctionForward.h"
 #include "storm/storage/SparseMatrix.h"
+#include "storm/utility/OptionalRef.h"
 #include "storm/utility/OsDetection.h"
 #include "storm/utility/constants.h"
 
@@ -206,6 +207,17 @@ class StandardRewardModel {
      *
      */
     StandardRewardModel<ValueType> permuteActions(std::vector<uint64_t> const& inversePermutation) const;
+
+    /*!
+     * Creates a new reward model by permuting the states.
+     * That is, assign to state i, the rewards previously assigned to state inversePermutation[i].
+     * @param inversePermutation The inverse permutation that is used to permute the states.
+     * @param rowGroupIndices must be given to respect grouped action rewards. If they are not given, it is assumed that each state has exactly one action
+     * @param permutation The (non-inverted) permutation. Relevant only if transition rewards are present.
+     */
+    StandardRewardModel<ValueType> permuteStates(std::vector<uint64_t> const& inversePermutation,
+                                                 storm::OptionalRef<std::vector<uint64_t> const> rowGroupIndices = storm::NullRef,
+                                                 storm::OptionalRef<std::vector<uint64_t> const> permutation = storm::NullRef) const;
 
     /*!
      * Reduces the transition-based rewards to state-action rewards by taking the average of each row. If

--- a/src/storm/settings/modules/TransformationSettings.h
+++ b/src/storm/settings/modules/TransformationSettings.h
@@ -1,13 +1,18 @@
-#ifndef STORM_TRANSFORMATIONSETTINGS_H
-#define STORM_TRANSFORMATIONSETTINGS_H
+#pragma once
+
+#include <optional>
 
 #include "storm-config.h"
 #include "storm/api/transformation.h"
 #include "storm/settings/modules/ModuleSettings.h"
 
 namespace storm {
-namespace settings {
-namespace modules {
+
+namespace utility::permutation {
+enum class OrderKind;
+}
+
+namespace settings::modules {
 
 /*!
  * This class represents the model transformer settings
@@ -43,6 +48,16 @@ class TransformationSettings : public ModuleSettings {
      */
     bool isToDiscreteTimeModelSet() const;
 
+    /*!
+     * If the returned value is not empty, the model should be permuted according to the given order.
+     */
+    std::optional<storm::utility::permutation::OrderKind> getModelPermutation() const;
+
+    /*!
+     * Retrieves a random seed to be used in case the model shall be permuted randomly.
+     */
+    std::optional<uint64_t> getModelPermutationSeed() const;
+
     bool check() const override;
 
     void finalize() override;
@@ -56,10 +71,8 @@ class TransformationSettings : public ModuleSettings {
     static const std::string labelBehaviorOptionName;
     static const std::string toNondetOptionName;
     static const std::string toDiscreteTimeOptionName;
+    static const std::string permuteModelOptionName;
 };
 
-}  // namespace modules
-}  // namespace settings
+}  // namespace settings::modules
 }  // namespace storm
-
-#endif  // STORM_TRANSFORMATIONSETTINGS_H

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -515,6 +515,18 @@ BitVector BitVector::permute(std::vector<uint64_t> const& inversePermutation) co
     return result;
 }
 
+BitVector BitVector::permuteGroupedVector(const std::vector<uint64_t>& inversePermutation, const std::vector<uint64_t>& rowGroupIndices) const {
+    BitVector result(this->size());
+    for (auto sourceIndex : inversePermutation) {
+        for (uint64_t i = rowGroupIndices[sourceIndex]; i < rowGroupIndices[sourceIndex + 1]; ++i) {
+            if (this->get(i)) {
+                result.set(i, true);
+            }
+        }
+    }
+    return result;
+}
+
 void BitVector::set(uint_fast64_t bitIndex, BitVector const& other) {
     STORM_LOG_ASSERT((bitIndex & mod64mask) == 0, "Bit index must be a multiple of 64.");
     STORM_LOG_ASSERT(other.size() <= this->size() - bitIndex, "Bit vector argument is too long.");

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -516,14 +516,17 @@ BitVector BitVector::permute(std::vector<uint64_t> const& inversePermutation) co
 }
 
 BitVector BitVector::permuteGroupedVector(const std::vector<uint64_t>& inversePermutation, const std::vector<uint64_t>& rowGroupIndices) const {
-    BitVector result(this->size());
-    for (auto sourceIndex : inversePermutation) {
-        for (uint64_t i = rowGroupIndices[sourceIndex]; i < rowGroupIndices[sourceIndex + 1]; ++i) {
-            if (this->get(i)) {
-                result.set(i, true);
+    STORM_LOG_ASSERT(inversePermutation.size() == rowGroupIndices.size() - 1, "Inverse permutation and row group indices do not match.");
+    BitVector result(this->size(), false);
+    uint64_t targetIndex = 0u;
+    for (auto const sourceGroupIndex : inversePermutation) {
+        for (uint64_t sourceIndex = rowGroupIndices[sourceGroupIndex]; sourceIndex < rowGroupIndices[sourceGroupIndex + 1]; ++sourceIndex, ++targetIndex) {
+            if (this->get(sourceIndex)) {
+                result.set(targetIndex, true);
             }
         }
     }
+    STORM_LOG_ASSERT(targetIndex == result.size(), "Target index does not match the size of the result.");
     return result;
 }
 

--- a/src/storm/storage/BitVector.h
+++ b/src/storm/storage/BitVector.h
@@ -486,6 +486,14 @@ class BitVector {
     BitVector permute(std::vector<uint64_t> const& inversePermutation) const;
 
     /*!
+     * Apply a permutation of entries assuming a grouped vector. That is, in row group i, write the entries of row group inversePermutation[i].
+     * @param inversePermutation.
+     * @return
+     * TODO this operation is slow.
+     */
+    BitVector permuteGroupedVector(std::vector<uint64_t> const& inversePermutation, std::vector<uint64_t> const& rowGroupIndices) const;
+
+    /*!
      * Retrieves the content of the current bit vector at the given index for the given number of bits as a new
      * bit vector.
      *

--- a/src/storm/storage/SparseMatrix.cpp
+++ b/src/storm/storage/SparseMatrix.cpp
@@ -7,6 +7,7 @@
 #include "storm/storage/BitVector.h"
 #include "storm/utility/ConstantsComparator.h"
 #include "storm/utility/constants.h"
+#include "storm/utility/permutation.h"
 #include "storm/utility/vector.h"
 
 #include "storm/exceptions/InvalidArgumentException.h"
@@ -1444,6 +1445,30 @@ SparseMatrix<ValueType> SparseMatrix<ValueType>::permuteRows(std::vector<index_t
         result.setRowGroupIndices(this->rowGroupIndices.get());
     }
     return result;
+}
+
+template<typename ValueType>
+SparseMatrix<ValueType> SparseMatrix<ValueType>::permuteRowGroupsAndColumns(std::vector<index_type> const& inverseRowGroupPermutation,
+                                                                            std::vector<index_type> const& columnPermutation) const {
+    STORM_LOG_ASSERT(storm::utility::permutation::isValidPermutation(inverseRowGroupPermutation), "Row group permutation is not a permutation.");
+    STORM_LOG_ASSERT(storm::utility::permutation::isValidPermutation(columnPermutation), "Column permutation is not a permutation.");
+    index_type const rowCount = getRowCount();
+    SparseMatrixBuilder<ValueType> matrixBuilder(rowCount, getColumnCount(), getEntryCount(), true, !hasTrivialRowGrouping(), getRowGroupCount());
+    auto oldGroupIt = inverseRowGroupPermutation.cbegin();
+    index_type newRowIndex = 0;
+    while (newRowIndex < rowCount) {
+        if (!hasTrivialRowGrouping()) {
+            matrixBuilder.newRowGroup(newRowIndex);
+        }
+        for (auto oldRowIndex : getRowGroupIndices(*oldGroupIt)) {
+            for (auto const& oldEntry : getRow(oldRowIndex)) {
+                matrixBuilder.addNextValue(newRowIndex, columnPermutation[oldEntry.getColumn()], oldEntry.getValue());
+            }
+            ++newRowIndex;
+        }
+        ++oldGroupIt;
+    }
+    return matrixBuilder.build();
 }
 
 template<typename ValueType>

--- a/src/storm/storage/SparseMatrix.h
+++ b/src/storm/storage/SparseMatrix.h
@@ -754,13 +754,22 @@ class SparseMatrix {
      */
     SparseMatrix restrictRows(storm::storage::BitVector const& rowsToKeep, bool allowEmptyRowGroups = false) const;
 
-    /*
+    /*!
      * Permute rows of the matrix according to the vector.
      * That is, in row i, write the entry of row inversePermutation[i].
      * Consequently, a single row might actually be written into multiple other rows, and the function application is not necessarily a permutation.
      * Notice that this method does *not* touch column entries, nor the row grouping.
      */
     SparseMatrix permuteRows(std::vector<index_type> const& inversePermutation) const;
+
+    /*!
+     * Permutes row groups and columns of the matrix according to the given  permutations.
+     * That is, in row group i, write the entries of row group inverseRowGroupPermutation[i] and in column columnPermutation[j], write the entries of column j.
+     * @pre inverseRowGroupPermutation and columnPermutation must be permutations (i.e., they must contain each index exactly once).
+     * @note the permutation for the row groups is inverted while the one for columns is not!
+     * @return the permuted matrix.
+     */
+    SparseMatrix permuteRowGroupsAndColumns(std::vector<index_type> const& inverseRowGroupPermutation, std::vector<index_type> const& columnPermutation) const;
 
     /*!
      * Returns a copy of this matrix that only considers entries in the selected rows.

--- a/src/storm/transformer/StatePermuter.cpp
+++ b/src/storm/transformer/StatePermuter.cpp
@@ -1,0 +1,80 @@
+#include "storm/transformer/StatePermuter.h"
+
+#include "storm/adapters/RationalFunctionAdapter.h"
+#include "storm/adapters/RationalNumberAdapter.h"
+#include "storm/exceptions/UnexpectedException.h"
+#include "storm/models/sparse/Ctmc.h"
+#include "storm/models/sparse/Dtmc.h"
+#include "storm/models/sparse/MarkovAutomaton.h"
+#include "storm/models/sparse/Mdp.h"
+#include "storm/models/sparse/Pomdp.h"
+#include "storm/models/sparse/StandardRewardModel.h"
+#include "storm/storage/SparseMatrix.h"
+#include "storm/storage/sparse/ModelComponents.h"
+#include "storm/utility/OptionalRef.h"
+#include "storm/utility/builder.h"
+#include "storm/utility/macros.h"
+#include "storm/utility/permutation.h"
+#include "storm/utility/vector.h"
+
+namespace storm::transformer {
+
+template<typename ValueType>
+std::shared_ptr<storm::models::sparse::Model<ValueType>> permuteStates(storm::models::sparse::Model<ValueType> const& originalModel,
+                                                                       std::vector<uint64_t> const& permutation) {
+    STORM_LOG_ASSERT(originalModel.getNumberOfStates() == permutation.size(), "Invalid permutation size.");
+    STORM_LOG_ASSERT(storm::utility::permutation::isValidPermutation(permutation), "Invalid permutation.");
+    auto const inversePermutation = storm::utility::permutation::invertPermutation(permutation);
+    storm::OptionalRef<std::vector<storm::storage::SparseMatrixIndexType> const> optionalGroupIndices;
+    if (!originalModel.getTransitionMatrix().hasTrivialRowGrouping()) {
+        optionalGroupIndices.reset(originalModel.getTransitionMatrix().getRowGroupIndices());
+    }
+
+    // transitions, state labels, reward models
+    auto permutedMatrix = originalModel.getTransitionMatrix().permuteRowGroupsAndColumns(inversePermutation, permutation);
+    auto permutedStateLabels = originalModel.getStateLabeling();
+    permutedStateLabels.permuteItems(inversePermutation);
+    storm::storage::sparse::ModelComponents<ValueType> components(std::move(permutedMatrix), std::move(permutedStateLabels));
+    for (auto const& [name, origRewardModel] : originalModel.getRewardModels()) {
+        auto permutedRewardModel = origRewardModel.permuteStates(inversePermutation, optionalGroupIndices, permutation);
+        components.rewardModels.emplace(name, std::move(permutedRewardModel));
+    }
+
+    // Choice labeling, choice origins, state valuations
+    if (originalModel.hasChoiceLabeling()) {
+        auto permutedChoiceLabeling = originalModel.getChoiceLabeling();
+        permutedChoiceLabeling.permuteItems(inversePermutation);
+        components.choiceLabeling = std::move(permutedChoiceLabeling);
+    }
+    STORM_LOG_WARN_COND(!originalModel.hasStateValuations(), "State valuations will be dropped as permuting them is currently not implemented.");
+    STORM_LOG_WARN_COND(!originalModel.hasChoiceOrigins(), "Choice origins will be dropped as permuting them is currently not implemented.");
+
+    // Model type specific components
+    if (originalModel.isOfType(storm::models::ModelType::Pomdp)) {
+        auto const& pomdp = *originalModel.template as<storm::models::sparse::Pomdp<ValueType>>();
+        components.observabilityClasses = storm::utility::vector::applyInversePermutation(inversePermutation, pomdp.getObservations());
+        STORM_LOG_WARN_COND(!pomdp.hasObservationValuations(), "Observation valuations will be dropped as permuting them is currently not implemented.");
+    }
+    if (originalModel.isOfType(storm::models::ModelType::MarkovAutomaton)) {
+        auto const& ma = *originalModel.template as<storm::models::sparse::MarkovAutomaton<ValueType>>();
+        components.markovianStates = ma.getMarkovianStates().permute(inversePermutation);
+        components.exitRates = storm::utility::vector::applyInversePermutation(inversePermutation, ma.getExitRates());
+        components.rateTransitions = false;  // Note that originalModel.getTransitionMatrix() contains probabilities
+    } else if (originalModel.isOfType(storm::models::ModelType::Ctmc)) {
+        auto const& ctmc = *originalModel.template as<storm::models::sparse::Ctmc<ValueType>>();
+        components.exitRates = storm::utility::vector::applyInversePermutation(inversePermutation, ctmc.getExitRateVector());
+        components.rateTransitions = true;
+    } else {
+        STORM_LOG_THROW(originalModel.isOfType(storm::models::ModelType::Dtmc) || originalModel.isOfType(storm::models::ModelType::Mdp),
+                        storm::exceptions::UnexpectedException, "Unhandled model type.");
+    }
+    return storm::utility::builder::buildModelFromComponents(originalModel.getType(), std::move(components));
+}
+
+template std::shared_ptr<storm::models::sparse::Model<double>> permuteStates(storm::models::sparse::Model<double> const& originalModel,
+                                                                             std::vector<uint64_t> const& permutation);
+template std::shared_ptr<storm::models::sparse::Model<storm::RationalNumber>> permuteStates(
+    storm::models::sparse::Model<storm::RationalNumber> const& originalModel, std::vector<uint64_t> const& permutation);
+template std::shared_ptr<storm::models::sparse::Model<storm::RationalFunction>> permuteStates(
+    storm::models::sparse::Model<storm::RationalFunction> const& originalModel, std::vector<uint64_t> const& permutation);
+}  // namespace storm::transformer

--- a/src/storm/transformer/StatePermuter.h
+++ b/src/storm/transformer/StatePermuter.h
@@ -1,0 +1,21 @@
+#include <cstdint>
+#include <memory>
+#include <vector>
+#include "storm/models/sparse/Model.h"
+
+namespace storm::transformer {
+
+/*!
+ * Applies the given permutation to the states of the given model.
+ * The permutation must be a permutation of the numbers 0, 1, ..., n-1 for n = model.getNumberOfStates().
+ * The state at position i of the input model will be moved to position permutation[i] in the output model.
+ * @tparam ValueType
+ * @param originalModel
+ * @param permutation
+ * @return
+ */
+template<typename ValueType>
+std::shared_ptr<storm::models::sparse::Model<ValueType>> permuteStates(storm::models::sparse::Model<ValueType> const& originalModel,
+                                                                       std::vector<uint64_t> const& permutation);
+
+}  // namespace storm::transformer

--- a/src/storm/utility/permutation.cpp
+++ b/src/storm/utility/permutation.cpp
@@ -1,0 +1,139 @@
+#include "storm/utility/permutation.h"
+
+#include <algorithm>
+#include <deque>
+#include <numeric>
+#include <random>
+
+#include "storm/adapters/RationalFunctionAdapter.h"
+#include "storm/adapters/RationalNumberAdapter.h"
+#include "storm/storage/BitVector.h"
+#include "storm/storage/SparseMatrix.h"
+#include "storm/utility/macros.h"
+
+namespace storm::utility::permutation {
+
+/*!
+ * Converts the given order to a string.
+ */
+std::string orderKindtoString(OrderKind order) {
+    switch (order) {
+        case OrderKind::Bfs:
+            return "bfs";
+        case OrderKind::Dfs:
+            return "dfs";
+        case OrderKind::ReverseBfs:
+            return "reverse-bfs";
+        case OrderKind::ReverseDfs:
+            return "reverse-dfs";
+        case OrderKind::Random:
+            return "random";
+    }
+    STORM_LOG_ASSERT(false, "unreachable");
+    return "";
+}
+
+OrderKind orderKindFromString(std::string const& order) {
+    for (auto kind : {OrderKind::Bfs, OrderKind::Dfs, OrderKind::ReverseBfs, OrderKind::ReverseDfs, OrderKind::Random}) {
+        if (order == orderKindtoString(kind)) {
+            return kind;
+        }
+    }
+    STORM_LOG_ASSERT(false, "Unknown order kind");
+    return OrderKind::Bfs;
+}
+
+std::vector<std::string> orderKinds() {
+    std::vector<std::string> kinds;
+    for (auto kind : {OrderKind::Bfs, OrderKind::Dfs, OrderKind::ReverseBfs, OrderKind::ReverseDfs, OrderKind::Random}) {
+        kinds.push_back(orderKindtoString(kind));
+    }
+    return kinds;
+}
+
+std::vector<index_type> createRandomPermutation(index_type size) {
+    std::random_device rd;
+    return createRandomPermutation(size, rd());
+}
+
+std::vector<index_type> createRandomPermutation(index_type size, index_type seed) {
+    std::vector<index_type> permutation(size);
+    std::iota(permutation.begin(), permutation.end(), 0);
+    // The random number engine below assumes that it operates on 64-bit unsigned integers.
+    static_assert(std::is_same_v<index_type, uint64_t>, "index_type is assumed to be a 64-bit unsigned integer");
+    std::shuffle(permutation.begin(), permutation.end(), std::mt19937_64(seed));
+    return permutation;
+}
+
+template<typename ValueType>
+std::vector<index_type> createPermutation(OrderKind order, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+                                          storm::storage::BitVector const& initialStates) {
+    if (order == OrderKind::Random) {
+        return createRandomPermutation(transitionMatrix.getRowGroupCount());
+    }
+    STORM_LOG_ASSERT((order == OrderKind::Bfs || order == OrderKind::Dfs || order == OrderKind::ReverseBfs || order == OrderKind::ReverseDfs),
+                     "Unknown order kind");
+    STORM_LOG_ASSERT(initialStates.size() == transitionMatrix.getRowGroupCount(), "Unexpected dimensions of initial states and transition matrix.");
+    STORM_LOG_ASSERT(initialStates.size() == transitionMatrix.getColumnCount(), "Unexpected dimensions of initial states and transition matrix.");
+    std::vector<index_type> permutation;
+    permutation.reserve(transitionMatrix.getRowGroupCount());
+
+    std::deque<index_type> stack(initialStates.begin(), initialStates.end());
+    storm::storage::BitVector discoveredStates = initialStates;
+    bool const useFifoStack = order == OrderKind::Bfs || order == OrderKind::ReverseBfs;
+
+    while (!stack.empty()) {
+        auto current = stack.front();
+        stack.pop_front();
+        permutation.push_back(current);
+        for (auto const& entry : transitionMatrix.getRowGroup(current)) {
+            if (auto const successor = entry.getColumn(); !discoveredStates.get(successor)) {
+                discoveredStates.set(successor, true);
+                if (useFifoStack) {
+                    stack.push_back(successor);
+                } else {
+                    stack.push_front(successor);
+                }
+            }
+        }
+    }
+    if (order == OrderKind::ReverseDfs || order == OrderKind::ReverseBfs) {
+        reversePermutationInPlace(permutation);
+    }
+    return permutation;
+}
+
+std::vector<index_type> invertPermutation(std::vector<index_type> const& permutation) {
+    std::vector<index_type> inverted(permutation.size());
+    for (index_type i = 0; i < permutation.size(); ++i) {
+        inverted[permutation[i]] = i;
+    }
+    return inverted;
+}
+
+void reversePermutationInPlace(std::vector<index_type>& permutation) {
+    auto const max = permutation.size() - 1;
+    for (auto& i : permutation) {
+        i = max - i;
+    }
+}
+
+bool isValidPermutation(std::vector<index_type> const& permutation) {
+    storage::BitVector occurring(permutation.size(), false);
+    for (auto i : permutation) {
+        if (occurring.get(i)) {
+            return false;
+        }
+        occurring.set(i, true);
+    }
+    return occurring.full();
+}
+
+template std::vector<index_type> createPermutation(OrderKind order, storm::storage::SparseMatrix<double> const& transitionMatrix,
+                                                   storm::storage::BitVector const& initialStates);
+template std::vector<index_type> createPermutation(OrderKind order, storm::storage::SparseMatrix<storm::RationalNumber> const& transitionMatrix,
+                                                   storm::storage::BitVector const& initialStates);
+template std::vector<index_type> createPermutation(OrderKind order, storm::storage::SparseMatrix<storm::RationalFunction> const& transitionMatrix,
+                                                   storm::storage::BitVector const& initialStates);
+
+}  // namespace storm::utility::permutation

--- a/src/storm/utility/permutation.h
+++ b/src/storm/utility/permutation.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace storm {
+
+namespace storage {
+class BitVector;
+template<typename ValueType>
+class SparseMatrix;
+}  // namespace storage
+
+namespace utility::permutation {
+using index_type = uint64_t;
+
+/*!
+ * The order in which the states of a matrix are visited in a depth-first search or breadth-first search traversal.
+ */
+enum class OrderKind { Bfs, Dfs, ReverseBfs, ReverseDfs, Random };
+
+/*!
+ * Converts the given order to a string.
+ */
+std::string orderKindtoString(OrderKind order);
+
+/*!
+ * Returns a list of possible order kinds
+ */
+std::vector<std::string> orderKinds();
+
+/*!
+ * Gets the order from the given string.
+ */
+OrderKind orderKindFromString(std::string const& order);
+
+/*!
+ * Creates a random (uniformly distributed) permutation of the given size.
+ */
+std::vector<index_type> createRandomPermutation(index_type size);
+
+/*!
+ * Creates a random (uniformly distributed) permutation of the given size.
+ * It is guaranteed that the same seed will always produce the same permutation.
+ */
+std::vector<index_type> createRandomPermutation(index_type size, index_type seed);
+
+/*!
+ * Creates a permutation that orders the states of the given matrix in the given exploration order.
+ *
+ * @note the resulting permutation will only contain those states that are reachable from the initial states.
+ *
+ * Example:
+ * Let permutation[i_0] = 0, permutation[i_1] = 1, ..., permutation[i_n-1] = n-1.
+ * i_0 is the firs initial state.
+ * If the order is Dfs, i_1 is a successor of i_0, i_2 is a successor of i_1, etc. (assuming those successors exist).
+ * If the order is Bfs, i_1 is the second initial state, ...
+ *
+ * @pre initialStates.size() == transitionMatrix.getRowGroupCount() == transitionMatrix.getColumnCount()
+ */
+template<typename ValueType>
+std::vector<index_type> createPermutation(OrderKind order, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+                                          storm::storage::BitVector const& initialStates);
+
+/*!
+ * Inverts the given permutation.
+ * @return a vector v such that v[permutation[i]] == permutation[v[i]] == i for all i.
+ */
+std::vector<index_type> invertPermutation(std::vector<index_type> const& permutation);
+
+/*!
+ * Reverses the given permutation.
+ * @note this does not reverse the given vector, but the permutation itself.
+ * @return a vector v such that v[i] == permutation.size() - 1 - permutation[i] for all i.
+ */
+void reversePermutationInPlace(std::vector<index_type>& permutation);
+
+/*!
+ * Returns true if the given vector is a permutation of the numbers 0, 1, ..., n-1 for n = permutation.size().
+ * In other words, every integer from 0 to n-1 occurs exactly once in the vector.
+ */
+bool isValidPermutation(std::vector<index_type> const& permutation);
+
+}  // namespace utility::permutation
+}  // namespace storm

--- a/src/storm/utility/vector.h
+++ b/src/storm/utility/vector.h
@@ -1276,13 +1276,15 @@ std::vector<T> applyInversePermutation(std::vector<uint64_t> const& inversePermu
 template<typename T>
 std::vector<T> applyInversePermutationToGroupedVector(std::vector<uint64_t> const& inversePermutation, std::vector<T> const& source,
                                                       std::vector<uint64_t> const& rowGroupIndices) {
+    STORM_LOG_ASSERT(inversePermutation.size() == rowGroupIndices.size() - 1, "Inverse permutation and row group indices do not match.");
     std::vector<T> result;
     result.reserve(source.size());
-    for (auto sourceIndex : inversePermutation) {
-        for (uint64_t i = rowGroupIndices[sourceIndex]; i < rowGroupIndices[sourceIndex + 1]; ++i) {
-            result.push_back(source[i]);
+    for (auto sourceGroupIndex : inversePermutation) {
+        for (uint64_t sourceIndex = rowGroupIndices[sourceGroupIndex]; sourceIndex < rowGroupIndices[sourceGroupIndex + 1]; ++sourceIndex) {
+            result.push_back(source[sourceIndex]);
         }
     }
+    STORM_LOG_ASSERT(result.size() == source.size(), "result has unexpected length.");
     return result;
 }
 

--- a/src/storm/utility/vector.h
+++ b/src/storm/utility/vector.h
@@ -1273,6 +1273,19 @@ std::vector<T> applyInversePermutation(std::vector<uint64_t> const& inversePermu
     return result;
 }
 
+template<typename T>
+std::vector<T> applyInversePermutationToGroupedVector(std::vector<uint64_t> const& inversePermutation, std::vector<T> const& source,
+                                                      std::vector<uint64_t> const& rowGroupIndices) {
+    std::vector<T> result;
+    result.reserve(source.size());
+    for (auto sourceIndex : inversePermutation) {
+        for (uint64_t i = rowGroupIndices[sourceIndex]; i < rowGroupIndices[sourceIndex + 1]; ++i) {
+            result.push_back(source[i]);
+        }
+    }
+    return result;
+}
+
 /*!
  * Output vector as string.
  *

--- a/src/test/storm/storage/BitVectorTest.cpp
+++ b/src/test/storm/storage/BitVectorTest.cpp
@@ -405,11 +405,11 @@ TEST(BitVectorTest, permute) {
 }
 
 TEST(BitVectorTest, permuteGrouped) {
-    storm::storage::BitVector vector1(6, {0, 1, 2});
+    storm::storage::BitVector vector1(6, {0, 2, 5});
     std::vector<uint64_t> inversePermutation = {1, 0, 2};
     std::vector<uint64_t> groupIndices = {0, 3, 5, 6};
     storm::storage::BitVector permuted = vector1.permuteGroupedVector(inversePermutation, groupIndices);
-    storm::storage::BitVector expected(6, {2, 3, 4});
+    storm::storage::BitVector expected(6, {2, 4, 5});
     EXPECT_EQ(expected, permuted);
 }
 

--- a/src/test/storm/storage/BitVectorTest.cpp
+++ b/src/test/storm/storage/BitVectorTest.cpp
@@ -404,6 +404,15 @@ TEST(BitVectorTest, permute) {
     EXPECT_TRUE(vector2.get(6));
 }
 
+TEST(BitVectorTest, permuteGrouped) {
+    storm::storage::BitVector vector1(6, {0, 1, 2});
+    std::vector<uint64_t> inversePermutation = {1, 0, 2};
+    std::vector<uint64_t> groupIndices = {0, 3, 5, 6};
+    storm::storage::BitVector permuted = vector1.permuteGroupedVector(inversePermutation, groupIndices);
+    storm::storage::BitVector expected(6, {2, 3, 4});
+    EXPECT_EQ(expected, permuted);
+}
+
 TEST(BitVectorTest, Implies) {
     storm::storage::BitVector vector1(32);
     storm::storage::BitVector vector2(32, true);

--- a/src/test/storm/transformer/StatePermuterTest.cpp
+++ b/src/test/storm/transformer/StatePermuterTest.cpp
@@ -1,0 +1,63 @@
+#include "storm-config.h"
+#include "storm-parsers/api/storm-parsers.h"
+#include "storm-parsers/parser/PrismParser.h"
+#include "storm/api/storm.h"
+#include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
+#include "storm/transformer/StatePermuter.h"
+#include "storm/utility/permutation.h"
+#include "test/storm_gtest.h"
+
+namespace {
+void testStatePermuter(std::string const& prismModelFile, std::string const& formulaString) {
+    storm::prism::Program program = storm::parser::PrismParser::parse(prismModelFile, true);
+    auto formulas = storm::api::extractFormulasFromProperties(storm::api::parsePropertiesForPrismProgram(formulaString, program));
+    auto model = storm::api::buildSparseModel<double>(program, formulas);
+    auto task = storm::api::createTask<double>(formulas.front(), false);
+    ASSERT_EQ(1ull, model->getInitialStates().getNumberOfSetBits()) << "For model " << prismModelFile << ".";
+
+    auto computeValue = [&task](auto m) {
+        auto result = storm::api::verifyWithSparseEngine(m, task);
+        return result->template asExplicitQuantitativeCheckResult<double>()[*m->getInitialStates().begin()];
+    };
+    auto const modelVal = computeValue(model);
+
+    auto checkOrder = [&model, &computeValue, &modelVal, &prismModelFile](storm::utility::permutation::OrderKind order) {
+        auto permutation = storm::utility::permutation::createPermutation(order, model->getTransitionMatrix(), model->getInitialStates());
+        auto permutedModel = storm::transformer::permuteStates(*model, permutation);
+        EXPECT_EQ(permutedModel->getNumberOfStates(), model->getNumberOfStates())
+            << "Failed for order " << storm::utility::permutation::orderKindtoString(order) << " and model " << prismModelFile << ".";
+        EXPECT_EQ(permutedModel->getNumberOfTransitions(), model->getNumberOfTransitions())
+            << "Failed for order " << storm::utility::permutation::orderKindtoString(order) << " and model " << prismModelFile << ".";
+        auto permVal = computeValue(permutedModel);
+        EXPECT_LE(std::abs(permVal - modelVal) / modelVal, 1e-4)
+            << "Relative difference between original model result (" << modelVal << ") and permuted model result (" << permVal
+            << ") is too high.\nFailed for order " << storm::utility::permutation::orderKindtoString(order) << " and model " << prismModelFile << ".";
+        return permutedModel;
+    };
+
+    auto permutedModel = checkOrder(storm::utility::permutation::OrderKind::Random);
+    permutedModel = checkOrder(storm::utility::permutation::OrderKind::Dfs);
+    EXPECT_EQ(0ull, *permutedModel->getInitialStates().begin()) << "Failed for model " << prismModelFile;
+    permutedModel = checkOrder(storm::utility::permutation::OrderKind::Bfs);
+    EXPECT_EQ(0ull, *permutedModel->getInitialStates().begin()) << "Failed for model " << prismModelFile;
+    permutedModel = checkOrder(storm::utility::permutation::OrderKind::ReverseDfs);
+    EXPECT_EQ(permutedModel->getNumberOfStates() - 1, *permutedModel->getInitialStates().begin()) << "Failed for model " << prismModelFile;
+    permutedModel = checkOrder(storm::utility::permutation::OrderKind::ReverseBfs);
+    EXPECT_EQ(permutedModel->getNumberOfStates() - 1, *permutedModel->getInitialStates().begin()) << "Failed for model " << prismModelFile;
+}
+TEST(StatePermuterTest, BrpTest) {
+    testStatePermuter(STORM_TEST_RESOURCES_DIR "/dtmc/brp-16-2.pm", "P=? [ F \"target\"]");
+}
+
+TEST(StatePermuterTest, ClusterTest) {
+    testStatePermuter(STORM_TEST_RESOURCES_DIR "/ctmc/cluster2.sm", " R{\"num_repairs\"}=? [C<=200]");
+}
+
+TEST(StatePermuterTest, Coin22Test) {
+    testStatePermuter(STORM_TEST_RESOURCES_DIR "/mdp/coin2-2.nm", "Rmax=? [ F \"finished\"]");
+}
+
+TEST(StatePermuterTest, StreamTest) {
+    testStatePermuter(STORM_TEST_RESOURCES_DIR "/ma/stream2.ma", "R{\"buffering\"}max=? [ F \"done\"]");
+}
+}  // namespace

--- a/src/test/storm/utility/VectorTest.cpp
+++ b/src/test/storm/utility/VectorTest.cpp
@@ -1,5 +1,6 @@
 #include "storm-config.h"
 #include "storm/storage/BitVector.h"
+#include "storm/utility/permutation.h"
 #include "storm/utility/vector.h"
 #include "test/storm_gtest.h"
 
@@ -30,7 +31,7 @@ TEST(VectorTest, min_if) {
     ASSERT_EQ(8.0, storm::utility::vector::min_if(a, f2));
 }
 
-TEST(VectorTest, permute) {
+TEST(VectorTest, inverse_permute) {
     std::vector<double> a = {1.0, 2.0, 3.0, 4.0};
     std::vector<uint64_t> inversePermutation = {0, 3, 1, 2};
     std::vector<double> aperm = storm::utility::vector::applyInversePermutation(inversePermutation, a);
@@ -38,4 +39,13 @@ TEST(VectorTest, permute) {
     EXPECT_EQ(aperm[1], a[3]);
     EXPECT_EQ(aperm[2], a[1]);
     EXPECT_EQ(aperm[3], a[2]);
+}
+
+TEST(VectorTest, grouped_inverse_permute) {
+    std::vector<double> a = {1.0, 2.0, 3.0, 4.0, 5.0};
+    std::vector<uint64_t> groupIndices = {0, 3, 5, 5};  // last group empty
+    std::vector<uint64_t> inversePermutation = {1, 2, 0};
+    std::vector<double> aperm = storm::utility::vector::applyInversePermutationToGroupedVector(inversePermutation, a, groupIndices);
+    std::vector<double> expected = {4.0, 5.0, 1.0, 2.0, 3.0};
+    EXPECT_EQ(aperm, expected);
 }


### PR DESCRIPTION
This is useful to, e.g., investigate how much algorithm performance is affected by the order of the states.

Example:
```console

$ ./storm --qvbsroot ~/git/qcomp/benchmarks --qvbs consensus 5 steps_min  --permute bfs   | grep "Time for model checking" -B1
Result (for initial states): 768.0679927
Time for model checking: 0.201s.

$ ./storm --qvbsroot ~/git/qcomp/benchmarks --qvbs consensus 5 steps_min  --permute reverse-bfs   | grep "Time for model checking" -B1
Result (for initial states): 768.0918665
Time for model checking: 0.861s.

$  ./storm --qvbsroot ~/git/qcomp/benchmarks --qvbs consensus 5 steps_min  --permute random 1234   | grep "Time for model checking" -B1
Result (for initial states): 768.0830197
Time for model checking: 0.394s.
