### PR TITLE
Remove more warnings

### DIFF
--- a/src/storm-pomdp/analysis/FormulaInformation.cpp
+++ b/src/storm-pomdp/analysis/FormulaInformation.cpp
@@ -76,7 +76,7 @@ template<typename PomdpType>
 FormulaInformation::StateSet getStateSet(PomdpType const& pomdp, storm::storage::BitVector&& inputStates) {
     FormulaInformation::StateSet result;
     result.states = std::move(inputStates);
-    for (auto const& state : result.states) {
+    for (auto const state : result.states) {
         result.observations.insert(pomdp.getObservation(state));
     }
     // check if this set is observation-closed, i.e., whether there is a state outside of this set with one of the observations collected above

--- a/src/storm-pomdp/analysis/IterativePolicySearch.cpp
+++ b/src/storm-pomdp/analysis/IterativePolicySearch.cpp
@@ -765,7 +765,7 @@ bool IterativePolicySearch<ValueType>::analyze(uint64_t k, storm::storage::BitVe
         }
         if (options.validateEveryStep) {
             STORM_LOG_WARN("Validating every step, for debug purposes only!");
-            validator->validate(surelyReachSinkStates);
+            validator->validate();
         }
         if (stats.getIterations() % options.restartAfterNIterations == options.restartAfterNIterations - 1) {
             reset();
@@ -824,7 +824,7 @@ bool IterativePolicySearch<ValueType>::analyze(uint64_t k, storm::storage::BitVe
     }
     if (options.validateResult) {
         STORM_LOG_WARN("Validating result is a winning region, only for debugging purposes.");
-        validator->validate(surelyReachSinkStates);
+        validator->validate();
         STORM_LOG_WARN("Validating result is a fixed point, only for debugging purposes.");
         validator->validateIsMaximal(surelyReachSinkStates);
     }

--- a/src/storm-pomdp/analysis/IterativePolicySearch.cpp
+++ b/src/storm-pomdp/analysis/IterativePolicySearch.cpp
@@ -401,7 +401,7 @@ bool IterativePolicySearch<ValueType>::analyze(uint64_t k, storm::storage::BitVe
     }
     STORM_LOG_DEBUG("Graph based winning obs: " << stats.getGraphBasedwinningObservations());
     observationsWithPartialWinners &= potentialWinner;
-    for (auto const& observation : observationsWithPartialWinners) {
+    for (auto const observation : observationsWithPartialWinners) {
         uint64_t nrStatesForObs = statesPerObservation[observation].size();
         storm::storage::BitVector update(nrStatesForObs);
         for (uint64_t i = 0; i < nrStatesForObs; ++i) {
@@ -736,7 +736,7 @@ bool IterativePolicySearch<ValueType>::analyze(uint64_t k, storm::storage::BitVe
                 }
                 STORM_LOG_DEBUG("Graph-based winning obs: " << stats.getGraphBasedwinningObservations());
                 observationsWithPartialWinners &= potentialWinner;
-                for (auto const& observation : observationsWithPartialWinners) {
+                for (auto const observation : observationsWithPartialWinners) {
                     uint64_t nrStatesForObs = statesPerObservation[observation].size();
                     storm::storage::BitVector update(nrStatesForObs);
                     for (uint64_t i = 0; i < nrStatesForObs; ++i) {

--- a/src/storm-pomdp/analysis/JaniBeliefSupportMdpGenerator.cpp
+++ b/src/storm-pomdp/analysis/JaniBeliefSupportMdpGenerator.cpp
@@ -128,13 +128,13 @@ void JaniBeliefSupportMdpGenerator<ValueType>::generate(storm::storage::BitVecto
     auto const& targetVar = model.addVariable(
         *storm::jani::Variable::makeBooleanVariable("target", exprManager.declareBooleanVariable("target"), exprManager.boolean(false), true));
     std::vector<storm::expressions::Expression> notTargetExpression;
-    for (auto const& state : ~targetStates) {
+    for (auto const state : ~targetStates) {
         notTargetExpression.push_back(!stateVariables.at(state)->getExpressionVariable().getExpression());
     }
     auto const& badVar =
         model.addVariable(*storm::jani::Variable::makeBooleanVariable("bad", exprManager.declareBooleanVariable("bad"), exprManager.boolean(false), true));
     std::vector<storm::expressions::Expression> badExpression;
-    for (auto const& state : badStates) {
+    for (auto const state : badStates) {
         badExpression.push_back(stateVariables.at(state)->getExpressionVariable().getExpression());
     }
 

--- a/src/storm-pomdp/analysis/QualitativeAnalysisOnGraphs.cpp
+++ b/src/storm-pomdp/analysis/QualitativeAnalysisOnGraphs.cpp
@@ -87,7 +87,7 @@ storm::storage::BitVector QualitativeAnalysisOnGraphs<ValueType>::analyseProb0Ma
 }
 
 template<typename ValueType>
-storm::storage::BitVector QualitativeAnalysisOnGraphs<ValueType>::analyseProb0Min(storm::logic::UntilFormula const& formula) const {
+[[maybe_unused]] storm::storage::BitVector QualitativeAnalysisOnGraphs<ValueType>::analyseProb0Min(storm::logic::UntilFormula const& formula) const {
     STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "Prob0 analysis is currently not implemented for minimizing properties.");
 }
 

--- a/src/storm-pomdp/analysis/QualitativeAnalysisOnGraphs.h
+++ b/src/storm-pomdp/analysis/QualitativeAnalysisOnGraphs.h
@@ -15,7 +15,7 @@ class QualitativeAnalysisOnGraphs {
    private:
     storm::storage::BitVector analyseProb0or1(storm::logic::ProbabilityOperatorFormula const& formula, bool prob0) const;
     storm::storage::BitVector analyseProb0Max(storm::logic::UntilFormula const& formula) const;
-    storm::storage::BitVector analyseProb0Min(storm::logic::UntilFormula const& formula) const;
+    [[maybe_unused]] storm::storage::BitVector analyseProb0Min(storm::logic::UntilFormula const& formula) const;
     storm::storage::BitVector analyseProb1Max(storm::logic::UntilFormula const& formula) const;
     storm::storage::BitVector analyseProb1Min(storm::logic::UntilFormula const& formula) const;
 

--- a/src/storm-pomdp/analysis/WinningRegion.cpp
+++ b/src/storm-pomdp/analysis/WinningRegion.cpp
@@ -211,11 +211,11 @@ std::pair<storm::RationalNumber, storm::RationalNumber> count(std::vector<storm:
         }
         STORM_LOG_DEBUG("Order of magnitude = " << oom);
 
-        critoom = oom - floor(log2(upperBoundElements));
+        critoom = oom - static_cast<uint64_t>(floor(log2(upperBoundElements)));
 
         STORM_LOG_DEBUG("Crit Order of magnitude = " << critoom);
 
-        uint64_t intersectSetSkip = critoom - floor(log2(origSets.size()));
+        uint64_t intersectSetSkip = critoom - static_cast<uint64_t>(floor(log2(origSets.size())));
 
         std::vector<storm::storage::BitVector> useIntersects;
         std::vector<storm::storage::BitVector> useInfo;
@@ -229,7 +229,7 @@ std::pair<storm::RationalNumber, storm::RationalNumber> count(std::vector<storm:
             }
         }
 
-        uint64_t origSetSkip = critoom - floor(log2(useIntersects.size()));
+        uint64_t origSetSkip = critoom - static_cast<uint64_t>(floor(log2(useIntersects.size())));
         STORM_LOG_DEBUG("OrigSkip= " << origSetSkip);
 
         std::vector<storm::storage::BitVector> newIntersects;

--- a/src/storm-pomdp/analysis/WinningRegionQueryInterface.cpp
+++ b/src/storm-pomdp/analysis/WinningRegionQueryInterface.cpp
@@ -91,7 +91,7 @@ void WinningRegionQueryInterface<ValueType>::validateIsMaximal(storm::storage::B
         STORM_LOG_DEBUG("Check listed belief supports for observation " << obs << " are maximal");
         for (auto const& winningBelief : winningRegion.getWinningSetsPerObservation(obs)) {
             storm::storage::BitVector remainders = ~winningBelief;
-            for (auto const& additional : remainders) {
+            for (auto const additional : remainders) {
                 uint64_t addState = statesPerObservation[obs][additional];
                 if (badStates.get(addState)) {
                     continue;

--- a/src/storm-pomdp/analysis/WinningRegionQueryInterface.cpp
+++ b/src/storm-pomdp/analysis/WinningRegionQueryInterface.cpp
@@ -66,7 +66,7 @@ bool WinningRegionQueryInterface<ValueType>::staysInWinningRegion(storm::storage
 }
 
 template<typename ValueType>
-void WinningRegionQueryInterface<ValueType>::validate(storm::storage::BitVector const& badStates) const {
+void WinningRegionQueryInterface<ValueType>::validate() const {
     for (uint64_t obs = 0; obs < pomdp.getNrObservations(); ++obs) {
         for (auto const& winningBelief : winningRegion.getWinningSetsPerObservation(obs)) {
             storm::storage::BitVector states(pomdp.getNumberOfStates());

--- a/src/storm-pomdp/analysis/WinningRegionQueryInterface.h
+++ b/src/storm-pomdp/analysis/WinningRegionQueryInterface.h
@@ -13,7 +13,7 @@ class WinningRegionQueryInterface {
 
     bool staysInWinningRegion(storm::storage::BitVector const& beliefSupport, uint64_t actionIndex) const;
 
-    void validate(storm::storage::BitVector const& badStates) const;
+    void validate() const;
 
     void validateIsMaximal(storm::storage::BitVector const& badStates) const;
 

--- a/src/storm-pomdp/builder/BeliefMdpExplorer.cpp
+++ b/src/storm-pomdp/builder/BeliefMdpExplorer.cpp
@@ -754,7 +754,7 @@ void BeliefMdpExplorer<PomdpType, BeliefValueType>::dropUnexploredStates() {
         MdpStateType newState = 0;
         assert(exploredChoiceIndices[0] == 0u);
         // Loop invariant: all indices up to exploredChoiceIndices[newState] consider the new row indices and all other entries are not touched.
-        for (auto const &oldState : relevantMdpStates) {
+        for (auto const oldState : relevantMdpStates) {
             if (oldState != newState) {
                 assert(oldState > newState);
                 uint64_t groupSize = getRowGroupSizeOfState(oldState);
@@ -785,7 +785,7 @@ void BeliefMdpExplorer<PomdpType, BeliefValueType>::dropUnexploredStates() {
     {  // mdpStateToChoiceLabelsMap
         if (!mdpStateToChoiceLabelsMap.empty()) {
             auto temp = std::map<BeliefId, std::map<uint64_t, std::string>>();
-            for (auto const &relevantState : relevantMdpStates) {
+            for (auto const relevantState : relevantMdpStates) {
                 temp[toRelevantStateIndexMap[relevantState]] = mdpStateToChoiceLabelsMap[relevantState];
             }
             mdpStateToChoiceLabelsMap = temp;

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -17,7 +17,6 @@
 
 #include "storm/environment/Environment.h"
 #include "storm/exceptions/NotSupportedException.h"
-#include "storm/storage/Scheduler.h"
 #include "storm/utility/SignalHandler.h"
 #include "storm/utility/graph.h"
 #include "storm/utility/macros.h"

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -1337,7 +1337,7 @@ void BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
                     }
                 } else if (clipping.onGrid) {
                     // If the belief is not clippable, but on the grid, it may need to be explored, too
-                    bool inserted = beliefExplorer->addTransitionToBelief(action, successor.first, successor.second, false);
+                    beliefExplorer->addTransitionToBelief(action, successor.first, successor.second, false);
                 } else {
                     // Otherwise, the reward for all candidates is infinite, clipping does not make sense. Cut it off instead
                     absDelta += utility::convertNumber<BeliefValueType>(successor.second);
@@ -1382,8 +1382,7 @@ bool BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
         statistics.nrClippedStates = statistics.nrClippedStates.value() + 1;
         // Transition probability to candidate is clipping value
         BeliefValueType transitionProb = (utility::one<BeliefValueType>() - clipping.delta);
-        bool addedCandidate =
-            beliefExplorer->addTransitionToBelief(localActionIndex, clipping.targetBelief, utility::convertNumber<BeliefMDPType>(transitionProb), false);
+        beliefExplorer->addTransitionToBelief(localActionIndex, clipping.targetBelief, utility::convertNumber<BeliefMDPType>(transitionProb), false);
         beliefExplorer->markAsGridBelief(clipping.targetBelief);
         if (computeRewards) {
             // collect cumulative reward bounds

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -1094,7 +1094,7 @@ bool BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
                                        << " ##### " << underApproximation->getUnexploredStates().size() << " beliefs queued\n")
             if (underApproximation->getCurrentNumberOfMdpStates() > heuristicParameters.sizeThreshold && options.useClipping) {
                 STORM_PRINT_AND_LOG("##### Clipping Attempts: " << statistics.nrClippingAttempts.value() << " ##### "
-                                                                << "Clipped States: " << statistics.nrClippedStates.value() << "\n");
+                                                                << "Clipped States: " << statistics.nrClippedStates.value() << "\n")
             }
         }
         if (unfoldingControl == UnfoldingControl::Pause && !stateStored) {
@@ -1278,7 +1278,7 @@ bool BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
     underApproximation->finishExploration();
     statistics.underApproximationBuildTime.stop();
     printUpdateStopwatch.stop();
-    STORM_PRINT_AND_LOG("Finished exploring under-approximation MDP.\nStart analysis...\n");
+    STORM_PRINT_AND_LOG("Finished exploring under-approximation MDP.\nStart analysis...\n")
     unfoldingStatus = Status::ModelExplorationFinished;
     statistics.underApproximationCheckTime.start();
     underApproximation->computeValuesOfExploredMdp(env, min ? storm::solver::OptimizationDirection::Minimize : storm::solver::OptimizationDirection::Maximize);

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -1134,7 +1134,7 @@ bool BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
             if (clipBelief && !underApproximation->isMarkedAsGridBelief(currId)) {
                 // Use a belief grid as clipping candidates
                 if (!options.useStateEliminationCutoff) {
-                    bool successfulClip = clipToGridExplicitly(currId, computeRewards, min, beliefManager, underApproximation, 0);
+                    bool successfulClip = clipToGridExplicitly(currId, computeRewards, beliefManager, underApproximation, 0);
                     // Set again as the current belief might have been detected to be a grid belief
                     stopExploration = !underApproximation->isMarkedAsGridBelief(currId);
                     if (successfulClip) {
@@ -1370,7 +1370,6 @@ void BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
 
 template<typename PomdpModelType, typename BeliefValueType, typename BeliefMDPType>
 bool BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefMDPType>::clipToGridExplicitly(uint64_t clippingStateId, bool computeRewards,
-                                                                                                              bool min,
                                                                                                               std::shared_ptr<BeliefManagerType>& beliefManager,
                                                                                                               std::shared_ptr<ExplorerType>& beliefExplorer,
                                                                                                               uint64_t localActionIndex) {

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -811,7 +811,7 @@ bool BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
             return r <= storm::utility::convertNumber<BeliefValueType>(heuristicParameters.observationThreshold);
         });
         STORM_LOG_DEBUG("Refining the resolution of " << refinedObservations.getNumberOfSetBits() << "/" << refinedObservations.size() << " observations.");
-        for (auto const& obs : refinedObservations) {
+        for (auto const obs : refinedObservations) {
             // Increment the resolution at the refined observations.
             // Use storm's rational number to detect overflows properly.
             storm::RationalNumber newObsResolutionAsRational = storm::utility::convertNumber<storm::RationalNumber>(observationResolutionVector[obs]) *

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.h
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.h
@@ -310,11 +310,10 @@ class BeliefExplorationPomdpModelChecker {
      * handled by the main exploration routine.
      * @param clippingStateId the state ID of the clipping belief
      * @param computeRewards true, if rewards are computed
-     * @param min true, if objective is to minimise
      * @param beliefManager the belief manager used
      * @param beliefExplorer the belief MDP explorer used
      */
-    bool clipToGridExplicitly(uint64_t clippingStateId, bool computeRewards, bool min, std::shared_ptr<BeliefManagerType>& beliefManager,
+    bool clipToGridExplicitly(uint64_t clippingStateId, bool computeRewards, std::shared_ptr<BeliefManagerType>& beliefManager,
                               std::shared_ptr<ExplorerType>& beliefExplorer, uint64_t localActionIndex);
 
     /**

--- a/src/storm-pomdp/modelchecker/PreprocessingPomdpValueBoundsModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/PreprocessingPomdpValueBoundsModelChecker.cpp
@@ -153,7 +153,7 @@ std::pair<std::vector<ValueType>, storm::storage::Scheduler<ValueType>> Preproce
 }
 
 template<typename ValueType>
-std::pair<std::vector<ValueType>, storm::storage::Scheduler<ValueType>>
+[[maybe_unused]] std::pair<std::vector<ValueType>, storm::storage::Scheduler<ValueType>>
 PreprocessingPomdpValueBoundsModelChecker<ValueType>::computeValuesForRandomMemorylessPolicy(
     storm::Environment const& env, storm::logic::Formula const& formula, storm::pomdp::analysis::FormulaInformation const& info,
     std::shared_ptr<storm::models::sparse::Mdp<ValueType>> underlyingMdp) {

--- a/src/storm-pomdp/modelchecker/PreprocessingPomdpValueBoundsModelChecker.h
+++ b/src/storm-pomdp/modelchecker/PreprocessingPomdpValueBoundsModelChecker.h
@@ -52,7 +52,7 @@ class PreprocessingPomdpValueBoundsModelChecker {
     std::pair<std::vector<ValueType>, storm::storage::Scheduler<ValueType>> computeValuesForRandomFMPolicy(
         storm::Environment const& env, storm::logic::Formula const& formula, storm::pomdp::analysis::FormulaInformation const& info, uint64_t memoryBound);
 
-    std::pair<std::vector<ValueType>, storm::storage::Scheduler<ValueType>> computeValuesForRandomMemorylessPolicy(
+    [[maybe_unused]] std::pair<std::vector<ValueType>, storm::storage::Scheduler<ValueType>> computeValuesForRandomMemorylessPolicy(
         storm::Environment const& env, storm::logic::Formula const& formula, storm::pomdp::analysis::FormulaInformation const& info,
         std::shared_ptr<storm::models::sparse::Mdp<ValueType>> underlyingMdp);
 };

--- a/src/storm-pomdp/transformer/ApplyFiniteSchedulerToPomdp.cpp
+++ b/src/storm-pomdp/transformer/ApplyFiniteSchedulerToPomdp.cpp
@@ -31,7 +31,7 @@ struct RationalFunctionConstructor {
 };
 
 template<typename ValueType>
-std::shared_ptr<RawPolynomialCache> getCache(storm::models::sparse::Pomdp<ValueType> const& model) {
+std::shared_ptr<RawPolynomialCache> getCache([[maybe_unused]] storm::models::sparse::Pomdp<ValueType> const& model) {
     return std::make_shared<RawPolynomialCache>();
 }
 

--- a/src/storm-pomdp/transformer/GlobalPOMDPSelfLoopEliminator.cpp
+++ b/src/storm-pomdp/transformer/GlobalPOMDPSelfLoopEliminator.cpp
@@ -78,7 +78,7 @@ std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> GlobalPOMDPSelfLoopElim
     for (uint64_t state = 0; state < nrStates; ++state) {
         storm::storage::BitVector& observationSelfLoopMask = observationSelfLoopMasks[pomdp.getObservation(state)];
         assert(!observationSelfLoopMask.full());
-        for (auto const& localChoiceIndex : observationSelfLoopMask) {
+        for (auto const localChoiceIndex : observationSelfLoopMask) {
             filter.set(offset + localChoiceIndex, false);
         }
         offset += pomdp.getNumberOfChoices(state);

--- a/src/storm-pomdp/transformer/GlobalPomdpMecChoiceEliminator.cpp
+++ b/src/storm-pomdp/transformer/GlobalPomdpMecChoiceEliminator.cpp
@@ -67,7 +67,7 @@ std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> GlobalPomdpMecChoiceEli
 
     // Filter the observations that have a state that is not an out state
     storm::storage::BitVector stateFilter = ~uniqueOutStates;
-    for (auto const& state : stateFilter) {
+    for (auto const state : stateFilter) {
         mecChoicesPerObservation[pomdp.getObservation(state)].clear();
     }
 
@@ -79,7 +79,7 @@ std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> GlobalPomdpMecChoiceEli
     // transform the set of selected choices to global choice indices
     storm::storage::BitVector choiceFilter(pomdp.getNumberOfChoices(), true);
     stateFilter.complement();
-    for (auto const& state : stateFilter) {
+    for (auto const state : stateFilter) {
         uint64_t offset = pomdp.getTransitionMatrix().getRowGroupIndices()[state];
         for (auto const& choice : mecChoicesPerObservation[pomdp.getObservation(state)]) {
             choiceFilter.set(offset + choice, false);
@@ -109,7 +109,7 @@ std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> GlobalPomdpMecChoiceEli
 
     // Filter the observations that have a state that is neither an out state, nor a prob0A state
     storm::storage::BitVector stateFilter = ~(uniqueOutStates | prob01States.first);
-    for (auto const& state : stateFilter) {
+    for (auto const state : stateFilter) {
         mecChoicesPerObservation[pomdp.getObservation(state)].clear();
     }
 
@@ -121,7 +121,7 @@ std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> GlobalPomdpMecChoiceEli
     // transform the set of selected choices to global choice indices
     storm::storage::BitVector choiceFilter(pomdp.getNumberOfChoices(), true);
     stateFilter.complement();
-    for (auto const& state : stateFilter) {
+    for (auto const state : stateFilter) {
         uint64_t offset = pomdp.getTransitionMatrix().getRowGroupIndices()[state];
         for (auto const& choice : mecChoicesPerObservation[pomdp.getObservation(state)]) {
             choiceFilter.set(offset + choice, false);

--- a/src/storm-pomdp/transformer/KnownProbabilityTransformer.cpp
+++ b/src/storm-pomdp/transformer/KnownProbabilityTransformer.cpp
@@ -24,7 +24,7 @@ std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> KnownProbabilityTransfo
     std::vector<uint32_t> newObservations;
 
     // New state 0 represents all states with probability 1
-    for (auto const &iter : prob1States) {
+    for (auto const iter : prob1States) {
         stateMap[iter] = 0;
 
         std::set<std::string> labelSet = pomdp.getStateLabeling().getLabelsOfState(iter);
@@ -36,7 +36,7 @@ std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> KnownProbabilityTransfo
         }
     }
     // New state 1 represents all states with probability 0
-    for (auto const &iter : prob0States) {
+    for (auto const iter : prob0States) {
         stateMap[iter] = 1;
         for (auto const &label : pomdp.getStateLabeling().getLabelsOfState(iter)) {
             if (!newLabeling.containsLabel(label)) {
@@ -50,7 +50,7 @@ std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> KnownProbabilityTransfo
     // If there are no states with probability 0 we set the next new state id to be 1, otherwise 2
     uint64_t newId = prob0States.empty() ? 1 : 2;
     uint64_t nextObservation = prob0States.empty() ? 1 : 2;
-    for (auto const &iter : unknownStates) {
+    for (auto const iter : unknownStates) {
         stateMap[iter] = newId;
         if (observationMap.count(pomdp.getObservation(iter)) == 0) {
             observationMap[pomdp.getObservation(iter)] = nextObservation;
@@ -86,7 +86,7 @@ std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> KnownProbabilityTransfo
 
     auto transitionMatrix = pomdp.getTransitionMatrix();
 
-    for (auto const &iter : unknownStates) {
+    for (auto const iter : unknownStates) {
         smb.newRowGroup(currentRow);
         // First collect all transitions
         // auto rowGroup = transitionMatrix.getRowGroup(iter);

--- a/src/storm-pomdp/transformer/MakeStateSetObservationClosed.cpp
+++ b/src/storm-pomdp/transformer/MakeStateSetObservationClosed.cpp
@@ -11,7 +11,7 @@ std::pair<std::shared_ptr<storm::models::sparse::Pomdp<ValueType>>, std::set<uin
     storm::storage::BitVector const& stateSet) const {
     // Collect observations of target states
     std::set<uint32_t> oldObservations;
-    for (auto const& state : stateSet) {
+    for (auto const state : stateSet) {
         oldObservations.insert(pomdp->getObservation(state));
     }
 
@@ -38,7 +38,7 @@ std::pair<std::shared_ptr<storm::models::sparse::Pomdp<ValueType>>, std::set<uin
     } else {
         // Create new observations
         auto newObservationVector = pomdp->getObservations();
-        for (auto const& state : stateSet) {
+        for (auto const state : stateSet) {
             auto findRes = oldToNewObservationMap.find(pomdp->getObservation(state));
             if (findRes != oldToNewObservationMap.end()) {
                 newObservationVector[state] = findRes->second;


### PR DESCRIPTION
This removes more warnings in storm-pomdp. This includes both warnings when compiling with AppleClang on macOS using cmake option STORM_ALLWARNINGS and some unused parameter warnings occurring with GCC (as observed in the CI).