### PR TITLE
Modify printing macros to require a trailing semicolon

### DIFF
--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -1221,7 +1221,7 @@ void verifyWithSparseEngine(std::shared_ptr<storm::models::ModelBase> const& mod
             if (result->isExplicitQuantitativeCheckResult()) {
                 if (result->template asExplicitQuantitativeCheckResult<ValueType>().hasScheduler()) {
                     auto const& scheduler = result->template asExplicitQuantitativeCheckResult<ValueType>().getScheduler();
-                    STORM_PRINT_AND_LOG("Exporting scheduler ... ")
+                    STORM_PRINT_AND_LOG("Exporting scheduler ... ");
                     if (input.model) {
                         STORM_LOG_WARN_COND(sparseModel->hasStateValuations(),
                                             "No information of state valuations available. The scheduler output will use internal state ids. You might be "

--- a/src/storm-gspn/storage/gspn/GSPN.cpp
+++ b/src/storm-gspn/storage/gspn/GSPN.cpp
@@ -262,17 +262,17 @@ bool GSPN::testPlaces() const {
 
     for (auto const& place : this->getPlaces()) {
         if (std::find(namesOfPlaces.begin(), namesOfPlaces.end(), place.getName()) != namesOfPlaces.end()) {
-            STORM_PRINT_AND_LOG("duplicates states with the name \"" + place.getName() + "\"\n")
+            STORM_PRINT_AND_LOG("duplicates states with the name \"" + place.getName() + "\"\n");
             result = false;
         }
 
         if (std::find(idsOfPlaces.begin(), idsOfPlaces.end(), place.getID()) != idsOfPlaces.end()) {
-            STORM_PRINT_AND_LOG("duplicates states with the id \"" + boost::lexical_cast<std::string>(place.getID()) + "\"\n")
+            STORM_PRINT_AND_LOG("duplicates states with the id \"" + boost::lexical_cast<std::string>(place.getID()) + "\"\n");
             result = false;
         }
 
         if (place.getNumberOfInitialTokens() > place.getNumberOfInitialTokens()) {
-            STORM_PRINT_AND_LOG("number of initial tokens is greater than the capacity for place \"" + place.getName() + "\"\n")
+            STORM_PRINT_AND_LOG("number of initial tokens is greater than the capacity for place \"" + place.getName() + "\"\n");
             result = false;
         }
     }

--- a/src/storm-pars-cli/feasibility.cpp
+++ b/src/storm-pars-cli/feasibility.cpp
@@ -30,7 +30,7 @@ void printFeasibilityResult(bool success,
     if (success) {
         STORM_PRINT_AND_LOG("Result at initial state: " << valueValuationPair.first << " ( approx. "
                                                         << storm::utility::convertNumber<double>(valueValuationPair.first) << ") at [" << valuationStr.str()
-                                                        << "].\n")
+                                                        << "].\n");
     } else {
         STORM_PRINT_AND_LOG("No satisfying result found.\n");
     }

--- a/src/storm-pars-cli/print.cpp
+++ b/src/storm-pars-cli/print.cpp
@@ -25,7 +25,7 @@ void printInitialStatesResult(std::unique_ptr<storm::modelchecker::CheckResult> 
 
             STORM_PRINT_AND_LOG(" for instance [" << ss.str() << "]");
         }
-        STORM_PRINT_AND_LOG(": ")
+        STORM_PRINT_AND_LOG(": ");
 
         auto const *regionCheckResult = dynamic_cast<storm::modelchecker::RegionCheckResult<ValueType> const *>(result.get());
         if (regionCheckResult != nullptr) {

--- a/src/storm-pomdp-cli/storm-pomdp.cpp
+++ b/src/storm-pomdp-cli/storm-pomdp.cpp
@@ -261,9 +261,9 @@ bool performAnalysis(std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> co
         auto result = checker.check(formula);
         checker.printStatisticsToStream(std::cout);
         if (storm::utility::resources::isTerminate()) {
-            STORM_PRINT_AND_LOG("\nResult till abort: ")
+            STORM_PRINT_AND_LOG("\nResult till abort: ");
         } else {
-            STORM_PRINT_AND_LOG("\nResult: ")
+            STORM_PRINT_AND_LOG("\nResult: ");
         }
         printResult(result.lowerBound, result.upperBound);
         STORM_PRINT_AND_LOG('\n');
@@ -281,9 +281,9 @@ bool performAnalysis(std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> co
             auto result = resultPtr->template asExplicitQuantitativeCheckResult<ValueType>();
             result.filter(storm::modelchecker::ExplicitQualitativeCheckResult(pomdp->getInitialStates()));
             if (storm::utility::resources::isTerminate()) {
-                STORM_PRINT_AND_LOG("\nResult till abort: ")
+                STORM_PRINT_AND_LOG("\nResult till abort: ");
             } else {
-                STORM_PRINT_AND_LOG("\nResult: ")
+                STORM_PRINT_AND_LOG("\nResult: ");
             }
             printResult(result.getMin(), result.getMax());
             STORM_PRINT_AND_LOG('\n');

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -1090,8 +1090,8 @@ bool BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
         }
         if (printUpdateStopwatch.getTimeInSeconds() >= 60) {
             printUpdateStopwatch.restart();
-            STORM_PRINT_AND_LOG("### " << underApproximation->getCurrentNumberOfMdpStates() << " beliefs in underapproximation MDP" << " ##### "
-                                       << underApproximation->getUnexploredStates().size() << " beliefs queued\n");
+            STORM_PRINT_AND_LOG("### " << underApproximation->getCurrentNumberOfMdpStates() << " beliefs in underapproximation MDP"
+                                       << " ##### " << underApproximation->getUnexploredStates().size() << " beliefs queued\n");
             if (underApproximation->getCurrentNumberOfMdpStates() > heuristicParameters.sizeThreshold && options.useClipping) {
                 STORM_PRINT_AND_LOG("##### Clipping Attempts: " << statistics.nrClippingAttempts.value() << " ##### "
                                                                 << "Clipped States: " << statistics.nrClippedStates.value() << "\n");

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -362,7 +362,7 @@ void BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
                 underApproxHeuristicPar.sizeThreshold = std::numeric_limits<uint64_t>::max();
             } else {
                 underApproxHeuristicPar.sizeThreshold = pomdp().getNumberOfStates() * pomdp().getMaxNrStatesWithSameObservation();
-                STORM_PRINT_AND_LOG("Heuristically selected an under-approximation MDP size threshold of " << underApproxHeuristicPar.sizeThreshold << ".\n")
+                STORM_PRINT_AND_LOG("Heuristically selected an under-approximation MDP size threshold of " << underApproxHeuristicPar.sizeThreshold << ".\n");
             }
         }
 
@@ -1048,7 +1048,7 @@ bool BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
 
     unfoldingStatus = Status::Exploring;
     if (options.useClipping) {
-        STORM_PRINT_AND_LOG("Use Belief Clipping with grid beliefs \n")
+        STORM_PRINT_AND_LOG("Use Belief Clipping with grid beliefs \n");
         statistics.nrClippingAttempts = 0;
         statistics.nrClippedStates = 0;
     }
@@ -1090,11 +1090,11 @@ bool BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
         }
         if (printUpdateStopwatch.getTimeInSeconds() >= 60) {
             printUpdateStopwatch.restart();
-            STORM_PRINT_AND_LOG("### " << underApproximation->getCurrentNumberOfMdpStates() << " beliefs in underapproximation MDP"
-                                       << " ##### " << underApproximation->getUnexploredStates().size() << " beliefs queued\n")
+            STORM_PRINT_AND_LOG("### " << underApproximation->getCurrentNumberOfMdpStates() << " beliefs in underapproximation MDP" << " ##### "
+                                       << underApproximation->getUnexploredStates().size() << " beliefs queued\n");
             if (underApproximation->getCurrentNumberOfMdpStates() > heuristicParameters.sizeThreshold && options.useClipping) {
                 STORM_PRINT_AND_LOG("##### Clipping Attempts: " << statistics.nrClippingAttempts.value() << " ##### "
-                                                                << "Clipped States: " << statistics.nrClippedStates.value() << "\n")
+                                                                << "Clipped States: " << statistics.nrClippedStates.value() << "\n");
             }
         }
         if (unfoldingControl == UnfoldingControl::Pause && !stateStored) {
@@ -1278,7 +1278,7 @@ bool BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
     underApproximation->finishExploration();
     statistics.underApproximationBuildTime.stop();
     printUpdateStopwatch.stop();
-    STORM_PRINT_AND_LOG("Finished exploring under-approximation MDP.\nStart analysis...\n")
+    STORM_PRINT_AND_LOG("Finished exploring under-approximation MDP.\nStart analysis...\n");
     unfoldingStatus = Status::ModelExplorationFinished;
     statistics.underApproximationCheckTime.start();
     underApproximation->computeValuesOfExploredMdp(env, min ? storm::solver::OptimizationDirection::Minimize : storm::solver::OptimizationDirection::Maximize);

--- a/src/storm/utility/macros.h
+++ b/src/storm/utility/macros.h
@@ -60,15 +60,15 @@
  * Define the macros that print information and optionally also log it.
  */
 #define STORM_PRINT(message)  \
-    {                         \
+    do {                      \
         std::cout << message; \
         std::cout.flush();    \
-    }
+    } while (false)
 
 #define STORM_PRINT_AND_LOG(message) \
-    {                                \
+    do {                             \
         STORM_LOG_INFO(message);     \
         STORM_PRINT(message);        \
-    }
+    } while (false)
 
 #endif /* STORM_UTILITY_MACROS_H_ */


### PR DESCRIPTION
Adds wrapping `do{...} while` to STORM_PRINT and STORM_PRINT_AND_LOG macro definitions to require their uses to be followed by a semicolon. Also adjusts occurences where previously the semicolon was not present.

Resolves #551 