### PR TITLE
Integrate sin, cos and constants to Storm Jani parser

### DIFF
--- a/resources/examples/testfiles/dtmc/test_trigonometry.jani
+++ b/resources/examples/testfiles/dtmc/test_trigonometry.jani
@@ -237,6 +237,45 @@
                     "op": "initial"
                 }
             }
+        },
+        {
+            "name": "test_int_trigonometry",
+            "expression": {
+                "op": "filter",
+                "fun": "values",
+                "values": {
+                    "op": "Pmin",
+                    "exp": {
+                        "op": "U",
+                        "step-bounds": {
+                            "upper": "max_n_steps"
+                        },
+                        "left": true,
+                        "right": {
+                            "op": "∧",
+                            "left": {
+                                "op": "=",
+                                "left": {
+                                    "op": "sin",
+                                    "exp": 0
+                                },
+                                "right": 0.0
+                            },
+                            "right": {
+                                "op": "=",
+                                "left": {
+                                    "op": "cos",
+                                    "exp": 0
+                                },
+                                "right": 1.0
+                            }
+                        }
+                    }
+                },
+                "states": {
+                    "op": "initial"
+                }
+            }
         }
     ]
 }

--- a/resources/examples/testfiles/dtmc/test_trigonometry.jani
+++ b/resources/examples/testfiles/dtmc/test_trigonometry.jani
@@ -1,0 +1,242 @@
+{
+    "jani-version": 1,
+    "name": "test_trigonometry",
+    "type": "dtmc",
+    "metadata": {
+        "description": "Testing sin, cos and constants in Storm SMC tool."
+    },
+    "features": [
+		"trigonometric-functions"
+	],
+    "variables": [
+        {
+            "name": "orientation_deg",
+            "type": "int",
+            "initial-value": 0,
+            "comment": "Orientation in degrees"
+        },
+        {
+            "name": "pose_x_cm",
+            "type": "int",
+            "initial-value": 0,
+            "comment": "X position in cm"
+        }
+    ],
+    "constants": [
+        {
+            "name": "step_size_rad",
+            "type": "real",
+            "comment": "How much to turn in each step in radians"
+        },
+        {
+            "name": "step_size_m",
+            "type": "real",
+            "comment": "How much to move in each step in meters"
+        },
+        {
+            "name": "max_n_steps",
+            "type": "int",
+            "comment": "Upper bound on the number of steps"
+        },
+        {
+            "name": "goal_orientation_rad",
+            "type": "real",
+            "value": {
+                "op": "/",
+                "left": {"constant": "π"},
+                "right": 2
+            },
+            "comment": "Orientation to reach in radians"
+        }
+    ],
+    "actions": [
+        {
+            "name": "advance"
+        }
+    ],
+    "automata": [
+        {
+            "name": "test_trig_automaton",
+            "locations": [
+                {
+                    "name": "loc"
+                }
+            ],
+            "initial-locations": [
+                "loc"
+            ],
+            "variables": [
+                {
+                    "name": "orientation_rad",
+                    "type": "real",
+                    "initial-value": 0.0,
+                    "transient": true
+                }
+            ],
+            "edges": [
+                {
+                    "location": "loc",
+                    "destinations": [
+                        {
+                            "location": "loc",
+                            "assignments": [
+                                {
+                                    "ref": "orientation_rad",
+                                    "value": {
+                                        "op": "*",
+                                        "left": "orientation_deg",
+                                        "right": {
+                                            "op": "/",
+                                            "left": {"constant": "π"},
+                                            "right": 180
+                                        }
+                                    },
+                                    "index": 0,
+                                    "comment": "Convert orientation from deg to rad"
+                                },
+                                {
+                                    "ref": "pose_x_cm",
+                                    "value": {
+                                        "op": "+",
+                                        "left": "pose_x_cm",
+                                        "right": {
+                                            "op": "*",
+                                            "left": {
+                                                "op": "*",
+                                                "left": "step_size_m",
+                                                "right": {
+                                                    "op": "cos",
+                                                    "exp": "orientation_rad"
+                                                }
+                                            },
+                                            "right": 100
+                                        }
+                                    },
+                                    "index": 1,
+                                    "comment": "Move the robot on the X axis depending on its angle"
+                                },
+                                {
+                                    "ref": "orientation_rad",
+                                    "value": {
+                                        "op": "+",
+                                        "left": "orientation_rad",
+                                        "right": "step_size_rad"
+                                    },
+                                    "index": 2,
+                                    "comment": "Turn by step_size"
+                                },
+                                {
+                                    "ref": "orientation_deg",
+                                    "value": {
+                                        "op": "*",
+                                        "left": "orientation_rad",
+                                        "right": {
+                                            "op": "/",
+                                            "left": 180,
+                                            "right": {"constant": "π"}
+                                        }
+                                    },
+                                    "index": 3,
+                                    "comment": "Convert orientation from rad to deg"
+                                }
+                            ]
+                        }
+                    ],
+                    "action": "advance"
+                }
+            ]
+        }
+    ],
+    "system": {
+        "elements": [
+            {
+                "automaton": "test_trig_automaton"
+            }
+        ],
+        "syncs": [
+            {
+                "result": "advance",
+                "synchronise": [
+                    "advance"
+                ]
+            }
+        ]
+    },
+    "properties": [
+        {
+            "name": "destination_reached_sin",
+            "expression": {
+                "op": "filter",
+                "fun": "values",
+                "values": {
+                    "op": "Pmin",
+                    "exp": {
+                        "op": "U",
+                        "step-bounds": {
+                            "upper": "max_n_steps"
+                        },
+                        "left": true,
+                        "right": {
+                            "op": "∧",
+                            "left": {
+                                "op": "∧",
+                                "left": {
+                                    "op": "<",
+                                    "left": {
+                                        "op": "abs",
+                                        "exp": {
+                                            "op": "-",
+                                            "left": "goal_orientation_rad",
+                                            "right": {
+                                                "op": "*",
+                                                "left": "orientation_deg",
+                                                "right": {
+                                                    "op": "/",
+                                                    "left": {"constant": "π"},
+                                                    "right": 180
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "right": 0.01,
+                                    "comment": "Check if orientation is close to goal"
+                                },
+                                "right": {
+                                    "op": "<",
+                                    "left": {
+                                        "op": "abs",
+                                        "exp": {
+                                            "op": "-",
+                                            "left": {
+                                                "op": "sin",
+                                                "exp": {
+                                                    "op": "*",
+                                                    "left": "orientation_deg",
+                                                    "right": {
+                                                        "op": "/",
+                                                        "left": {"constant": "π"},
+                                                        "right": 180
+                                                    }
+                                                }
+                                            },
+                                            "right": 1.0
+                                        }
+                                    },
+                                    "right": 0.01
+                                }
+                            },
+                            "right": {
+                                "op": ">",
+                                "left": "pose_x_cm",
+                                "right": 1
+                            }
+                        }
+                    }
+                },
+                "states": {
+                    "op": "initial"
+                }
+            }
+        }
+    ]
+}

--- a/resources/examples/testfiles/dtmc/test_trigonometry.jani
+++ b/resources/examples/testfiles/dtmc/test_trigonometry.jani
@@ -13,40 +13,32 @@
             "name": "orientation_deg",
             "type": "int",
             "initial-value": 0,
-            "comment": "Orientation in degrees"
-        },
-        {
-            "name": "pose_x_cm",
-            "type": "int",
-            "initial-value": 0,
-            "comment": "X position in cm"
+            "comment": "Current orientation in degrees"
         }
     ],
     "constants": [
         {
             "name": "step_size_rad",
-            "type": "real",
-            "comment": "How much to turn in each step in radians"
-        },
-        {
-            "name": "step_size_m",
-            "type": "real",
-            "comment": "How much to move in each step in meters"
-        },
-        {
-            "name": "max_n_steps",
-            "type": "int",
-            "comment": "Upper bound on the number of steps"
-        },
-        {
-            "name": "goal_orientation_rad",
-            "type": "real",
-            "value": {
-                "op": "/",
-                "left": {"constant": "π"},
-                "right": 2
+            "type": {
+                "kind": "bounded",
+                "base": "real",
+                "lower-bound": {
+                    "op": "/",
+                    "left": {
+                        "constant": "π"
+                    },
+                    "right": 180
+                },
+                "upper-bound": {
+                    "op": "*",
+                    "left": {
+                        "constant": "π"
+                    },
+                    "right": 2
+                }
+
             },
-            "comment": "Orientation to reach in radians"
+            "comment": "How much to turn in each step in radians. Bounds: [1 deg., 360 deg.]"
         }
     ],
     "actions": [
@@ -59,11 +51,16 @@
             "name": "test_trig_automaton",
             "locations": [
                 {
-                    "name": "loc"
+                    "name": "increasing",
+                    "comment": "A state were the angle is increased each transition"
+                },
+                {
+                    "name": "final",
+                    "comment": "State reached when cos(angle) ~= 1"
                 }
             ],
             "initial-locations": [
-                "loc"
+                "increasing"
             ],
             "variables": [
                 {
@@ -75,10 +72,29 @@
             ],
             "edges": [
                 {
-                    "location": "loc",
+                    "action": "advance",
+                    "location": "increasing",
+                    "guard": {
+                        "exp": {
+                            "op": "<",
+                            "left": {
+                                "op": "sin",
+                                "exp": {
+                                    "op": "*",
+                                    "left": "orientation_deg",
+                                    "right": {
+                                        "op": "/",
+                                        "left": {"constant": "π"},
+                                        "right": 180
+                                    }
+                                }
+                            },
+                            "right": 0.99
+                        }
+                    },
                     "destinations": [
                         {
-                            "location": "loc",
+                            "location": "increasing",
                             "assignments": [
                                 {
                                     "ref": "orientation_rad",
@@ -95,34 +111,13 @@
                                     "comment": "Convert orientation from deg to rad"
                                 },
                                 {
-                                    "ref": "pose_x_cm",
-                                    "value": {
-                                        "op": "+",
-                                        "left": "pose_x_cm",
-                                        "right": {
-                                            "op": "*",
-                                            "left": {
-                                                "op": "*",
-                                                "left": "step_size_m",
-                                                "right": {
-                                                    "op": "cos",
-                                                    "exp": "orientation_rad"
-                                                }
-                                            },
-                                            "right": 100
-                                        }
-                                    },
-                                    "index": 1,
-                                    "comment": "Move the robot on the X axis depending on its angle"
-                                },
-                                {
                                     "ref": "orientation_rad",
                                     "value": {
                                         "op": "+",
                                         "left": "orientation_rad",
                                         "right": "step_size_rad"
                                     },
-                                    "index": 2,
+                                    "index": 1,
                                     "comment": "Turn by step_size"
                                 },
                                 {
@@ -136,13 +131,39 @@
                                             "right": {"constant": "π"}
                                         }
                                     },
-                                    "index": 3,
+                                    "index": 2,
                                     "comment": "Convert orientation from rad to deg"
                                 }
                             ]
                         }
-                    ],
-                    "action": "advance"
+                    ]
+                },
+                {
+                    "action": "advance",
+                    "location": "increasing",
+                    "guard": {
+                        "exp": {
+                            "op": "≥",
+                            "left": {
+                                "op": "sin",
+                                "exp": {
+                                    "op": "*",
+                                    "left": "orientation_deg",
+                                    "right": {
+                                        "op": "/",
+                                        "left": {"constant": "π"},
+                                        "right": 180
+                                    }
+                                }
+                            },
+                            "right": 0.99
+                        }
+                    },
+                    "destinations": [
+                        {
+                            "location": "final"
+                        }
+                    ]
                 }
             ]
         }
@@ -173,63 +194,24 @@
                     "exp": {
                         "op": "U",
                         "step-bounds": {
-                            "upper": "max_n_steps"
+                            "upper": 1000
                         },
                         "left": true,
                         "right": {
-                            "op": "∧",
+                            "op": "≥",
                             "left": {
-                                "op": "∧",
-                                "left": {
-                                    "op": "<",
-                                    "left": {
-                                        "op": "abs",
-                                        "exp": {
-                                            "op": "-",
-                                            "left": "goal_orientation_rad",
-                                            "right": {
-                                                "op": "*",
-                                                "left": "orientation_deg",
-                                                "right": {
-                                                    "op": "/",
-                                                    "left": {"constant": "π"},
-                                                    "right": 180
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "right": 0.01,
-                                    "comment": "Check if orientation is close to goal"
-                                },
-                                "right": {
-                                    "op": "<",
-                                    "left": {
-                                        "op": "abs",
-                                        "exp": {
-                                            "op": "-",
-                                            "left": {
-                                                "op": "sin",
-                                                "exp": {
-                                                    "op": "*",
-                                                    "left": "orientation_deg",
-                                                    "right": {
-                                                        "op": "/",
-                                                        "left": {"constant": "π"},
-                                                        "right": 180
-                                                    }
-                                                }
-                                            },
-                                            "right": 1.0
-                                        }
-                                    },
-                                    "right": 0.01
+                                "op": "sin",
+                                "exp": {
+                                    "op": "*",
+                                    "left": "orientation_deg",
+                                    "right": {
+                                        "op": "/",
+                                        "left": {"constant": "π"},
+                                        "right": 180
+                                    }
                                 }
                             },
-                            "right": {
-                                "op": ">",
-                                "left": "pose_x_cm",
-                                "right": 1
-                            }
+                            "right": 0.99
                         }
                     }
                 },
@@ -247,9 +229,6 @@
                     "op": "Pmin",
                     "exp": {
                         "op": "U",
-                        "step-bounds": {
-                            "upper": "max_n_steps"
-                        },
                         "left": true,
                         "right": {
                             "op": "∧",

--- a/src/storm-conv/api/storm-conv.cpp
+++ b/src/storm-conv/api/storm-conv.cpp
@@ -22,7 +22,7 @@ void transformJani(storm::jani::Model& janiModel, std::vector<storm::jani::Prope
     }
 
     if (options.substituteConstants) {
-        janiModel.substituteConstantsInPlace();
+        janiModel.substituteConstantsInPlace(false);
     }
 
     if (options.localVars) {

--- a/src/storm-parsers/parser/JaniParser.cpp
+++ b/src/storm-parsers/parser/JaniParser.cpp
@@ -12,6 +12,7 @@
 #include "storm/storage/jani/TemplateEdge.h"
 #include "storm/storage/jani/expressions/JaniExpressions.h"
 #include "storm/storage/jani/visitor/CompositionInformationVisitor.h"
+#include "storm/storage/jani/visitor/JaniExpressionSubstitutionVisitor.h"
 
 #include "storm/storage/jani/types/ArrayType.h"
 #include "storm/storage/jani/types/BasicType.h"
@@ -847,7 +848,11 @@ std::pair<std::unique_ptr<storm::jani::JaniType>, storm::expressions::Type> Jani
                                 "Upper bound for bounded real variable " << variableName << "(scope: " << scope.description << ") must be numeric");
                 if (lowerboundExpr.isInitialized() && upperboundExpr.isInitialized() && !lowerboundExpr.containsVariables() &&
                     !upperboundExpr.containsVariables()) {
-                    STORM_LOG_THROW(lowerboundExpr.evaluateAsRational() <= upperboundExpr.evaluateAsRational(), storm::exceptions::InvalidJaniException,
+                    using SubMap = std::map<storm::expressions::Variable, storm::expressions::Expression>;
+                    storm::expressions::JaniExpressionSubstitutionVisitor<SubMap> transcendentalVisitor(SubMap(), true);
+                    const storm::RationalNumber lowerboundValue = transcendentalVisitor.substitute(lowerboundExpr).evaluateAsRational();
+                    const storm::RationalNumber upperboundValue = transcendentalVisitor.substitute(upperboundExpr).evaluateAsRational();
+                    STORM_LOG_THROW(lowerboundValue <= upperboundValue, storm::exceptions::InvalidJaniException,
                                     "Lower bound must not be larger than upper bound for bounded real variable " << variableName
                                                                                                                  << "(scope: " << scope.description << ").");
                 }

--- a/src/storm-parsers/parser/JaniParser.cpp
+++ b/src/storm-parsers/parser/JaniParser.cpp
@@ -125,7 +125,7 @@ std::pair<storm::jani::Model, std::vector<storm::jani::Property>> JaniParser<Val
     uint_fast64_t featuresCount = parsedStructure.count("features");
     STORM_LOG_THROW(featuresCount < 2, storm::exceptions::InvalidJaniException, "features-declarations can be given at most once.");
     if (featuresCount == 1) {
-        auto allKnownModelFeatures = storm::jani::getAllKnownModelFeatures();
+        const auto allKnownModelFeatures = storm::jani::getAllKnownModelFeatures();
         for (auto const& feature : parsedStructure.at("features")) {
             std::string featureStr = getString<ValueType>(feature, "Model feature");
             bool found = false;

--- a/src/storm-parsers/parser/JaniParser.cpp
+++ b/src/storm-parsers/parser/JaniParser.cpp
@@ -1446,10 +1446,14 @@ storm::expressions::Expression JaniParser<ValueType>::parseExpression(Json const
             // Convert constants to a numeric value (only PI and Euler number, as in Jani specification)
             const std::string constantStr = getString<ValueType>(expressionStructure.at("constant"), scope.description);
             if (constantStr == "π") {
-                return expressionManager->rational(M_PI);
+                return std::make_shared<storm::expressions::TranscendentalNumberLiteralExpression>(
+                           *expressionManager, storm::expressions::TranscendentalNumberLiteralExpression::TranscendentalNumber::PI)
+                    ->toExpression();
             }
             if (constantStr == "e") {
-                return expressionManager->rational(std::exp(1.0));
+                return std::make_shared<storm::expressions::TranscendentalNumberLiteralExpression>(
+                           *expressionManager, storm::expressions::TranscendentalNumberLiteralExpression::TranscendentalNumber::E)
+                    ->toExpression();
             }
         }
         STORM_LOG_THROW(

--- a/src/storm-parsers/parser/JaniParser.cpp
+++ b/src/storm-parsers/parser/JaniParser.cpp
@@ -758,7 +758,8 @@ std::shared_ptr<storm::jani::Constant> JaniParser<ValueType>::parseConstant(Json
         // variable occurs also on the assignment.
         definingExpression = parseExpression(constantStructure.at("value"), scope.refine("Value of constant " + name));
         assert(definingExpression.isInitialized());
-        STORM_LOG_THROW((type.second == definingExpression.getType() || type.second.isRationalType() && definingExpression.getType().isIntegerType()),
+        // Check that the defined and actual expression value match OR the defined value is a rational and the actual value is a numerical type.
+        STORM_LOG_THROW((type.second == definingExpression.getType() || type.second.isRationalType() && definingExpression.getType().isNumericalType()),
                         storm::exceptions::InvalidJaniException,
                         "Type of value for constant '" + name + "' (scope: " + scope.description + ") does not match the given type '" +
                             type.first->getStringRepresentation() + ".");

--- a/src/storm/api/properties.cpp
+++ b/src/storm/api/properties.cpp
@@ -22,6 +22,14 @@ std::vector<storm::jani::Property> substituteConstantsInProperties(std::vector<s
     return preprocessedProperties;
 }
 
+std::vector<storm::jani::Property> substituteTranscendentalNumbersInProperties(std::vector<storm::jani::Property> const& properties) {
+    std::vector<storm::jani::Property> preprocessedProperties;
+    for (auto const& property : properties) {
+        preprocessedProperties.emplace_back(property.substituteTranscendentalNumbers());
+    }
+    return preprocessedProperties;
+}
+
 std::vector<storm::jani::Property> filterProperties(std::vector<storm::jani::Property> const& properties,
                                                     boost::optional<std::set<std::string>> const& propertyFilter) {
     if (propertyFilter) {

--- a/src/storm/api/properties.h
+++ b/src/storm/api/properties.h
@@ -32,6 +32,7 @@ namespace api {
 // Process properties.
 std::vector<storm::jani::Property> substituteConstantsInProperties(std::vector<storm::jani::Property> const& properties,
                                                                    std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution);
+std::vector<storm::jani::Property> substituteTranscendentalNumbersInProperties(std::vector<storm::jani::Property> const& properties);
 std::vector<storm::jani::Property> filterProperties(std::vector<storm::jani::Property> const& properties,
                                                     boost::optional<std::set<std::string>> const& propertyFilter);
 std::vector<std::shared_ptr<storm::logic::Formula const>> extractFormulasFromProperties(std::vector<storm::jani::Property> const& properties);

--- a/src/storm/generator/JaniNextStateGenerator.cpp
+++ b/src/storm/generator/JaniNextStateGenerator.cpp
@@ -60,6 +60,7 @@ JaniNextStateGenerator<ValueType, StateType>::JaniNextStateGenerator(storm::jani
     auto features = this->model.getModelFeatures();
     features.remove(storm::jani::ModelFeature::DerivedOperators);
     features.remove(storm::jani::ModelFeature::StateExitRewards);
+    features.remove(storm::jani::ModelFeature::TrigonometricFunctions);
     // Eliminate arrays if necessary.
     if (features.hasArrays()) {
         arrayEliminatorData = this->model.eliminateArrays(true);
@@ -144,6 +145,7 @@ storm::jani::ModelFeatures JaniNextStateGenerator<ValueType, StateType>::getSupp
     features.add(storm::jani::ModelFeature::DerivedOperators);
     features.add(storm::jani::ModelFeature::StateExitRewards);
     features.add(storm::jani::ModelFeature::Arrays);
+    features.add(storm::jani::ModelFeature::TrigonometricFunctions);
     // We do not add Functions as these should ideally be substituted before creating this generator.
     // This is because functions may also occur in properties and the user of this class should take care of that.
     return features;
@@ -156,6 +158,7 @@ bool JaniNextStateGenerator<ValueType, StateType>::canHandle(storm::jani::Model 
     features.remove(storm::jani::ModelFeature::DerivedOperators);
     features.remove(storm::jani::ModelFeature::Functions);  // can be substituted
     features.remove(storm::jani::ModelFeature::StateExitRewards);
+    features.remove(storm::jani::ModelFeature::TrigonometricFunctions);
     if (!features.empty()) {
         STORM_LOG_INFO("The model can not be build as it contains these unsupported features: " << features.toString());
         return false;

--- a/src/storm/generator/JaniNextStateGenerator.cpp
+++ b/src/storm/generator/JaniNextStateGenerator.cpp
@@ -42,7 +42,7 @@ namespace generator {
 
 template<typename ValueType, typename StateType>
 JaniNextStateGenerator<ValueType, StateType>::JaniNextStateGenerator(storm::jani::Model const& model, NextStateGeneratorOptions const& options)
-    : JaniNextStateGenerator(model.substituteConstantsFunctions(), options, false) {
+    : JaniNextStateGenerator(model.substituteConstantsFunctionsTranscendentals(), options, false) {
     // Intentionally left empty.
 }
 

--- a/src/storm/logic/Formula.cpp
+++ b/src/storm/logic/Formula.cpp
@@ -504,7 +504,7 @@ std::shared_ptr<Formula> Formula::clone() const {
 }
 
 std::shared_ptr<Formula> Formula::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) const {
-    storm::expressions::JaniExpressionSubstitutionVisitor<std::map<storm::expressions::Variable, storm::expressions::Expression>> v(substitution);
+    storm::expressions::JaniExpressionSubstitutionVisitor<std::map<storm::expressions::Variable, storm::expressions::Expression>> v(substitution, false);
     return substitute([&v](storm::expressions::Expression const& exp) { return v.substitute(exp); });
 }
 
@@ -527,6 +527,12 @@ std::shared_ptr<Formula> Formula::substitute(std::map<std::string, std::string> 
 std::shared_ptr<Formula> Formula::substituteRewardModelNames(std::map<std::string, std::string> const& rewardModelNameSubstitution) const {
     RewardModelNameSubstitutionVisitor visitor(rewardModelNameSubstitution);
     return visitor.substitute(*this);
+}
+
+std::shared_ptr<Formula> Formula::substituteTranscendentalNumbers() const {
+    const std::map<storm::expressions::Variable, storm::expressions::Expression> emptySubstitutionMap = {};
+    storm::expressions::JaniExpressionSubstitutionVisitor<std::map<storm::expressions::Variable, storm::expressions::Expression>> v(emptySubstitutionMap, true);
+    return substitute([&v](storm::expressions::Expression const& exp) { return v.substitute(exp); });
 }
 
 storm::expressions::Expression Formula::toExpression(storm::expressions::ExpressionManager const& manager,

--- a/src/storm/logic/Formula.cpp
+++ b/src/storm/logic/Formula.cpp
@@ -530,9 +530,9 @@ std::shared_ptr<Formula> Formula::substituteRewardModelNames(std::map<std::strin
 }
 
 std::shared_ptr<Formula> Formula::substituteTranscendentalNumbers() const {
-    const std::map<storm::expressions::Variable, storm::expressions::Expression> emptySubstitutionMap = {};
-    storm::expressions::JaniExpressionSubstitutionVisitor<std::map<storm::expressions::Variable, storm::expressions::Expression>> v(emptySubstitutionMap, true);
-    return substitute([&v](storm::expressions::Expression const& exp) { return v.substitute(exp); });
+    using SubMap = std::map<storm::expressions::Variable, storm::expressions::Expression>;
+    storm::expressions::JaniExpressionSubstitutionVisitor<SubMap> transcendentalsVisitor(SubMap(), true);
+    return substitute([&transcendentalsVisitor](storm::expressions::Expression const& exp) { return transcendentalsVisitor.substitute(exp); });
 }
 
 storm::expressions::Expression Formula::toExpression(storm::expressions::ExpressionManager const& manager,

--- a/src/storm/logic/Formula.h
+++ b/src/storm/logic/Formula.h
@@ -227,6 +227,7 @@ class Formula : public std::enable_shared_from_this<Formula> {
     std::shared_ptr<Formula> substitute(std::map<std::string, storm::expressions::Expression> const& labelSubstitution) const;
     std::shared_ptr<Formula> substitute(std::map<std::string, std::string> const& labelSubstitution) const;
     std::shared_ptr<Formula> substituteRewardModelNames(std::map<std::string, std::string> const& rewardModelNameSubstitution) const;
+    std::shared_ptr<Formula> substituteTranscendentalNumbers() const;
 
     /*!
      * Takes the formula and converts it to an equivalent expression. The formula may contain atomic labels, but

--- a/src/storm/storage/expressions/Expression.cpp
+++ b/src/storm/storage/expressions/Expression.cpp
@@ -549,12 +549,14 @@ Expression logarithm(Expression const& first, Expression const& second) {
 }
 
 Expression cos(Expression const& first) {
+    STORM_LOG_THROW(first.hasNumericalType(), storm::exceptions::InvalidTypeException, "Operator 'cos' requires numerical operand.");
     return Expression(std::shared_ptr<BaseExpression>(new UnaryNumericalFunctionExpression(first.getBaseExpression().getManager(),
                                                                                            first.getType().trigonometric(), first.getBaseExpressionPointer(),
                                                                                            UnaryNumericalFunctionExpression::OperatorType::Cos)));
 }
 
 Expression sin(Expression const& first) {
+    STORM_LOG_THROW(first.hasNumericalType(), storm::exceptions::InvalidTypeException, "Operator 'sin' requires numerical operand.");
     return Expression(std::shared_ptr<BaseExpression>(new UnaryNumericalFunctionExpression(first.getBaseExpression().getManager(),
                                                                                            first.getType().trigonometric(), first.getBaseExpressionPointer(),
                                                                                            UnaryNumericalFunctionExpression::OperatorType::Sin)));

--- a/src/storm/storage/expressions/Expression.cpp
+++ b/src/storm/storage/expressions/Expression.cpp
@@ -548,6 +548,18 @@ Expression logarithm(Expression const& first, Expression const& second) {
         second.getBaseExpressionPointer(), BinaryNumericalFunctionExpression::OperatorType::Logarithm)));
 }
 
+Expression cos(Expression const& first) {
+    return Expression(std::shared_ptr<BaseExpression>(new UnaryNumericalFunctionExpression(first.getBaseExpression().getManager(),
+                                                                                           first.getType().trigonometric(), first.getBaseExpressionPointer(),
+                                                                                           UnaryNumericalFunctionExpression::OperatorType::Cos)));
+}
+
+Expression sin(Expression const& first) {
+    return Expression(std::shared_ptr<BaseExpression>(new UnaryNumericalFunctionExpression(first.getBaseExpression().getManager(),
+                                                                                           first.getType().trigonometric(), first.getBaseExpressionPointer(),
+                                                                                           UnaryNumericalFunctionExpression::OperatorType::Sin)));
+}
+
 Expression apply(std::vector<storm::expressions::Expression> const& expressions,
                  std::function<Expression(Expression const&, Expression const&)> const& function) {
     STORM_LOG_THROW(!expressions.empty(), storm::exceptions::InvalidArgumentException, "Cannot build function application of empty expression list.");

--- a/src/storm/storage/expressions/Expression.h
+++ b/src/storm/storage/expressions/Expression.h
@@ -454,6 +454,8 @@ Expression ceil(Expression const& first);
 Expression round(Expression const& first);
 Expression modulo(Expression const& first, Expression const& second);
 Expression logarithm(Expression const& first, Expression const& second);
+Expression cos(Expression const& first);
+Expression sin(Expression const& first);
 Expression minimum(Expression const& first, Expression const& second);
 Expression maximum(Expression const& first, Expression const& second);
 Expression atLeastOneOf(std::vector<storm::expressions::Expression> const& expressions);

--- a/src/storm/storage/expressions/ExpressionManager.cpp
+++ b/src/storm/storage/expressions/ExpressionManager.cpp
@@ -137,6 +137,13 @@ Type const& ExpressionManager::getArrayType(Type elementType) const {
     return *arrayTypes.insert(type).first;
 }
 
+Type const& ExpressionManager::getTranscendentalNumberType() const {
+    if (!transcendentalNumberType) {
+        transcendentalNumberType = Type(this->getSharedPointer(), std::shared_ptr<BaseType>(new TranscendentalNumberType()));
+    }
+    return transcendentalNumberType.get();
+}
+
 bool ExpressionManager::isValidVariableName(std::string const& name) {
     return name.size() < 2 || name.at(0) != '_' || name.at(1) != '_';
 }

--- a/src/storm/storage/expressions/ExpressionManager.h
+++ b/src/storm/storage/expressions/ExpressionManager.h
@@ -163,6 +163,12 @@ class ExpressionManager : public std::enable_shared_from_this<ExpressionManager>
     Type const& getArrayType(Type elementType) const;
 
     /*!
+     * Retrieves the transcendental numbers type (i.e. pi and e)
+     * @return The transcendental numbers type
+     */
+    Type const& getTranscendentalNumberType() const;
+
+    /*!
      * Declares a variable that is a copy of the provided variable (i.e. has the same type).
      *
      * @param variable The variable of which to create a copy.
@@ -486,6 +492,7 @@ class ExpressionManager : public std::enable_shared_from_this<ExpressionManager>
     mutable std::unordered_set<Type> bitvectorTypes;
     mutable boost::optional<Type> rationalType;
     mutable std::unordered_set<Type> arrayTypes;
+    mutable boost::optional<Type> transcendentalNumberType;
 
     // A mask that can be used to query whether a variable is an auxiliary variable.
     static const uint64_t auxiliaryMask = (1ull << 50);

--- a/src/storm/storage/expressions/OperatorType.h
+++ b/src/storm/storage/expressions/OperatorType.h
@@ -21,6 +21,8 @@ enum class OperatorType {
     Power,
     Modulo,
     Logarithm,
+    Cos,
+    Sin,
     Equal,
     NotEqual,
     Less,

--- a/src/storm/storage/expressions/ToExprtkStringVisitor.cpp
+++ b/src/storm/storage/expressions/ToExprtkStringVisitor.cpp
@@ -228,6 +228,16 @@ boost::any ToExprtkStringVisitor::visit(UnaryNumericalFunctionExpression const& 
             expression.getOperand()->accept(*this, data);
             stream << ")";
             break;
+        case UnaryNumericalFunctionExpression::OperatorType::Cos:
+            stream << "cos(";
+            expression.getOperand()->accept(*this, data);
+            stream << ")";
+            break;
+        case UnaryNumericalFunctionExpression::OperatorType::Sin:
+            stream << "sin(";
+            expression.getOperand()->accept(*this, data);
+            stream << ")";
+            break;
     }
     return boost::any();
 }

--- a/src/storm/storage/expressions/Type.cpp
+++ b/src/storm/storage/expressions/Type.cpp
@@ -66,6 +66,14 @@ bool ArrayType::isArrayType() const {
     return true;
 }
 
+bool BaseType::isTranscendentalNumberType() const {
+    return false;
+}
+
+bool TranscendentalNumberType::isTranscendentalNumberType() const {
+    return true;
+}
+
 uint64_t BooleanType::getMask() const {
     return BooleanType::mask;
 }
@@ -130,6 +138,14 @@ std::string ArrayType::getStringRepresentation() const {
     return "array[" + elementType.getStringRepresentation() + "]";
 }
 
+uint64_t TranscendentalNumberType::getMask() const {
+    return TranscendentalNumberType::mask;
+}
+
+std::string TranscendentalNumberType::getStringRepresentation() const {
+    return "transcendental";
+}
+
 bool operator<(BaseType const& first, BaseType const& second) {
     if (first.getMask() < second.getMask()) {
         return true;
@@ -172,11 +188,15 @@ bool Type::isBitVectorType() const {
 }
 
 bool Type::isNumericalType() const {
-    return this->isIntegerType() || this->isRationalType();
+    return this->isIntegerType() || this->isRationalType() || this->isTranscendentalNumberType();
 }
 
 bool Type::isArrayType() const {
     return this->innerType->isArrayType();
+}
+
+bool Type::isTranscendentalNumberType() const {
+    return this->innerType->isTranscendentalNumberType();
 }
 
 std::string Type::getStringRepresentation() const {

--- a/src/storm/storage/expressions/Type.cpp
+++ b/src/storm/storage/expressions/Type.cpp
@@ -236,6 +236,11 @@ Type Type::power(Type const& other, bool allowIntegerType) const {
     }
 }
 
+Type Type::trigonometric() const {
+    STORM_LOG_THROW(this->isNumericalType(), storm::exceptions::InvalidTypeException, "Operator requires numerical operand.");
+    return this->getManager().getRationalType();
+}
+
 Type Type::logicalConnective(Type const& other) const {
     STORM_LOG_THROW(this->isBooleanType() && other.isBooleanType(), storm::exceptions::InvalidTypeException, "Operator requires boolean operands.");
     return *this;

--- a/src/storm/storage/expressions/Type.h
+++ b/src/storm/storage/expressions/Type.h
@@ -116,6 +116,7 @@ class Type {
     Type modulo(Type const& other) const;
     Type logarithm(Type const& other) const;
     Type power(Type const& other, bool allowIntegerType = false) const;
+    Type trigonometric() const;
     Type logicalConnective(Type const& other) const;
     Type logicalConnective() const;
     Type numericalComparison(Type const& other) const;

--- a/src/storm/storage/expressions/Type.h
+++ b/src/storm/storage/expressions/Type.h
@@ -89,6 +89,13 @@ class Type {
     bool isArrayType() const;
 
     /*!
+     * Checks whether this type is a transcendental number type.
+     *
+     * @return True iff the type is a transcendental number.
+     */
+    bool isTranscendentalNumberType() const;
+
+    /*!
      * Retrieves the bit width of the type, provided that it is a bitvector type.
      *
      * @return The bit width of the bitvector type.
@@ -169,6 +176,7 @@ class BaseType {
     virtual bool isBitVectorType() const;
     virtual bool isRationalType() const;
     virtual bool isArrayType() const;
+    virtual bool isTranscendentalNumberType() const;
 };
 
 class BooleanType : public BaseType {
@@ -178,7 +186,7 @@ class BooleanType : public BaseType {
     virtual bool isBooleanType() const override;
 
    private:
-    static const uint64_t mask = (1ull << 60);
+    static const uint64_t mask = (1ull << 56);
 };
 
 class IntegerType : public BaseType {
@@ -188,7 +196,7 @@ class IntegerType : public BaseType {
     virtual bool isIntegerType() const override;
 
    private:
-    static const uint64_t mask = (1ull << 62);
+    static const uint64_t mask = (1ull << 58);
 };
 
 class BitVectorType : public BaseType {
@@ -214,7 +222,7 @@ class BitVectorType : public BaseType {
     virtual bool isBitVectorType() const override;
 
    private:
-    static const uint64_t mask = (1ull << 61);
+    static const uint64_t mask = (1ull << 57);
 
     // The bit width of the type.
     std::size_t width;
@@ -227,7 +235,7 @@ class RationalType : public BaseType {
     virtual bool isRationalType() const override;
 
    private:
-    static const uint64_t mask = (1ull << 63);
+    static const uint64_t mask = (1ull << 59);
 };
 
 class ArrayType : public BaseType {
@@ -242,10 +250,20 @@ class ArrayType : public BaseType {
     virtual bool isArrayType() const override;
 
    private:
-    static const uint64_t mask = (1ull << 59);
+    static const uint64_t mask = (1ull << 55);
 
     // The type of the array elements (can again be of type array).
     Type elementType;
+};
+
+class TranscendentalNumberType : public BaseType {
+   public:
+    virtual uint64_t getMask() const override;
+    virtual std::string getStringRepresentation() const override;
+    virtual bool isTranscendentalNumberType() const override;
+
+   private:
+    static const uint64_t mask = (1ull << 60);
 };
 
 class ErrorType : public BaseType {

--- a/src/storm/storage/expressions/UnaryNumericalFunctionExpression.cpp
+++ b/src/storm/storage/expressions/UnaryNumericalFunctionExpression.cpp
@@ -36,6 +36,12 @@ storm::expressions::OperatorType UnaryNumericalFunctionExpression::getOperator()
         case OperatorType::Ceil:
             result = storm::expressions::OperatorType::Ceil;
             break;
+        case OperatorType::Cos:
+            result = storm::expressions::OperatorType::Cos;
+            break;
+        case OperatorType::Sin:
+            result = storm::expressions::OperatorType::Sin;
+            break;
     }
     return result;
 }
@@ -78,6 +84,12 @@ double UnaryNumericalFunctionExpression::evaluateAsDouble(Valuation const* valua
         case OperatorType::Ceil:
             result = std::ceil(result);
             break;
+        case OperatorType::Cos:
+            result = std::cos(result);
+            break;
+        case OperatorType::Sin:
+            result = std::sin(result);
+            break;
     }
     return result;
 }
@@ -96,6 +108,11 @@ std::shared_ptr<BaseExpression const> UnaryNumericalFunctionExpression::simplify
                 case OperatorType::Floor:
                 case OperatorType::Ceil:
                     break;
+                case OperatorType::Cos:
+                case OperatorType::Sin:
+                    // The operands expect a real value. Raise an exception
+                    STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Cannot apply cos or sin to an integer value.");
+                    break;
             }
             return std::shared_ptr<BaseExpression>(new IntegerLiteralExpression(this->getManager(), value));
         } else {
@@ -112,6 +129,12 @@ std::shared_ptr<BaseExpression const> UnaryNumericalFunctionExpression::simplify
                 case OperatorType::Ceil:
                     value = storm::utility::ceil(value);
                     convertToInteger = true;
+                    break;
+                case OperatorType::Cos:
+                    value = storm::utility::cos(value);
+                    break;
+                case OperatorType::Sin:
+                    value = storm::utility::sin(value);
                     break;
             }
             if (convertToInteger) {
@@ -148,6 +171,12 @@ void UnaryNumericalFunctionExpression::printToStream(std::ostream& stream) const
             break;
         case OperatorType::Ceil:
             stream << "ceil(";
+            break;
+        case OperatorType::Cos:
+            stream << "cos(";
+            break;
+        case OperatorType::Sin:
+            stream << "sin(";
             break;
     }
     stream << *this->getOperand() << ")";

--- a/src/storm/storage/expressions/UnaryNumericalFunctionExpression.h
+++ b/src/storm/storage/expressions/UnaryNumericalFunctionExpression.h
@@ -11,7 +11,7 @@ class UnaryNumericalFunctionExpression : public UnaryExpression {
     /*!
      * An enum type specifying the different functions applicable.
      */
-    enum class OperatorType { Minus, Floor, Ceil };
+    enum class OperatorType { Minus, Floor, Ceil, Cos, Sin };
 
     /*!
      * Creates a unary numerical function expression with the given return type, operand and operator.

--- a/src/storm/storage/jani/Assignment.cpp
+++ b/src/storm/storage/jani/Assignment.cpp
@@ -62,12 +62,13 @@ bool Assignment::isTransient() const {
     return lValue.isTransient();
 }
 
-void Assignment::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
-    this->setAssignedExpression(substituteJaniExpression(this->getAssignedExpression(), substitution).simplify());
+void Assignment::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                            bool const& substituteTranscendentalNumbers) {
+    this->setAssignedExpression(substituteJaniExpression(this->getAssignedExpression(), substitution, substituteTranscendentalNumbers).simplify());
     if (lValue.isArrayAccess()) {
         std::vector<storm::expressions::Expression> substitutedExpressions;
         for (auto& index : lValue.getArrayIndexVector()) {
-            substitutedExpressions.push_back(substituteJaniExpression(index, substitution).simplify());
+            substitutedExpressions.push_back(substituteJaniExpression(index, substitution, substituteTranscendentalNumbers).simplify());
         }
 
         lValue = LValue(lValue.getVariable(), substitutedExpressions);

--- a/src/storm/storage/jani/Assignment.cpp
+++ b/src/storm/storage/jani/Assignment.cpp
@@ -63,7 +63,7 @@ bool Assignment::isTransient() const {
 }
 
 void Assignment::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
-                            bool const& substituteTranscendentalNumbers) {
+                            bool const substituteTranscendentalNumbers) {
     this->setAssignedExpression(substituteJaniExpression(this->getAssignedExpression(), substitution, substituteTranscendentalNumbers).simplify());
     if (lValue.isArrayAccess()) {
         std::vector<storm::expressions::Expression> substitutedExpressions;

--- a/src/storm/storage/jani/Assignment.h
+++ b/src/storm/storage/jani/Assignment.h
@@ -68,7 +68,7 @@ class Assignment {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const substituteTranscendentalNumbers);
 
     /**
      * Retrieves whether the assignment assigns to a transient variable.

--- a/src/storm/storage/jani/Assignment.h
+++ b/src/storm/storage/jani/Assignment.h
@@ -68,7 +68,7 @@ class Assignment {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
 
     /**
      * Retrieves whether the assignment assigns to a transient variable.

--- a/src/storm/storage/jani/Automaton.cpp
+++ b/src/storm/storage/jani/Automaton.cpp
@@ -38,7 +38,9 @@ Automaton Automaton::clone(storm::expressions::ExpressionManager& manager, std::
         oldToNewVarMap[v] = cloneVariable(manager, v, variablePrefix).getExpression();
     }
     result.variables.substituteExpressionVariables(oldToNewVarMap);
-    result.substitute(oldToNewVarMap);
+    // When cloning an automaton, keep the transcendental numbers as they are.
+    const bool substituteTranscendentalNumbers = false;
+    result.substitute(oldToNewVarMap, substituteTranscendentalNumbers);
     return result;
 }
 
@@ -429,22 +431,23 @@ std::vector<storm::expressions::Expression> Automaton::getAllRangeExpressions() 
     return result;
 }
 
-void Automaton::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
+void Automaton::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                           bool const& substituteTranscendentalNumbers) {
     for (auto& functionDefinition : this->getFunctionDefinitions()) {
-        functionDefinition.second.substitute(substitution);
+        functionDefinition.second.substitute(substitution, substituteTranscendentalNumbers);
     }
 
-    this->getVariables().substitute(substitution);
+    this->getVariables().substitute(substitution, substituteTranscendentalNumbers);
 
     for (auto& location : this->getLocations()) {
-        location.substitute(substitution);
+        location.substitute(substitution, substituteTranscendentalNumbers);
     }
 
     if (hasInitialStatesRestriction()) {
-        this->setInitialStatesRestriction(substituteJaniExpression(this->getInitialStatesRestriction(), substitution));
+        this->setInitialStatesRestriction(substituteJaniExpression(this->getInitialStatesRestriction(), substitution, substituteTranscendentalNumbers));
     }
 
-    edges.substitute(substitution);
+    edges.substitute(substitution, substituteTranscendentalNumbers);
 }
 void Automaton::registerTemplateEdge(std::shared_ptr<TemplateEdge> const& te) {
     edges.insertTemplateEdge(te);

--- a/src/storm/storage/jani/Automaton.cpp
+++ b/src/storm/storage/jani/Automaton.cpp
@@ -432,7 +432,7 @@ std::vector<storm::expressions::Expression> Automaton::getAllRangeExpressions() 
 }
 
 void Automaton::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
-                           bool const& substituteTranscendentalNumbers) {
+                           bool const substituteTranscendentalNumbers) {
     for (auto& functionDefinition : this->getFunctionDefinitions()) {
         functionDefinition.second.substitute(substitution, substituteTranscendentalNumbers);
     }

--- a/src/storm/storage/jani/Automaton.h
+++ b/src/storm/storage/jani/Automaton.h
@@ -284,7 +284,7 @@ class Automaton {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const substituteTranscendentalNumbers);
 
     /*!
      * Changes all variables in assignments based on the given mapping.

--- a/src/storm/storage/jani/Automaton.h
+++ b/src/storm/storage/jani/Automaton.h
@@ -284,7 +284,7 @@ class Automaton {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
 
     /*!
      * Changes all variables in assignments based on the given mapping.

--- a/src/storm/storage/jani/Edge.cpp
+++ b/src/storm/storage/jani/Edge.cpp
@@ -90,7 +90,7 @@ OrderedAssignments const& Edge::getAssignments() const {
     return templateEdge->getAssignments();
 }
 
-void Edge::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers) {
+void Edge::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const substituteTranscendentalNumbers) {
     if (this->hasRate()) {
         this->setRate(substituteJaniExpression(this->getRate(), substitution, substituteTranscendentalNumbers));
     }

--- a/src/storm/storage/jani/Edge.cpp
+++ b/src/storm/storage/jani/Edge.cpp
@@ -90,12 +90,12 @@ OrderedAssignments const& Edge::getAssignments() const {
     return templateEdge->getAssignments();
 }
 
-void Edge::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
+void Edge::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers) {
     if (this->hasRate()) {
-        this->setRate(substituteJaniExpression(this->getRate(), substitution));
+        this->setRate(substituteJaniExpression(this->getRate(), substitution, substituteTranscendentalNumbers));
     }
     for (auto& destination : destinations) {
-        destination.substitute(substitution);
+        destination.substitute(substitution, substituteTranscendentalNumbers);
     }
 }
 

--- a/src/storm/storage/jani/Edge.h
+++ b/src/storm/storage/jani/Edge.h
@@ -93,7 +93,7 @@ class Edge {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
 
     /*!
      * Retrieves a set of (global) variables that are written by at least one of the edge's destinations.

--- a/src/storm/storage/jani/Edge.h
+++ b/src/storm/storage/jani/Edge.h
@@ -93,7 +93,7 @@ class Edge {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const substituteTranscendentalNumbers);
 
     /*!
      * Retrieves a set of (global) variables that are written by at least one of the edge's destinations.

--- a/src/storm/storage/jani/EdgeContainer.cpp
+++ b/src/storm/storage/jani/EdgeContainer.cpp
@@ -95,7 +95,7 @@ void EdgeContainer::liftTransientDestinationAssignments(int64_t maxLevel) {
 }
 
 void EdgeContainer::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
-                               bool const& substituteTranscendentalNumbers) {
+                               bool const substituteTranscendentalNumbers) {
     for (auto& templateEdge : templates) {
         templateEdge->substitute(substitution, substituteTranscendentalNumbers);
     }

--- a/src/storm/storage/jani/EdgeContainer.cpp
+++ b/src/storm/storage/jani/EdgeContainer.cpp
@@ -94,12 +94,13 @@ void EdgeContainer::liftTransientDestinationAssignments(int64_t maxLevel) {
     }
 }
 
-void EdgeContainer::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
+void EdgeContainer::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                               bool const& substituteTranscendentalNumbers) {
     for (auto& templateEdge : templates) {
-        templateEdge->substitute(substitution);
+        templateEdge->substitute(substitution, substituteTranscendentalNumbers);
     }
     for (auto& edge : edges) {
-        edge.substitute(substitution);
+        edge.substitute(substitution, substituteTranscendentalNumbers);
     }
 }
 

--- a/src/storm/storage/jani/EdgeContainer.h
+++ b/src/storm/storage/jani/EdgeContainer.h
@@ -103,7 +103,7 @@ class EdgeContainer {
 
     std::set<uint64_t> getActionIndices() const;
 
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
     void liftTransientDestinationAssignments(int64_t maxLevel = 0);
     void pushAssignmentsToDestinations();
     void insertEdge(Edge const& e, uint64_t locStart, uint64_t locEnd);

--- a/src/storm/storage/jani/EdgeContainer.h
+++ b/src/storm/storage/jani/EdgeContainer.h
@@ -103,7 +103,7 @@ class EdgeContainer {
 
     std::set<uint64_t> getActionIndices() const;
 
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const substituteTranscendentalNumbers);
     void liftTransientDestinationAssignments(int64_t maxLevel = 0);
     void pushAssignmentsToDestinations();
     void insertEdge(Edge const& e, uint64_t locStart, uint64_t locEnd);

--- a/src/storm/storage/jani/EdgeDestination.cpp
+++ b/src/storm/storage/jani/EdgeDestination.cpp
@@ -40,8 +40,9 @@ OrderedAssignments const& EdgeDestination::getOrderedAssignments() const {
     return templateEdgeDestination.get().getOrderedAssignments();
 }
 
-void EdgeDestination::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
-    this->setProbability(substituteJaniExpression(this->getProbability(), substitution));
+void EdgeDestination::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                                 bool const& substituteTranscendentalNumbers) {
+    this->setProbability(substituteJaniExpression(this->getProbability(), substitution, substituteTranscendentalNumbers));
 }
 
 bool EdgeDestination::hasAssignment(Assignment const& assignment) const {

--- a/src/storm/storage/jani/EdgeDestination.cpp
+++ b/src/storm/storage/jani/EdgeDestination.cpp
@@ -41,7 +41,7 @@ OrderedAssignments const& EdgeDestination::getOrderedAssignments() const {
 }
 
 void EdgeDestination::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
-                                 bool const& substituteTranscendentalNumbers) {
+                                 bool const substituteTranscendentalNumbers) {
     this->setProbability(substituteJaniExpression(this->getProbability(), substitution, substituteTranscendentalNumbers));
 }
 

--- a/src/storm/storage/jani/EdgeDestination.h
+++ b/src/storm/storage/jani/EdgeDestination.h
@@ -34,7 +34,7 @@ class EdgeDestination {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
 
     /*!
      * Retrieves the mapping from variables to their assigned expressions that corresponds to the assignments

--- a/src/storm/storage/jani/EdgeDestination.h
+++ b/src/storm/storage/jani/EdgeDestination.h
@@ -34,7 +34,7 @@ class EdgeDestination {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const substituteTranscendentalNumbers);
 
     /*!
      * Retrieves the mapping from variables to their assigned expressions that corresponds to the assignments

--- a/src/storm/storage/jani/FunctionDefinition.cpp
+++ b/src/storm/storage/jani/FunctionDefinition.cpp
@@ -42,7 +42,7 @@ storm::expressions::Expression FunctionDefinition::call(std::vector<std::shared_
 }
 
 void FunctionDefinition::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
-                                    bool const& substituteTranscendentalNumbers) {
+                                    bool const substituteTranscendentalNumbers) {
     this->setFunctionBody(substituteJaniExpression(this->getFunctionBody(), substitution, substituteTranscendentalNumbers));
 }
 

--- a/src/storm/storage/jani/FunctionDefinition.cpp
+++ b/src/storm/storage/jani/FunctionDefinition.cpp
@@ -33,15 +33,17 @@ storm::expressions::Expression FunctionDefinition::call(std::vector<std::shared_
     // substitute the parameters in the function body
     STORM_LOG_THROW(arguments.size() == parameters.size(), storm::exceptions::InvalidArgumentException,
                     "The number of arguments does not match the number of parameters.");
+    const bool substituteTranscendentalNumbers = true;
     std::unordered_map<storm::expressions::Variable, storm::expressions::Expression> parameterSubstitution;
     for (uint64_t i = 0; i < arguments.size(); ++i) {
         parameterSubstitution.emplace(parameters[i], arguments[i]);
     }
-    return substituteJaniExpression(functionBody, parameterSubstitution);
+    return substituteJaniExpression(functionBody, parameterSubstitution, substituteTranscendentalNumbers);
 }
 
-void FunctionDefinition::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
-    this->setFunctionBody(substituteJaniExpression(this->getFunctionBody(), substitution));
+void FunctionDefinition::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                                    bool const& substituteTranscendentalNumbers) {
+    this->setFunctionBody(substituteJaniExpression(this->getFunctionBody(), substitution, substituteTranscendentalNumbers));
 }
 
 void FunctionDefinition::setFunctionBody(storm::expressions::Expression const& body) {

--- a/src/storm/storage/jani/FunctionDefinition.h
+++ b/src/storm/storage/jani/FunctionDefinition.h
@@ -49,7 +49,7 @@ class FunctionDefinition {
      */
     storm::expressions::Expression call(std::vector<std::shared_ptr<storm::expressions::BaseExpression const>> const& arguments) const;
 
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
 
    private:
     // The name of the function.

--- a/src/storm/storage/jani/FunctionDefinition.h
+++ b/src/storm/storage/jani/FunctionDefinition.h
@@ -49,7 +49,7 @@ class FunctionDefinition {
      */
     storm::expressions::Expression call(std::vector<std::shared_ptr<storm::expressions::BaseExpression const>> const& arguments) const;
 
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const substituteTranscendentalNumbers);
 
    private:
     // The name of the function.

--- a/src/storm/storage/jani/JaniLocationExpander.cpp
+++ b/src/storm/storage/jani/JaniLocationExpander.cpp
@@ -41,6 +41,7 @@ JaniLocationExpander::AutomatonAndIndices JaniLocationExpander::transformAutomat
     bool isGlobalVariable = !automaton.hasVariable(variableName);
     VariableSet &containingSet = isGlobalVariable ? newModel.getGlobalVariables() : newAutomaton.getVariables();
 
+    const bool substituteTranscendentalNumbers = false;
     auto &var = containingSet.getVariable(variableName);
     bool isBoundedInteger = var.getType().isBoundedType() && var.getType().asBoundedType().isIntegerType();
     bool isBool = var.getType().isBasicType() && var.getType().asBasicType().isBooleanType();
@@ -116,7 +117,7 @@ JaniLocationExpander::AutomatonAndIndices JaniLocationExpander::transformAutomat
                 substitutionMap[eliminatedExpressionVariable] = newIndices.variableDomain[i];
 
                 OrderedAssignments newAssignments = loc.getAssignments().clone();
-                newAssignments.substitute(substitutionMap);
+                newAssignments.substitute(substitutionMap, substituteTranscendentalNumbers);
 
                 Location newLoc(newLocationName, newAssignments);
 
@@ -140,7 +141,7 @@ JaniLocationExpander::AutomatonAndIndices JaniLocationExpander::transformAutomat
             substitutionMap[eliminatedExpressionVariable] = newIndices.variableDomain[currentValueIndex];
 
             uint64_t newSourceIndex = newValueAndLocation.second;
-            storm::expressions::Expression newGuard = substituteJaniExpression(edge.getGuard(), substitutionMap).simplify();
+            storm::expressions::Expression newGuard = substituteJaniExpression(edge.getGuard(), substitutionMap, substituteTranscendentalNumbers).simplify();
             if (!newGuard.containsVariables() && !newGuard.evaluateAsBool()) {
                 continue;
             }
@@ -153,7 +154,7 @@ JaniLocationExpander::AutomatonAndIndices JaniLocationExpander::transformAutomat
             std::vector<std::pair<uint64_t, storm::expressions::Expression>> destinationLocationsAndProbabilities;
             for (auto const &destination : edge.getDestinations()) {
                 OrderedAssignments oa(destination.getOrderedAssignments().clone());
-                oa.substitute(substitutionMap);
+                oa.substitute(substitutionMap, substituteTranscendentalNumbers);
 
                 int64_t newValueIndex = currentValueIndex;
                 for (auto const &assignment : oa) {
@@ -188,16 +189,18 @@ JaniLocationExpander::AutomatonAndIndices JaniLocationExpander::transformAutomat
 
                 TemplateEdgeDestination ted(oa);
                 templateEdge->addDestination(ted);
-                destinationLocationsAndProbabilities.emplace_back(newIndices.locationVariableValueMap[destination.getLocationIndex()][newValueIndex],
-                                                                  substituteJaniExpression(destination.getProbability(), substitutionMap));
+                destinationLocationsAndProbabilities.emplace_back(
+                    newIndices.locationVariableValueMap[destination.getLocationIndex()][newValueIndex],
+                    substituteJaniExpression(destination.getProbability(), substitutionMap, substituteTranscendentalNumbers));
             }
 
             if (!isEdgeInvalid) {
                 templateEdge->finalize(newModel);
-                newAutomaton.addEdge(storm::jani::Edge(
-                    newSourceIndex, edge.getActionIndex(),
-                    edge.hasRate() ? boost::optional<storm::expressions::Expression>(substituteJaniExpression(edge.getRate(), substitutionMap)) : boost::none,
-                    templateEdge, destinationLocationsAndProbabilities));
+                newAutomaton.addEdge(storm::jani::Edge(newSourceIndex, edge.getActionIndex(),
+                                                       edge.hasRate() ? boost::optional<storm::expressions::Expression>(substituteJaniExpression(
+                                                                            edge.getRate(), substitutionMap, substituteTranscendentalNumbers))
+                                                                      : boost::none,
+                                                       templateEdge, destinationLocationsAndProbabilities));
                 newAutomaton.registerTemplateEdge(templateEdge);
             }
         }

--- a/src/storm/storage/jani/Location.cpp
+++ b/src/storm/storage/jani/Location.cpp
@@ -45,12 +45,13 @@ void Location::setTimeProgressInvariant(storm::expressions::Expression const& ex
     timeProgressInvariant = expression;
 }
 
-void Location::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
+void Location::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                          bool const& substituteTranscendentalNumbers) {
     for (auto& assignment : assignments) {
-        assignment.substitute(substitution);
+        assignment.substitute(substitution, substituteTranscendentalNumbers);
     }
     if (hasTimeProgressInvariant()) {
-        setTimeProgressInvariant(substituteJaniExpression(getTimeProgressInvariant(), substitution));
+        setTimeProgressInvariant(substituteJaniExpression(getTimeProgressInvariant(), substitution, substituteTranscendentalNumbers));
     }
 }
 

--- a/src/storm/storage/jani/Location.cpp
+++ b/src/storm/storage/jani/Location.cpp
@@ -46,7 +46,7 @@ void Location::setTimeProgressInvariant(storm::expressions::Expression const& ex
 }
 
 void Location::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
-                          bool const& substituteTranscendentalNumbers) {
+                          bool const substituteTranscendentalNumbers) {
     for (auto& assignment : assignments) {
         assignment.substitute(substitution, substituteTranscendentalNumbers);
     }

--- a/src/storm/storage/jani/Location.h
+++ b/src/storm/storage/jani/Location.h
@@ -59,7 +59,7 @@ class Location {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
 
     /*!
      * Changes all variables in assignments based on the given mapping.

--- a/src/storm/storage/jani/Location.h
+++ b/src/storm/storage/jani/Location.h
@@ -59,7 +59,7 @@ class Location {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const substituteTranscendentalNumbers);
 
     /*!
      * Changes all variables in assignments based on the given mapping.

--- a/src/storm/storage/jani/Model.cpp
+++ b/src/storm/storage/jani/Model.cpp
@@ -1102,36 +1102,37 @@ Model& Model::replaceUnassignedVariablesWithConstants() {
 
 Model& Model::substituteConstantsInPlace() {
     // Gather all defining expressions of constants.
+    const bool substituteTrancendentalNumbers = true;
     std::map<storm::expressions::Variable, storm::expressions::Expression> constantSubstitution;
     for (auto& constant : this->getConstants()) {
         if (constant.hasConstraint()) {
-            constant.setConstraintExpression(substituteJaniExpression(constant.getConstraintExpression(), constantSubstitution));
+            constant.setConstraintExpression(
+                substituteJaniExpression(constant.getConstraintExpression(), constantSubstitution, substituteTrancendentalNumbers));
         }
         if (constant.isDefined()) {
-            constant.define(substituteJaniExpression(constant.getExpression(), constantSubstitution));
+            constant.define(substituteJaniExpression(constant.getExpression(), constantSubstitution, substituteTrancendentalNumbers));
             constantSubstitution[constant.getExpressionVariable()] = constant.getExpression();
         }
     }
 
     for (auto& functionDefinition : this->getGlobalFunctionDefinitions()) {
-        functionDefinition.second.substitute(constantSubstitution);
+        functionDefinition.second.substitute(constantSubstitution, substituteTrancendentalNumbers);
     }
 
     // Substitute constants in all global variables.
-    this->getGlobalVariables().substitute(constantSubstitution);
+    this->getGlobalVariables().substitute(constantSubstitution, substituteTrancendentalNumbers);
 
     // Substitute constants in initial states expression.
-    this->setInitialStatesRestriction(substituteJaniExpression(this->getInitialStatesRestriction(), constantSubstitution));
+    this->setInitialStatesRestriction(substituteJaniExpression(this->getInitialStatesRestriction(), constantSubstitution, substituteTrancendentalNumbers));
 
     for (auto& rewMod : this->getNonTrivialRewardExpressions()) {
-        rewMod.second = substituteJaniExpression(rewMod.second, constantSubstitution);
+        rewMod.second = substituteJaniExpression(rewMod.second, constantSubstitution, substituteTrancendentalNumbers);
     }
 
     // Substitute constants in variables of automata and their edges.
     for (auto& automaton : this->getAutomata()) {
-        automaton.substitute(constantSubstitution);
+        automaton.substitute(constantSubstitution, substituteTrancendentalNumbers);
     }
-
     return *this;
 }
 
@@ -1162,42 +1163,43 @@ std::map<storm::expressions::Variable, storm::expressions::Expression> Model::ge
     return result;
 }
 
-void Model::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
+void Model::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                       bool const& substituteTranscendentalNumbers) {
     // substitute in all defining expressions of constants
     for (auto& constant : this->getConstants()) {
         if (constant.hasConstraint()) {
-            constant.setConstraintExpression(substituteJaniExpression(constant.getConstraintExpression(), substitution));
+            constant.setConstraintExpression(substituteJaniExpression(constant.getConstraintExpression(), substitution, substituteTranscendentalNumbers));
         }
         if (constant.isDefined()) {
-            constant.define(substituteJaniExpression(constant.getExpression(), substitution));
+            constant.define(substituteJaniExpression(constant.getExpression(), substitution, substituteTranscendentalNumbers));
         }
     }
 
     for (auto& functionDefinition : this->getGlobalFunctionDefinitions()) {
-        functionDefinition.second.substitute(substitution);
+        functionDefinition.second.substitute(substitution, substituteTranscendentalNumbers);
     }
 
     // Substitute in all global variables.
     for (auto& variable : this->getGlobalVariables().getBoundedIntegerVariables()) {
-        variable.substitute(substitution);
+        variable.substitute(substitution, substituteTranscendentalNumbers);
     }
     for (auto& variable : this->getGlobalVariables().getArrayVariables()) {
-        variable.substitute(substitution);
+        variable.substitute(substitution, substituteTranscendentalNumbers);
     }
     for (auto& variable : this->getGlobalVariables().getClockVariables()) {
-        variable.substitute(substitution);
+        variable.substitute(substitution, substituteTranscendentalNumbers);
     }
 
     // Substitute in initial states expression.
-    this->setInitialStatesRestriction(substituteJaniExpression(this->getInitialStatesRestriction(), substitution));
+    this->setInitialStatesRestriction(substituteJaniExpression(this->getInitialStatesRestriction(), substitution, substituteTranscendentalNumbers));
 
     for (auto& rewMod : getNonTrivialRewardExpressions()) {
-        rewMod.second = substituteJaniExpression(rewMod.second, substitution);
+        rewMod.second = substituteJaniExpression(rewMod.second, substitution, substituteTranscendentalNumbers);
     }
 
     // Substitute in variables of automata and their edges.
     for (auto& automaton : this->getAutomata()) {
-        automaton.substitute(substitution);
+        automaton.substitute(substitution, substituteTranscendentalNumbers);
     }
 }
 

--- a/src/storm/storage/jani/Model.cpp
+++ b/src/storm/storage/jani/Model.cpp
@@ -1100,38 +1100,37 @@ Model& Model::replaceUnassignedVariablesWithConstants() {
     return *this;
 }
 
-Model& Model::substituteConstantsInPlace() {
+Model& Model::substituteConstantsInPlace(bool const& substituteTranscendentalNumbers) {
     // Gather all defining expressions of constants.
-    const bool substituteTrancendentalNumbers = true;
     std::map<storm::expressions::Variable, storm::expressions::Expression> constantSubstitution;
     for (auto& constant : this->getConstants()) {
         if (constant.hasConstraint()) {
             constant.setConstraintExpression(
-                substituteJaniExpression(constant.getConstraintExpression(), constantSubstitution, substituteTrancendentalNumbers));
+                substituteJaniExpression(constant.getConstraintExpression(), constantSubstitution, substituteTranscendentalNumbers));
         }
         if (constant.isDefined()) {
-            constant.define(substituteJaniExpression(constant.getExpression(), constantSubstitution, substituteTrancendentalNumbers));
+            constant.define(substituteJaniExpression(constant.getExpression(), constantSubstitution, substituteTranscendentalNumbers));
             constantSubstitution[constant.getExpressionVariable()] = constant.getExpression();
         }
     }
 
     for (auto& functionDefinition : this->getGlobalFunctionDefinitions()) {
-        functionDefinition.second.substitute(constantSubstitution, substituteTrancendentalNumbers);
+        functionDefinition.second.substitute(constantSubstitution, substituteTranscendentalNumbers);
     }
 
     // Substitute constants in all global variables.
-    this->getGlobalVariables().substitute(constantSubstitution, substituteTrancendentalNumbers);
+    this->getGlobalVariables().substitute(constantSubstitution, substituteTranscendentalNumbers);
 
     // Substitute constants in initial states expression.
-    this->setInitialStatesRestriction(substituteJaniExpression(this->getInitialStatesRestriction(), constantSubstitution, substituteTrancendentalNumbers));
+    this->setInitialStatesRestriction(substituteJaniExpression(this->getInitialStatesRestriction(), constantSubstitution, substituteTranscendentalNumbers));
 
     for (auto& rewMod : this->getNonTrivialRewardExpressions()) {
-        rewMod.second = substituteJaniExpression(rewMod.second, constantSubstitution, substituteTrancendentalNumbers);
+        rewMod.second = substituteJaniExpression(rewMod.second, constantSubstitution, substituteTranscendentalNumbers);
     }
 
     // Substitute constants in variables of automata and their edges.
     for (auto& automaton : this->getAutomata()) {
-        automaton.substitute(constantSubstitution, substituteTrancendentalNumbers);
+        automaton.substitute(constantSubstitution, substituteTranscendentalNumbers);
     }
     return *this;
 }
@@ -1139,14 +1138,14 @@ Model& Model::substituteConstantsInPlace() {
 Model Model::substituteConstants() const {
     Model result(*this);
     result.replaceUnassignedVariablesWithConstants();
-    result.substituteConstantsInPlace();
+    result.substituteConstantsInPlace(false);
     return result;
 }
 
 Model Model::substituteConstantsFunctions() const {
     Model result(*this);
     result.replaceUnassignedVariablesWithConstants();
-    result.substituteConstantsInPlace();
+    result.substituteConstantsInPlace(true);
     result.substituteFunctions();
     return result;
 }

--- a/src/storm/storage/jani/Model.cpp
+++ b/src/storm/storage/jani/Model.cpp
@@ -1265,6 +1265,11 @@ ModelFeatures Model::restrictToFeatures(ModelFeatures const& features, std::vect
         uncheckedFeatures.remove(ModelFeature::DerivedOperators);
     }
 
+    // There is no elimination of trigonometric operators
+    if (features.hasTrigonometricFunctions()) {
+        uncheckedFeatures.remove(ModelFeature::TrigonometricFunctions);
+    }
+
     return uncheckedFeatures;
 }
 

--- a/src/storm/storage/jani/Model.cpp
+++ b/src/storm/storage/jani/Model.cpp
@@ -1148,7 +1148,7 @@ Model Model::substituteConstants() const {
     return result;
 }
 
-Model Model::substituteConstantsFunctions() const {
+Model Model::substituteConstantsFunctionsTranscendentals() const {
     Model result(*this);
     result.replaceUnassignedVariablesWithConstants();
     result.substituteConstantsInPlace(true);

--- a/src/storm/storage/jani/Model.cpp
+++ b/src/storm/storage/jani/Model.cpp
@@ -1106,7 +1106,7 @@ Model& Model::replaceUnassignedVariablesWithConstants() {
     return *this;
 }
 
-Model& Model::substituteConstantsInPlace(bool const& substituteTranscendentalNumbers) {
+Model& Model::substituteConstantsInPlace(bool const substituteTranscendentalNumbers) {
     // Gather all defining expressions of constants.
     std::map<storm::expressions::Variable, storm::expressions::Expression> constantSubstitution;
     for (auto& constant : this->getConstants()) {
@@ -1168,8 +1168,7 @@ std::map<storm::expressions::Variable, storm::expressions::Expression> Model::ge
     return result;
 }
 
-void Model::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
-                       bool const& substituteTranscendentalNumbers) {
+void Model::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const substituteTranscendentalNumbers) {
     // substitute in all defining expressions of constants
     for (auto& constant : this->getConstants()) {
         if (constant.hasConstraint()) {

--- a/src/storm/storage/jani/Model.cpp
+++ b/src/storm/storage/jani/Model.cpp
@@ -1066,6 +1066,12 @@ Model Model::defineUndefinedConstants(std::map<storm::expressions::Variable, sto
                                 "Illegal type of expression defining constant '" << constant.getName() << "'.");
 
                 // Now define the constant.
+                if (constant.hasConstraint()) {
+                    // Constraints need to be evaluated before defining a constant.
+                    using SubMap = std::map<storm::expressions::Variable, storm::expressions::Expression>;
+                    storm::expressions::JaniExpressionSubstitutionVisitor<SubMap> transcendentalsVisitor(SubMap(), true);
+                    constant.setConstraintExpression(transcendentalsVisitor.substitute(constant.getConstraintExpression()));
+                }
                 constant.define(variableExpressionPair->second);
             }
         }

--- a/src/storm/storage/jani/Model.h
+++ b/src/storm/storage/jani/Model.h
@@ -439,7 +439,7 @@ class Model {
      * Substitutes all expression variables in all expressions of the model. The original model is not modified, but
      * instead a new model is created.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
 
     /*!
      * Substitutes all function calls with the corresponding function definition

--- a/src/storm/storage/jani/Model.h
+++ b/src/storm/storage/jani/Model.h
@@ -421,7 +421,7 @@ class Model {
     /*!
      * Substitutes all constants in all expressions of the model.
      */
-    Model& substituteConstantsInPlace(bool const& substituteTranscendentalNumbers);
+    Model& substituteConstantsInPlace(bool const substituteTranscendentalNumbers);
 
     /*!
      * Substitutes all constants in all expressions of the model. The original model is not modified, but
@@ -439,7 +439,7 @@ class Model {
      * Substitutes all expression variables in all expressions of the model. The original model is not modified, but
      * instead a new model is created.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const substituteTranscendentalNumbers);
 
     /*!
      * Substitutes all function calls with the corresponding function definition

--- a/src/storm/storage/jani/Model.h
+++ b/src/storm/storage/jani/Model.h
@@ -421,7 +421,7 @@ class Model {
     /*!
      * Substitutes all constants in all expressions of the model.
      */
-    Model& substituteConstantsInPlace();
+    Model& substituteConstantsInPlace(bool const& substituteTranscendentalNumbers);
 
     /*!
      * Substitutes all constants in all expressions of the model. The original model is not modified, but
@@ -451,7 +451,8 @@ class Model {
     /*!
      * 1. Tries to replace variables by constants (if possible).
      * 2. Substitutes all constants in all expressions of the model.
-     * 3. Afterwards, all function calls are substituted with the defining expression.
+     * 3. Substitutes transcendental numbers by their actual value
+     * 4. Afterwards, all function calls are substituted with the defining expression.
      * The original model is not modified, but  instead a new model is created.
      */
     Model substituteConstantsFunctions() const;

--- a/src/storm/storage/jani/Model.h
+++ b/src/storm/storage/jani/Model.h
@@ -455,7 +455,7 @@ class Model {
      * 4. Afterwards, all function calls are substituted with the defining expression.
      * The original model is not modified, but  instead a new model is created.
      */
-    Model substituteConstantsFunctions() const;
+    Model substituteConstantsFunctionsTranscendentals() const;
 
     /*!
      * Returns true if at least one array variable occurs in the model.

--- a/src/storm/storage/jani/ModelFeatures.cpp
+++ b/src/storm/storage/jani/ModelFeatures.cpp
@@ -15,6 +15,8 @@ std::string toString(ModelFeature const& modelFeature) {
             return "functions";
         case ModelFeature::StateExitRewards:
             return "state-exit-rewards";
+        case ModelFeature::TrigonometricFunctions:
+            return "trigonometric-functions";
     }
     STORM_LOG_ASSERT(false, "Unhandled model feature");
     return "Unhandled-feature";
@@ -50,6 +52,10 @@ bool ModelFeatures::hasStateExitRewards() const {
     return features.count(ModelFeature::StateExitRewards) > 0;
 }
 
+bool ModelFeatures::hasTrigonometricFunctions() const {
+    return features.count(ModelFeature::TrigonometricFunctions) > 0;
+}
+
 std::set<ModelFeature> const& ModelFeatures::asSet() const {
     return features;
 }
@@ -68,7 +74,12 @@ void ModelFeatures::remove(ModelFeature const& modelFeature) {
 }
 
 ModelFeatures getAllKnownModelFeatures() {
-    return ModelFeatures().add(ModelFeature::Arrays).add(ModelFeature::DerivedOperators).add(ModelFeature::Functions).add(ModelFeature::StateExitRewards);
+    return ModelFeatures()
+        .add(ModelFeature::Arrays)
+        .add(ModelFeature::DerivedOperators)
+        .add(ModelFeature::Functions)
+        .add(ModelFeature::StateExitRewards)
+        .add(ModelFeature::TrigonometricFunctions);
 }
 }  // namespace jani
 }  // namespace storm

--- a/src/storm/storage/jani/ModelFeatures.h
+++ b/src/storm/storage/jani/ModelFeatures.h
@@ -6,7 +6,7 @@
 namespace storm {
 namespace jani {
 
-enum class ModelFeature { Arrays, DerivedOperators, Functions, StateExitRewards };
+enum class ModelFeature { Arrays, DerivedOperators, Functions, StateExitRewards, TrigonometricFunctions };
 
 std::string toString(ModelFeature const& modelFeature);
 
@@ -18,6 +18,7 @@ class ModelFeatures {
     bool hasFunctions() const;
     bool hasDerivedOperators() const;
     bool hasStateExitRewards() const;
+    bool hasTrigonometricFunctions() const;
 
     // Returns true, if no model feature is enabled.
     bool empty() const;

--- a/src/storm/storage/jani/OrderedAssignments.cpp
+++ b/src/storm/storage/jani/OrderedAssignments.cpp
@@ -238,9 +238,10 @@ detail::ConstAssignments::iterator OrderedAssignments::end() const {
     return detail::ConstAssignments::make_iterator(allAssignments.end());
 }
 
-void OrderedAssignments::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
+void OrderedAssignments::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                                    bool const& substituteTranscendentalNumbers) {
     for (auto& assignment : allAssignments) {
-        assignment->substitute(substitution);
+        assignment->substitute(substitution, substituteTranscendentalNumbers);
     }
 }
 

--- a/src/storm/storage/jani/OrderedAssignments.cpp
+++ b/src/storm/storage/jani/OrderedAssignments.cpp
@@ -239,7 +239,7 @@ detail::ConstAssignments::iterator OrderedAssignments::end() const {
 }
 
 void OrderedAssignments::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
-                                    bool const& substituteTranscendentalNumbers) {
+                                    bool const substituteTranscendentalNumbers) {
     for (auto& assignment : allAssignments) {
         assignment->substitute(substitution, substituteTranscendentalNumbers);
     }

--- a/src/storm/storage/jani/OrderedAssignments.h
+++ b/src/storm/storage/jani/OrderedAssignments.h
@@ -139,7 +139,7 @@ class OrderedAssignments {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const substituteTranscendentalNumbers);
 
     /*!
      * Changes all variables in assignments based on the given mapping.

--- a/src/storm/storage/jani/OrderedAssignments.h
+++ b/src/storm/storage/jani/OrderedAssignments.h
@@ -139,7 +139,7 @@ class OrderedAssignments {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
 
     /*!
      * Changes all variables in assignments based on the given mapping.

--- a/src/storm/storage/jani/Property.cpp
+++ b/src/storm/storage/jani/Property.cpp
@@ -77,6 +77,10 @@ Property Property::substituteRewardModelNames(std::map<std::string, std::string>
     return Property(name, filterExpression.substituteRewardModelNames(rewardModelNameSubstitution), undefinedConstants, comment);
 }
 
+Property Property::substituteTranscendentalNumbers() const {
+    return Property(name, filterExpression.substituteTranscendentalNumbers(), undefinedConstants, comment);
+}
+
 Property Property::clone() const {
     return Property(name, filterExpression.clone(), undefinedConstants, comment);
 }

--- a/src/storm/storage/jani/Property.h
+++ b/src/storm/storage/jani/Property.h
@@ -78,6 +78,10 @@ class FilterExpression {
                                 statesFormula->substituteRewardModelNames(rewardModelNameSubstitution));
     }
 
+    FilterExpression substituteTranscendentalNumbers() const {
+        return FilterExpression(formula->substituteTranscendentalNumbers(), ft, statesFormula->substituteTranscendentalNumbers());
+    }
+
     FilterExpression clone() const {
         storm::logic::CloneVisitor cv;
         return FilterExpression(cv.clone(*formula), ft, cv.clone(*statesFormula));
@@ -131,6 +135,7 @@ class Property {
     Property substitute(std::function<storm::expressions::Expression(storm::expressions::Expression const&)> const& substitutionFunction) const;
     Property substituteLabels(std::map<std::string, std::string> const& labelSubstitution) const;
     Property substituteRewardModelNames(std::map<std::string, std::string> const& rewardModelNameSubstitution) const;
+    Property substituteTranscendentalNumbers() const;
     Property clone() const;
 
     FilterExpression const& getFilter() const;

--- a/src/storm/storage/jani/TemplateEdge.cpp
+++ b/src/storm/storage/jani/TemplateEdge.cpp
@@ -85,15 +85,16 @@ OrderedAssignments& TemplateEdge::getAssignments() {
     return assignments;
 }
 
-void TemplateEdge::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
-    guard = substituteJaniExpression(guard, substitution);
+void TemplateEdge::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                              bool const& substituteTranscendentalNumbers) {
+    guard = substituteJaniExpression(guard, substitution, substituteTranscendentalNumbers);
 
     for (auto& assignment : assignments) {
-        assignment.substitute(substitution);
+        assignment.substitute(substitution, substituteTranscendentalNumbers);
     }
 
     for (auto& destination : destinations) {
-        destination.substitute(substitution);
+        destination.substitute(substitution, substituteTranscendentalNumbers);
     }
 }
 

--- a/src/storm/storage/jani/TemplateEdge.cpp
+++ b/src/storm/storage/jani/TemplateEdge.cpp
@@ -86,7 +86,7 @@ OrderedAssignments& TemplateEdge::getAssignments() {
 }
 
 void TemplateEdge::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
-                              bool const& substituteTranscendentalNumbers) {
+                              bool const substituteTranscendentalNumbers) {
     guard = substituteJaniExpression(guard, substitution, substituteTranscendentalNumbers);
 
     for (auto& assignment : assignments) {

--- a/src/storm/storage/jani/TemplateEdge.h
+++ b/src/storm/storage/jani/TemplateEdge.h
@@ -55,7 +55,7 @@ class TemplateEdge {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
 
     /*!
      * Changes all variables in assignments based on the given mapping.

--- a/src/storm/storage/jani/TemplateEdge.h
+++ b/src/storm/storage/jani/TemplateEdge.h
@@ -55,7 +55,7 @@ class TemplateEdge {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const substituteTranscendentalNumbers);
 
     /*!
      * Changes all variables in assignments based on the given mapping.

--- a/src/storm/storage/jani/TemplateEdgeDestination.cpp
+++ b/src/storm/storage/jani/TemplateEdgeDestination.cpp
@@ -15,8 +15,9 @@ TemplateEdgeDestination::TemplateEdgeDestination(std::vector<Assignment> const& 
     // Intentionally left empty.
 }
 
-void TemplateEdgeDestination::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
-    assignments.substitute(substitution);
+void TemplateEdgeDestination::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                                         bool const& substituteTranscendentalNumbers) {
+    assignments.substitute(substitution, substituteTranscendentalNumbers);
 }
 
 void TemplateEdgeDestination::changeAssignmentVariables(std::map<Variable const*, std::reference_wrapper<Variable const>> const& remapping) {

--- a/src/storm/storage/jani/TemplateEdgeDestination.cpp
+++ b/src/storm/storage/jani/TemplateEdgeDestination.cpp
@@ -16,7 +16,7 @@ TemplateEdgeDestination::TemplateEdgeDestination(std::vector<Assignment> const& 
 }
 
 void TemplateEdgeDestination::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
-                                         bool const& substituteTranscendentalNumbers) {
+                                         bool const substituteTranscendentalNumbers) {
     assignments.substitute(substitution, substituteTranscendentalNumbers);
 }
 

--- a/src/storm/storage/jani/TemplateEdgeDestination.h
+++ b/src/storm/storage/jani/TemplateEdgeDestination.h
@@ -15,7 +15,7 @@ class TemplateEdgeDestination {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
 
     /*!
      * Changes all variables in assignments based on the given mapping.

--- a/src/storm/storage/jani/TemplateEdgeDestination.h
+++ b/src/storm/storage/jani/TemplateEdgeDestination.h
@@ -15,7 +15,7 @@ class TemplateEdgeDestination {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const substituteTranscendentalNumbers);
 
     /*!
      * Changes all variables in assignments based on the given mapping.

--- a/src/storm/storage/jani/Variable.cpp
+++ b/src/storm/storage/jani/Variable.cpp
@@ -61,7 +61,7 @@ void Variable::substitute(std::map<storm::expressions::Variable, storm::expressi
     if (this->hasInitExpression()) {
         this->setInitExpression(substituteJaniExpression(this->getInitExpression(), substitution, substituteTranscendentalNumbers));
     }
-    type->substitute(substitution);
+    type->substitute(substitution, substituteTranscendentalNumbers);
 }
 
 JaniType& Variable::getType() {

--- a/src/storm/storage/jani/Variable.cpp
+++ b/src/storm/storage/jani/Variable.cpp
@@ -56,9 +56,10 @@ void Variable::setInitExpression(storm::expressions::Expression const& initialEx
     this->init = initialExpression;
 }
 
-void Variable::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
+void Variable::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                          bool const& substituteTranscendentalNumbers) {
     if (this->hasInitExpression()) {
-        this->setInitExpression(substituteJaniExpression(this->getInitExpression(), substitution));
+        this->setInitExpression(substituteJaniExpression(this->getInitExpression(), substitution, substituteTranscendentalNumbers));
     }
     type->substitute(substitution);
 }

--- a/src/storm/storage/jani/Variable.cpp
+++ b/src/storm/storage/jani/Variable.cpp
@@ -57,7 +57,7 @@ void Variable::setInitExpression(storm::expressions::Expression const& initialEx
 }
 
 void Variable::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
-                          bool const& substituteTranscendentalNumbers) {
+                          bool const substituteTranscendentalNumbers) {
     if (this->hasInitExpression()) {
         this->setInitExpression(substituteJaniExpression(this->getInitExpression(), substitution, substituteTranscendentalNumbers));
     }

--- a/src/storm/storage/jani/Variable.h
+++ b/src/storm/storage/jani/Variable.h
@@ -82,7 +82,7 @@ class Variable {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const substituteTranscendentalNumbers);
 
     /**
      * Convenience functions to call the appropriate constructor and return a shared pointer to the variable.

--- a/src/storm/storage/jani/Variable.h
+++ b/src/storm/storage/jani/Variable.h
@@ -82,7 +82,7 @@ class Variable {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
 
     /**
      * Convenience functions to call the appropriate constructor and return a shared pointer to the variable.

--- a/src/storm/storage/jani/VariableSet.cpp
+++ b/src/storm/storage/jani/VariableSet.cpp
@@ -351,9 +351,10 @@ std::map<std::string, std::reference_wrapper<Variable const>> VariableSet::getNa
     return result;
 }
 
-void VariableSet::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
+void VariableSet::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                             bool const& substituteTranscendentalNumbers) {
     for (auto& variable : variables) {
-        variable->substitute(substitution);
+        variable->substitute(substitution, substituteTranscendentalNumbers);
     }
 }
 

--- a/src/storm/storage/jani/VariableSet.cpp
+++ b/src/storm/storage/jani/VariableSet.cpp
@@ -352,7 +352,7 @@ std::map<std::string, std::reference_wrapper<Variable const>> VariableSet::getNa
 }
 
 void VariableSet::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
-                             bool const& substituteTranscendentalNumbers) {
+                             bool const substituteTranscendentalNumbers) {
     for (auto& variable : variables) {
         variable->substitute(substitution, substituteTranscendentalNumbers);
     }

--- a/src/storm/storage/jani/VariableSet.h
+++ b/src/storm/storage/jani/VariableSet.h
@@ -261,7 +261,7 @@ class VariableSet {
      * The substitution does not apply to the variables itself, but to initial expressions, variable bounds, ...
      * @param substitution
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const substituteTranscendentalNumbers);
 
     /*!
      * Substitutes the actual variables according to the given substitution.

--- a/src/storm/storage/jani/VariableSet.h
+++ b/src/storm/storage/jani/VariableSet.h
@@ -261,7 +261,7 @@ class VariableSet {
      * The substitution does not apply to the variables itself, but to initial expressions, variable bounds, ...
      * @param substitution
      */
-    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution);
+    void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution, bool const& substituteTranscendentalNumbers);
 
     /*!
      * Substitutes the actual variables according to the given substitution.

--- a/src/storm/storage/jani/eliminator/ArrayEliminator.cpp
+++ b/src/storm/storage/jani/eliminator/ArrayEliminator.cpp
@@ -280,6 +280,11 @@ class ArrayReplacementsCollectorExpressionVisitor : public storm::expressions::E
             "Found Function call expression within an array expression. This is not expected since functions are expected to be eliminated at this point.");
     }
 
+    virtual boost::any visit(storm::expressions::TranscendentalNumberLiteralExpression const&, boost::any const&) override {
+        STORM_LOG_THROW(false, storm::exceptions::UnexpectedException, "Unexpected type of expression.");
+        return boost::any();
+    }
+
    private:
     storm::jani::Variable const& addReplacementVariable(std::vector<std::size_t> const& indices) {
         auto& manager = model.getExpressionManager();
@@ -799,6 +804,10 @@ class ArrayExpressionEliminationVisitor : public storm::expressions::ExpressionV
                         "Found Function call expression while eliminating array expressions. This is not expected since functions are expected to be "
                         "eliminated at this point.");
         return false;
+    }
+
+    virtual boost::any visit(storm::expressions::TranscendentalNumberLiteralExpression const& expression, boost::any const&) override {
+        return ResultType(expression.getSharedPointer());
     }
 
    private:

--- a/src/storm/storage/jani/eliminator/FunctionEliminator.cpp
+++ b/src/storm/storage/jani/eliminator/FunctionEliminator.cpp
@@ -212,6 +212,10 @@ class FunctionEliminationExpressionVisitor : public storm::expressions::Expressi
         return boost::any_cast<BaseExprPtr>(funDef->call(expression.getArguments()).getBaseExpression().accept(*this, data));
     }
 
+    virtual boost::any visit(storm::expressions::TranscendentalNumberLiteralExpression const& expression, boost::any const&) override {
+        return expression.getSharedPointer();
+    }
+
    private:
     std::unordered_map<std::string, FunctionDefinition> const* globalFunctions;
     std::unordered_map<std::string, FunctionDefinition> const* localFunctions;

--- a/src/storm/storage/jani/expressions/ConstructorArrayExpression.cpp
+++ b/src/storm/storage/jani/expressions/ConstructorArrayExpression.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<BaseExpression const> ConstructorArrayExpression::size() const {
 std::shared_ptr<BaseExpression const> ConstructorArrayExpression::at(uint64_t i) const {
     std::map<storm::expressions::Variable, storm::expressions::Expression> substitution;
     substitution.emplace(indexVar, this->getManager().integer(i));
-    return storm::jani::substituteJaniExpression(elementExpression->toExpression(), substitution, true).getBaseExpressionPointer();
+    return storm::jani::substituteJaniExpression(elementExpression->toExpression(), substitution, false).getBaseExpressionPointer();
 }
 
 std::shared_ptr<BaseExpression const> const& ConstructorArrayExpression::getElementExpression() const {

--- a/src/storm/storage/jani/expressions/ConstructorArrayExpression.cpp
+++ b/src/storm/storage/jani/expressions/ConstructorArrayExpression.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<BaseExpression const> ConstructorArrayExpression::size() const {
 std::shared_ptr<BaseExpression const> ConstructorArrayExpression::at(uint64_t i) const {
     std::map<storm::expressions::Variable, storm::expressions::Expression> substitution;
     substitution.emplace(indexVar, this->getManager().integer(i));
-    return storm::jani::substituteJaniExpression(elementExpression->toExpression(), substitution).getBaseExpressionPointer();
+    return storm::jani::substituteJaniExpression(elementExpression->toExpression(), substitution, true).getBaseExpressionPointer();
 }
 
 std::shared_ptr<BaseExpression const> const& ConstructorArrayExpression::getElementExpression() const {

--- a/src/storm/storage/jani/expressions/JaniExpressions.h
+++ b/src/storm/storage/jani/expressions/JaniExpressions.h
@@ -2,4 +2,5 @@
 #include "storm/storage/jani/expressions/ArrayAccessExpression.h"
 #include "storm/storage/jani/expressions/ConstructorArrayExpression.h"
 #include "storm/storage/jani/expressions/FunctionCallExpression.h"
+#include "storm/storage/jani/expressions/TranscendentalNumberLiteralExpression.h"
 #include "storm/storage/jani/expressions/ValueArrayExpression.h"

--- a/src/storm/storage/jani/expressions/TranscendentalNumberLiteralExpression.cpp
+++ b/src/storm/storage/jani/expressions/TranscendentalNumberLiteralExpression.cpp
@@ -1,0 +1,71 @@
+#include "storm/exceptions/UnexpectedException.h"
+
+#include "storm/storage/expressions/ExpressionManager.h"
+#include "storm/storage/jani/expressions/TranscendentalNumberLiteralExpression.h"
+#include "storm/storage/jani/visitor/JaniExpressionVisitor.h"
+
+#include "storm/utility/constants.h"
+
+namespace storm {
+namespace expressions {
+TranscendentalNumberLiteralExpression::TranscendentalNumberLiteralExpression(ExpressionManager const& manager, TranscendentalNumber const& value)
+    : BaseExpression(manager, manager.getRationalType()), value(value) {
+    // Intentionally left empty.
+}
+
+double TranscendentalNumberLiteralExpression::evaluateAsDouble(Valuation const*) const {
+    switch (value) {
+        case TranscendentalNumber::PI:
+            return M_PI;
+            break;
+        case TranscendentalNumber::E:
+            return std::exp(1.0);
+            break;
+        default:
+            STORM_LOG_THROW(false, storm::exceptions::UnexpectedException, "Unexpected constant value.");
+            break;
+    }
+}
+
+bool TranscendentalNumberLiteralExpression::isLiteral() const {
+    return true;
+}
+
+void TranscendentalNumberLiteralExpression::gatherVariables(std::set<storm::expressions::Variable>&) const {
+    // A constant value is not supposed to have any variable
+    return;
+}
+
+std::shared_ptr<BaseExpression const> TranscendentalNumberLiteralExpression::simplify() const {
+    // No further simplification for constant values
+    return this->shared_from_this();
+}
+
+boost::any TranscendentalNumberLiteralExpression::accept(ExpressionVisitor& visitor, boost::any const& data) const {
+    auto janiVisitor = dynamic_cast<JaniExpressionVisitor*>(&visitor);
+    STORM_LOG_ASSERT(janiVisitor != nullptr, "Visitor of jani expression should be of type JaniVisitor.");
+    STORM_LOG_THROW(janiVisitor != nullptr, storm::exceptions::UnexpectedException, "Visitor of jani expression should be of type JaniVisitor.");
+    return janiVisitor->visit(*this, data);
+}
+
+TranscendentalNumberLiteralExpression::TranscendentalNumber const& TranscendentalNumberLiteralExpression::getTranscendentalNumber() const {
+    return value;
+}
+
+std::string TranscendentalNumberLiteralExpression::asString() const {
+    switch (value) {
+        case TranscendentalNumber::PI:
+            return "π";
+        case TranscendentalNumber::E:
+            return "e";
+        default:
+            STORM_LOG_THROW(false, storm::exceptions::UnexpectedException, "Unexpected constant value.");
+    }
+    return "";
+}
+
+void TranscendentalNumberLiteralExpression::printToStream(std::ostream& stream) const {
+    stream << asString();
+}
+}  // namespace expressions
+}  // namespace storm

--- a/src/storm/storage/jani/expressions/TranscendentalNumberLiteralExpression.cpp
+++ b/src/storm/storage/jani/expressions/TranscendentalNumberLiteralExpression.cpp
@@ -9,7 +9,7 @@
 namespace storm {
 namespace expressions {
 TranscendentalNumberLiteralExpression::TranscendentalNumberLiteralExpression(ExpressionManager const& manager, TranscendentalNumber const& value)
-    : BaseExpression(manager, manager.getRationalType()), value(value) {
+    : BaseExpression(manager, manager.getTranscendentalNumberType()), value(value) {
     // Intentionally left empty.
 }
 

--- a/src/storm/storage/jani/expressions/TranscendentalNumberLiteralExpression.h
+++ b/src/storm/storage/jani/expressions/TranscendentalNumberLiteralExpression.h
@@ -1,0 +1,64 @@
+#ifndef STORM_STORAGE_EXPRESSIONS_TRANSCENDENTALNUMBERLITERALEXPRESSION_H_
+#define STORM_STORAGE_EXPRESSIONS_TRANSCENDENTALNUMBERLITERALEXPRESSION_H_
+
+#include "storm/storage/expressions/BaseExpression.h"
+#include "storm/storage/expressions/RationalLiteralExpression.h"
+#include "storm/utility/OsDetection.h"
+
+namespace storm {
+namespace expressions {
+class TranscendentalNumberLiteralExpression : public BaseExpression {
+   public:
+    /*!
+     * @brief Enum class to represent the supported TranscendentalNumbers
+     */
+    enum class TranscendentalNumber {
+        PI,  // π
+        E    // EulerNumber
+    };
+    /*!
+     * Creates a unary expression with the given return type and operand.
+     *
+     * @param manager The manager responsible for this expression.
+     * @param value The constant value assigned to the variable
+     */
+    TranscendentalNumberLiteralExpression(ExpressionManager const& manager, TranscendentalNumber const& value);
+
+    // Instantiate constructors and assignments with their default implementations.
+    TranscendentalNumberLiteralExpression(TranscendentalNumberLiteralExpression const& other) = default;
+    TranscendentalNumberLiteralExpression& operator=(TranscendentalNumberLiteralExpression const& other) = delete;
+    TranscendentalNumberLiteralExpression(TranscendentalNumberLiteralExpression&&) = default;
+    TranscendentalNumberLiteralExpression& operator=(TranscendentalNumberLiteralExpression&&) = delete;
+    virtual ~TranscendentalNumberLiteralExpression() = default;
+
+    // Override base class methods.
+    virtual double evaluateAsDouble(Valuation const* valuation = nullptr) const override;
+    virtual bool isLiteral() const override;
+    virtual void gatherVariables(std::set<storm::expressions::Variable>& variables) const override;
+    virtual std::shared_ptr<BaseExpression const> simplify() const override;
+    virtual boost::any accept(ExpressionVisitor& visitor, boost::any const& data) const override;
+
+    /*!
+     * @brief Getter for the constant value stored by the object
+     * @return A reference to the stored TranscendentalNumber
+     */
+    TranscendentalNumber const& getTranscendentalNumber() const;
+
+    /*!
+     * @brief Get the Transcendental number as string, like in the Jani file (single character)
+     * @return A string representing the transcendental number
+     */
+    std::string asString() const;
+
+   protected:
+    // Override base class method.
+    virtual void printToStream(std::ostream& stream) const override;
+
+   private:
+    // The operand of the unary expression.
+    const TranscendentalNumber value;
+};
+}  // namespace expressions
+}  // namespace storm
+
+#endif /* STORM_STORAGE_EXPRESSIONS_TRANSCENDENTALNUMBERLITERALEXPRESSION_H_ */

--- a/src/storm/storage/jani/traverser/ArrayExpressionFinder.cpp
+++ b/src/storm/storage/jani/traverser/ArrayExpressionFinder.cpp
@@ -78,6 +78,10 @@ class ArrayExpressionFinderExpressionVisitor : public storm::expressions::Expres
         }
         return false;
     }
+
+    virtual boost::any visit(storm::expressions::TranscendentalNumberLiteralExpression const&, boost::any const&) override {
+        return false;
+    }
 };
 
 class ArrayExpressionFinderTraverser : public ConstJaniTraverser {

--- a/src/storm/storage/jani/traverser/FunctionCallExpressionFinder.cpp
+++ b/src/storm/storage/jani/traverser/FunctionCallExpressionFinder.cpp
@@ -93,6 +93,10 @@ class FunctionCallExpressionFinderExpressionVisitor : public storm::expressions:
         }
         return boost::any();
     }
+
+    virtual boost::any visit(storm::expressions::TranscendentalNumberLiteralExpression const&, boost::any const&) override {
+        return boost::any();
+    }
 };
 
 class FunctionCallExpressionFinderTraverser : public ConstJaniTraverser {

--- a/src/storm/storage/jani/traverser/RewardModelInformation.cpp
+++ b/src/storm/storage/jani/traverser/RewardModelInformation.cpp
@@ -41,7 +41,7 @@ RewardModelInformation::RewardModelInformation(Model const& model, storm::expres
             }
         }
     }
-    auto initExpr = storm::jani::substituteJaniExpression(rewardModelExpression, initialSubstitution).simplify();
+    auto initExpr = storm::jani::substituteJaniExpression(rewardModelExpression, initialSubstitution, true).simplify();
     if (containsNonTransientVariable || initExpr.containsVariables() || !storm::utility::isZero(initExpr.evaluateAsRational())) {
         stateRewards = true;
         actionRewards = true;

--- a/src/storm/storage/jani/types/ArrayType.cpp
+++ b/src/storm/storage/jani/types/ArrayType.cpp
@@ -43,9 +43,10 @@ std::string ArrayType::getStringRepresentation() const {
     return "array[" + getBaseType().getStringRepresentation() + "]";
 }
 
-void ArrayType::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
-    JaniType::substitute(substitution);
-    baseType->substitute(substitution);
+void ArrayType::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                           bool const substituteTranscendentalNumbers) {
+    JaniType::substitute(substitution, substituteTranscendentalNumbers);
+    baseType->substitute(substitution, substituteTranscendentalNumbers);
 }
 
 std::unique_ptr<JaniType> ArrayType::clone() const {

--- a/src/storm/storage/jani/types/ArrayType.h
+++ b/src/storm/storage/jani/types/ArrayType.h
@@ -29,7 +29,8 @@ class ArrayType : public JaniType {
     uint64_t getNestingDegree() const;
 
     virtual std::string getStringRepresentation() const override;
-    virtual void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) override;
+    virtual void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                            bool const substituteTranscendentalNumbers) override;
     virtual std::unique_ptr<JaniType> clone() const override;
 
    private:

--- a/src/storm/storage/jani/types/BoundedType.cpp
+++ b/src/storm/storage/jani/types/BoundedType.cpp
@@ -63,13 +63,14 @@ storm::expressions::Expression const& BoundedType::getUpperBound() const {
     return this->upperBound;
 }
 
-void BoundedType::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
-    JaniType::substitute(substitution);
+void BoundedType::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                             bool const substituteTranscendentalNumbers) {
+    JaniType::substitute(substitution, substituteTranscendentalNumbers);
     if (this->hasLowerBound()) {
-        this->setLowerBound(substituteJaniExpression(this->getLowerBound(), substitution, true));
+        this->setLowerBound(substituteJaniExpression(this->getLowerBound(), substitution, substituteTranscendentalNumbers));
     }
     if (this->hasUpperBound()) {
-        this->setUpperBound(substituteJaniExpression(this->getUpperBound(), substitution, true));
+        this->setUpperBound(substituteJaniExpression(this->getUpperBound(), substitution, substituteTranscendentalNumbers));
     }
 }
 

--- a/src/storm/storage/jani/types/BoundedType.cpp
+++ b/src/storm/storage/jani/types/BoundedType.cpp
@@ -66,10 +66,10 @@ storm::expressions::Expression const& BoundedType::getUpperBound() const {
 void BoundedType::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) {
     JaniType::substitute(substitution);
     if (this->hasLowerBound()) {
-        this->setLowerBound(substituteJaniExpression(this->getLowerBound(), substitution));
+        this->setLowerBound(substituteJaniExpression(this->getLowerBound(), substitution, true));
     }
     if (this->hasUpperBound()) {
-        this->setUpperBound(substituteJaniExpression(this->getUpperBound(), substitution));
+        this->setUpperBound(substituteJaniExpression(this->getUpperBound(), substitution, true));
     }
 }
 

--- a/src/storm/storage/jani/types/BoundedType.h
+++ b/src/storm/storage/jani/types/BoundedType.h
@@ -19,7 +19,8 @@ class BoundedType : public JaniType {
     bool isNumericalType() const;  /// true iff type is either real or int (i.e. it's  always true but let's make it explicit)
 
     virtual std::string getStringRepresentation() const override;
-    virtual void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution) override;
+    virtual void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                            bool const substituteTranscendentalNumbers) override;
     virtual std::unique_ptr<JaniType> clone() const override;
 
     void setLowerBound(storm::expressions::Expression const& expression);

--- a/src/storm/storage/jani/types/JaniType.cpp
+++ b/src/storm/storage/jani/types/JaniType.cpp
@@ -68,7 +68,8 @@ ContinuousType& JaniType::asContinuousType() {
     return dynamic_cast<ContinuousType&>(*this);
 }
 
-void JaniType::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& /*substitution*/) {
+void JaniType::substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& /*substitution*/,
+                          bool const /*substituteTranscendentalNumbers*/) {
     // intentionally left empty
 }
 

--- a/src/storm/storage/jani/types/JaniType.h
+++ b/src/storm/storage/jani/types/JaniType.h
@@ -47,7 +47,8 @@ class JaniType {
     /*!
      * Substitutes all variables in all expressions according to the given substitution.
      */
-    virtual void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution);
+    virtual void substitute(std::map<storm::expressions::Variable, storm::expressions::Expression> const& substitution,
+                            bool const substituteTranscendentalNumbers);
 
     friend std::ostream& operator<<(std::ostream& stream, JaniType const& type);
 };

--- a/src/storm/storage/jani/visitor/JSONExporter.cpp
+++ b/src/storm/storage/jani/visitor/JSONExporter.cpp
@@ -634,6 +634,10 @@ std::string operatorTypeToJaniString(storm::expressions::OperatorType optype) {
             return "ceil";
         case OpType::Ite:
             return "ite";
+        case OpType::Sin:
+            return "sin";
+        case OpType::Cos:
+            return "cos";
         default:
             STORM_LOG_THROW(false, storm::exceptions::InvalidJaniException, "Operator not supported by Jani");
     }

--- a/src/storm/storage/jani/visitor/JSONExporter.cpp
+++ b/src/storm/storage/jani/visitor/JSONExporter.cpp
@@ -793,6 +793,12 @@ boost::any ExpressionToJson::visit(storm::expressions::FunctionCallExpression co
     return opDecl;
 }
 
+boost::any ExpressionToJson::visit(storm::expressions::TranscendentalNumberLiteralExpression const& expression, boost::any const&) {
+    ExportJsonType constantDecl;
+    constantDecl["constant"] = expression.asString();
+    return constantDecl;
+}
+
 void JsonExporter::toFile(storm::jani::Model const& janiModel, std::vector<storm::jani::Property> const& formulas, std::string const& filepath, bool checkValid,
                           bool compact) {
     std::ofstream stream;

--- a/src/storm/storage/jani/visitor/JSONExporter.h
+++ b/src/storm/storage/jani/visitor/JSONExporter.h
@@ -34,6 +34,7 @@ class ExpressionToJson : public storm::expressions::ExpressionVisitor, public st
     virtual boost::any visit(storm::expressions::ConstructorArrayExpression const& expression, boost::any const& data);
     virtual boost::any visit(storm::expressions::ArrayAccessExpression const& expression, boost::any const& data);
     virtual boost::any visit(storm::expressions::FunctionCallExpression const& expression, boost::any const& data);
+    virtual boost::any visit(storm::expressions::TranscendentalNumberLiteralExpression const& expression, boost::any const& data) override;
 
    private:
     ExpressionToJson(std::vector<storm::jani::Constant> const& constants, VariableSet const& globalVariables, VariableSet const& localVariables,

--- a/src/storm/storage/jani/visitor/JSONExporter.h
+++ b/src/storm/storage/jani/visitor/JSONExporter.h
@@ -34,7 +34,7 @@ class ExpressionToJson : public storm::expressions::ExpressionVisitor, public st
     virtual boost::any visit(storm::expressions::ConstructorArrayExpression const& expression, boost::any const& data);
     virtual boost::any visit(storm::expressions::ArrayAccessExpression const& expression, boost::any const& data);
     virtual boost::any visit(storm::expressions::FunctionCallExpression const& expression, boost::any const& data);
-    virtual boost::any visit(storm::expressions::TranscendentalNumberLiteralExpression const& expression, boost::any const& data) override;
+    virtual boost::any visit(storm::expressions::TranscendentalNumberLiteralExpression const& expression, boost::any const& data);
 
    private:
     ExpressionToJson(std::vector<storm::jani::Constant> const& constants, VariableSet const& globalVariables, VariableSet const& localVariables,

--- a/src/storm/storage/jani/visitor/JaniExpressionSubstitutionVisitor.cpp
+++ b/src/storm/storage/jani/visitor/JaniExpressionSubstitutionVisitor.cpp
@@ -99,7 +99,6 @@ boost::any JaniExpressionSubstitutionVisitor<MapType>::visit(TranscendentalNumbe
     if (shallSubstituteTranscendentalNumbers) {
         return std::const_pointer_cast<BaseExpression const>(
             std::shared_ptr<BaseExpression>(new RationalLiteralExpression(expression.getManager(), expression.evaluateAsDouble())));
-        ;
     }
     // No substitution requested for transcendental numbers
     return expression.getSharedPointer();

--- a/src/storm/storage/jani/visitor/JaniExpressionSubstitutionVisitor.cpp
+++ b/src/storm/storage/jani/visitor/JaniExpressionSubstitutionVisitor.cpp
@@ -7,7 +7,7 @@ namespace storm {
 namespace jani {
 storm::expressions::Expression substituteJaniExpression(storm::expressions::Expression const& expression,
                                                         std::map<storm::expressions::Variable, storm::expressions::Expression> const& identifierToExpressionMap,
-                                                        bool const& substituteTranscendentalNumbers) {
+                                                        bool const substituteTranscendentalNumbers) {
     return storm::expressions::JaniExpressionSubstitutionVisitor<std::map<storm::expressions::Variable, storm::expressions::Expression>>(
                identifierToExpressionMap, substituteTranscendentalNumbers)
         .substitute(expression);
@@ -16,7 +16,7 @@ storm::expressions::Expression substituteJaniExpression(storm::expressions::Expr
 storm::expressions::Expression substituteJaniExpression(
     storm::expressions::Expression const& expression,
     std::unordered_map<storm::expressions::Variable, storm::expressions::Expression> const& identifierToExpressionMap,
-    bool const& substituteTranscendentalNumbers) {
+    bool const substituteTranscendentalNumbers) {
     return storm::expressions::JaniExpressionSubstitutionVisitor<std::unordered_map<storm::expressions::Variable, storm::expressions::Expression>>(
                identifierToExpressionMap, substituteTranscendentalNumbers)
         .substitute(expression);
@@ -27,7 +27,7 @@ namespace expressions {
 
 template<typename MapType>
 JaniExpressionSubstitutionVisitor<MapType>::JaniExpressionSubstitutionVisitor(MapType const& variableToExpressionMapping,
-                                                                              bool const& substituteTranscendentalNumbers)
+                                                                              bool const substituteTranscendentalNumbers)
     : SubstitutionVisitor<MapType>(variableToExpressionMapping), shallSubstituteTranscendentalNumbers(substituteTranscendentalNumbers) {
     // Intentionally left empty.
 }

--- a/src/storm/storage/jani/visitor/JaniExpressionSubstitutionVisitor.h
+++ b/src/storm/storage/jani/visitor/JaniExpressionSubstitutionVisitor.h
@@ -7,11 +7,13 @@
 namespace storm {
 
 namespace jani {
-storm::expressions::Expression substituteJaniExpression(
-    storm::expressions::Expression const& expression, std::map<storm::expressions::Variable, storm::expressions::Expression> const& identifierToExpressionMap);
+storm::expressions::Expression substituteJaniExpression(storm::expressions::Expression const& expression,
+                                                        std::map<storm::expressions::Variable, storm::expressions::Expression> const& identifierToExpressionMap,
+                                                        bool const& substituteTranscendentalNumbers);
 storm::expressions::Expression substituteJaniExpression(
     storm::expressions::Expression const& expression,
-    std::unordered_map<storm::expressions::Variable, storm::expressions::Expression> const& identifierToExpressionMap);
+    std::unordered_map<storm::expressions::Variable, storm::expressions::Expression> const& identifierToExpressionMap,
+    bool const& substituteTranscendentalNumbers);
 }  // namespace jani
 
 namespace expressions {
@@ -22,14 +24,19 @@ class JaniExpressionSubstitutionVisitor : public SubstitutionVisitor<MapType>, p
      * Creates a new substitution visitor that uses the given map to replace variables.
      *
      * @param variableToExpressionMapping A mapping from variables to expressions.
+     * @param substituteTranscendentalNumbers Enables transcendental numbers substitution
      */
-    JaniExpressionSubstitutionVisitor(MapType const& variableToExpressionMapping);
+    JaniExpressionSubstitutionVisitor(MapType const& variableToExpressionMapping, bool const& substituteTranscendentalNumbers);
     using SubstitutionVisitor<MapType>::visit;
 
     virtual boost::any visit(ValueArrayExpression const& expression, boost::any const& data) override;
     virtual boost::any visit(ConstructorArrayExpression const& expression, boost::any const& data) override;
     virtual boost::any visit(ArrayAccessExpression const& expression, boost::any const& data) override;
     virtual boost::any visit(FunctionCallExpression const& expression, boost::any const& data) override;
+    virtual boost::any visit(TranscendentalNumberLiteralExpression const& expression, boost::any const& data) override;
+
+   protected:
+    const bool shallSubstituteTranscendentalNumbers;
 };
 }  // namespace expressions
 }  // namespace storm

--- a/src/storm/storage/jani/visitor/JaniExpressionSubstitutionVisitor.h
+++ b/src/storm/storage/jani/visitor/JaniExpressionSubstitutionVisitor.h
@@ -9,11 +9,11 @@ namespace storm {
 namespace jani {
 storm::expressions::Expression substituteJaniExpression(storm::expressions::Expression const& expression,
                                                         std::map<storm::expressions::Variable, storm::expressions::Expression> const& identifierToExpressionMap,
-                                                        bool const& substituteTranscendentalNumbers);
+                                                        bool const substituteTranscendentalNumbers);
 storm::expressions::Expression substituteJaniExpression(
     storm::expressions::Expression const& expression,
     std::unordered_map<storm::expressions::Variable, storm::expressions::Expression> const& identifierToExpressionMap,
-    bool const& substituteTranscendentalNumbers);
+    bool const substituteTranscendentalNumbers);
 }  // namespace jani
 
 namespace expressions {
@@ -26,7 +26,7 @@ class JaniExpressionSubstitutionVisitor : public SubstitutionVisitor<MapType>, p
      * @param variableToExpressionMapping A mapping from variables to expressions.
      * @param substituteTranscendentalNumbers Enables transcendental numbers substitution
      */
-    JaniExpressionSubstitutionVisitor(MapType const& variableToExpressionMapping, bool const& substituteTranscendentalNumbers);
+    JaniExpressionSubstitutionVisitor(MapType const& variableToExpressionMapping, bool const substituteTranscendentalNumbers);
     using SubstitutionVisitor<MapType>::visit;
 
     virtual boost::any visit(ValueArrayExpression const& expression, boost::any const& data) override;

--- a/src/storm/storage/jani/visitor/JaniExpressionVisitor.h
+++ b/src/storm/storage/jani/visitor/JaniExpressionVisitor.h
@@ -11,6 +11,7 @@ class JaniExpressionVisitor {
     virtual boost::any visit(ConstructorArrayExpression const& expression, boost::any const& data) = 0;
     virtual boost::any visit(ArrayAccessExpression const& expression, boost::any const& data) = 0;
     virtual boost::any visit(FunctionCallExpression const& expression, boost::any const& data) = 0;
+    virtual boost::any visit(TranscendentalNumberLiteralExpression const& expression, boost::any const& data) = 0;
 };
 }  // namespace expressions
 }  // namespace storm

--- a/src/storm/storage/jani/visitor/JaniReduceNestingExpressionVisitor.cpp
+++ b/src/storm/storage/jani/visitor/JaniReduceNestingExpressionVisitor.cpp
@@ -73,7 +73,7 @@ boost::any JaniReduceNestingExpressionVisitor::visit(FunctionCallExpression cons
 
 boost::any JaniReduceNestingExpressionVisitor::visit(TranscendentalNumberLiteralExpression const& expression, boost::any const& data) {
     // No substitution is required for constants
-    return expression;
+    return expression.getSharedPointer();
 }
 }  // namespace expressions
 }  // namespace storm

--- a/src/storm/storage/jani/visitor/JaniReduceNestingExpressionVisitor.cpp
+++ b/src/storm/storage/jani/visitor/JaniReduceNestingExpressionVisitor.cpp
@@ -70,5 +70,10 @@ boost::any JaniReduceNestingExpressionVisitor::visit(FunctionCallExpression cons
     return std::const_pointer_cast<BaseExpression const>(std::shared_ptr<BaseExpression>(
         new FunctionCallExpression(expression.getManager(), expression.getType(), expression.getFunctionIdentifier(), newArguments)));
 }
+
+boost::any JaniReduceNestingExpressionVisitor::visit(TranscendentalNumberLiteralExpression const& expression, boost::any const& data) {
+    // No substitution is required for constants
+    return expression;
+}
 }  // namespace expressions
 }  // namespace storm

--- a/src/storm/storage/jani/visitor/JaniReduceNestingExpressionVisitor.h
+++ b/src/storm/storage/jani/visitor/JaniReduceNestingExpressionVisitor.h
@@ -20,6 +20,7 @@ class JaniReduceNestingExpressionVisitor : public ReduceNestingVisitor, public J
     virtual boost::any visit(ConstructorArrayExpression const& expression, boost::any const& data) override;
     virtual boost::any visit(ArrayAccessExpression const& expression, boost::any const& data) override;
     virtual boost::any visit(FunctionCallExpression const& expression, boost::any const& data) override;
+    virtual boost::any visit(TranscendentalNumberLiteralExpression const& expression, boost::any const& data) override;
 };
 }  // namespace expressions
 }  // namespace storm

--- a/src/storm/storage/jani/visitor/JaniSyntacticalEqualityCheckVisitor.cpp
+++ b/src/storm/storage/jani/visitor/JaniSyntacticalEqualityCheckVisitor.cpp
@@ -72,5 +72,16 @@ boost::any JaniSyntacticalEqualityCheckVisitor::visit(FunctionCallExpression con
         return false;
     }
 }
+
+boost::any JaniSyntacticalEqualityCheckVisitor::visit(TranscendentalNumberLiteralExpression const& expression, boost::any const& data) {
+    BaseExpression const& otherBaseExpression = boost::any_cast<std::reference_wrapper<BaseExpression const>>(data).get();
+    auto const rhs = std::dynamic_pointer_cast<storm::expressions::TranscendentalNumberLiteralExpression const>(otherBaseExpression.getSharedPointer());
+    if (rhs) {
+        return expression.getTranscendentalNumber() == rhs->getTranscendentalNumber();
+    } else {
+        return false;
+    }
+}
+
 }  // namespace expressions
 }  // namespace storm

--- a/src/storm/storage/jani/visitor/JaniSyntacticalEqualityCheckVisitor.h
+++ b/src/storm/storage/jani/visitor/JaniSyntacticalEqualityCheckVisitor.h
@@ -21,6 +21,7 @@ class JaniSyntacticalEqualityCheckVisitor : public SyntacticalEqualityCheckVisit
     virtual boost::any visit(ConstructorArrayExpression const& expression, boost::any const& data) override;
     virtual boost::any visit(ArrayAccessExpression const& expression, boost::any const& data) override;
     virtual boost::any visit(FunctionCallExpression const& expression, boost::any const& data) override;
+    virtual boost::any visit(TranscendentalNumberLiteralExpression const& expression, boost::any const& data) override;
 };
 }  // namespace expressions
 }  // namespace storm

--- a/src/storm/storage/prism/Program.cpp
+++ b/src/storm/storage/prism/Program.cpp
@@ -442,7 +442,7 @@ std::map<storm::expressions::Variable, storm::expressions::Expression> Program::
 
     std::map<storm::expressions::Variable, storm::expressions::Expression> newSubstitution;
     for (auto const& substVarExpr : substitution) {
-        newSubstitution.emplace(substVarExpr.first, storm::jani::substituteJaniExpression(substVarExpr.second, renamingAsSubstitution));
+        newSubstitution.emplace(substVarExpr.first, storm::jani::substituteJaniExpression(substVarExpr.second, renamingAsSubstitution, false));
     }
     return newSubstitution;
 }

--- a/src/storm/storage/prism/ToJaniConverter.cpp
+++ b/src/storm/storage/prism/ToJaniConverter.cpp
@@ -122,11 +122,12 @@ storm::jani::Model ToJaniConverter::convert(storm::prism::Program const& program
                 functionBodySubstitution[var] = functionParameters.back().getExpression();
             }
             for (auto const& formulaVar : placeholdersInFormula) {
-                functionBodySubstitution[formulaVar] = storm::jani::substituteJaniExpression(formulaToFunctionCallMap[formulaVar], functionBodySubstitution);
+                functionBodySubstitution[formulaVar] =
+                    storm::jani::substituteJaniExpression(formulaToFunctionCallMap[formulaVar], functionBodySubstitution, false);
             }
 
             storm::jani::FunctionDefinition funDef(formula.getName(), formula.getType(), functionParameters,
-                                                   storm::jani::substituteJaniExpression(formula.getExpression(), functionBodySubstitution));
+                                                   storm::jani::substituteJaniExpression(formula.getExpression(), functionBodySubstitution, false));
             janiModel.addFunctionDefinition(funDef);
             auto functionCallExpression =
                 std::make_shared<storm::expressions::FunctionCallExpression>(*manager, formula.getType(), formula.getName(), functionArguments);
@@ -514,7 +515,7 @@ storm::jani::Model ToJaniConverter::convert(storm::prism::Program const& program
         // formula placeholders. Note that the formula placeholders of non-renamed modules are replaced later.
         if (program.getNumberOfFormulas() > 0 && module.isRenamedFromModule()) {
             auto renamedFormulaToFunctionCallMap = program.getSubstitutionForRenamedModule(module, formulaToFunctionCallMap);
-            automaton.substitute(renamedFormulaToFunctionCallMap);
+            automaton.substitute(renamedFormulaToFunctionCallMap, false);
         }
 
         janiModel.addAutomaton(automaton);
@@ -532,7 +533,7 @@ storm::jani::Model ToJaniConverter::convert(storm::prism::Program const& program
     // if there are formulas, replace the remaining placeholder variables by actual function calls in all expressions
     if (program.getNumberOfFormulas() > 0) {
         janiModel.getModelFeatures().add(storm::jani::ModelFeature::Functions);
-        janiModel.substitute(formulaToFunctionCallMap);
+        janiModel.substitute(formulaToFunctionCallMap, false);
     }
 
     janiModel.finalize();

--- a/src/storm/utility/constants.cpp
+++ b/src/storm/utility/constants.cpp
@@ -254,6 +254,16 @@ ValueType log10(ValueType const& number) {
 }
 
 template<typename ValueType>
+ValueType cos(ValueType const& number) {
+    return std::cos(number);
+}
+
+template<typename ValueType>
+ValueType sin(ValueType const& number) {
+    return std::sin(number);
+}
+
+template<typename ValueType>
 typename NumberTraits<ValueType>::IntegerType trunc(ValueType const& number) {
     return static_cast<typename NumberTraits<ValueType>::IntegerType>(std::trunc(number));
 }
@@ -417,6 +427,16 @@ ClnRationalNumber log(ClnRationalNumber const& number) {
 template<>
 ClnRationalNumber log10(ClnRationalNumber const& number) {
     return carl::log10(number);
+}
+
+template<>
+ClnRationalNumber cos(ClnRationalNumber const& number) {
+    return carl::cos(number);
+}
+
+template<>
+ClnRationalNumber sin(ClnRationalNumber const& number) {
+    return carl::sin(number);
 }
 
 template<>
@@ -622,6 +642,16 @@ GmpRationalNumber log(GmpRationalNumber const& number) {
 template<>
 GmpRationalNumber log10(GmpRationalNumber const& number) {
     return carl::log10(number);
+}
+
+template<>
+GmpRationalNumber cos(GmpRationalNumber const& number) {
+    return carl::cos(number);
+}
+
+template<>
+GmpRationalNumber sin(GmpRationalNumber const& number) {
+    return carl::sin(number);
 }
 
 template<>
@@ -955,6 +985,8 @@ template double ceil(double const& number);
 template double round(double const& number);
 template double log(double const& number);
 template double log10(double const& number);
+template double cos(double const& number);
+template double sin(double const& number);
 template typename NumberTraits<double>::IntegerType trunc(double const& number);
 template double mod(double const& first, double const& second);
 template std::string to_string(double const& value);

--- a/src/storm/utility/constants.h
+++ b/src/storm/utility/constants.h
@@ -168,6 +168,12 @@ template<typename ValueType>
 ValueType log10(ValueType const& number);
 
 template<typename ValueType>
+ValueType cos(ValueType const& number);
+
+template<typename ValueType>
+ValueType sin(ValueType const& number);
+
+template<typename ValueType>
 typename NumberTraits<ValueType>::IntegerType trunc(ValueType const& number);
 
 template<typename RationalType>

--- a/src/test/storm/builder/ExplicitJaniModelBuilderTest.cpp
+++ b/src/test/storm/builder/ExplicitJaniModelBuilderTest.cpp
@@ -59,6 +59,13 @@ TEST(ExplicitJaniModelBuilderTest, Dtmc) {
     model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
     EXPECT_EQ(1728ul, model->getNumberOfStates());
     EXPECT_EQ(2505ul, model->getNumberOfTransitions());
+
+    janiModel = storm::api::parseJaniModel(STORM_TEST_RESOURCES_DIR "/dtmc/test_trigonometry.jani").first;
+    auto constants = storm::utility::cli::parseConstantDefinitionString(janiModel.getManager(), "step_size_rad=0.523599");  // step_size = 30 deg
+    janiModel = janiModel.defineUndefinedConstants(constants);
+    model = storm::builder::ExplicitModelBuilder<double>(janiModel).build();
+    EXPECT_EQ(5ul, model->getNumberOfStates());
+    EXPECT_EQ(5ul, model->getNumberOfTransitions());
 }
 
 TEST(ExplicitJaniModelBuilderTest, pdtmc) {

--- a/src/test/storm/builder/ExplicitJaniModelBuilderTest.cpp
+++ b/src/test/storm/builder/ExplicitJaniModelBuilderTest.cpp
@@ -76,7 +76,7 @@ TEST(ExplicitJaniModelBuilderTest, pdtmc) {
     EXPECT_EQ(20ul, model->getNumberOfTransitions());
 
     janiModel = storm::api::parseJaniModel(STORM_TEST_RESOURCES_DIR "/pdtmc/die_array_nested.jani").first;
-    janiModel.substituteConstantsFunctions();
+    janiModel.substituteConstantsFunctionsTranscendentals();
     model = storm::builder::ExplicitModelBuilder<storm::RationalFunction>(janiModel).build();
     EXPECT_EQ(13ul, model->getNumberOfStates());
     EXPECT_EQ(20ul, model->getNumberOfTransitions());

--- a/src/test/storm/parser/JaniParserTest.cpp
+++ b/src/test/storm/parser/JaniParserTest.cpp
@@ -414,3 +414,14 @@ TEST(JaniParser, UnassignedVariablesTest) {
     EXPECT_TRUE(result.first.hasConstant("c"));
     EXPECT_EQ(2ul, result.first.getNumberOfAutomata());
 }
+
+TEST(JaniParser, TrigonometryAndTranscendentalNumbersTest) {
+    std::pair<storm::jani::Model, std::vector<storm::jani::Property>> result;
+    EXPECT_NO_THROW(result = storm::api::parseJaniModel(STORM_TEST_RESOURCES_DIR "/dtmc/test_trigonometry.jani"));
+    auto& model = result.first;
+    auto& properties = result.second;
+    EXPECT_EQ(storm::jani::ModelType::DTMC, model.getModelType());
+    EXPECT_EQ(model.getNumberOfAutomata(), 1U);
+    EXPECT_EQ(properties.size(), 1U);
+    EXPECT_NO_THROW(model.substitute({}, true));
+}

--- a/src/test/storm/parser/JaniParserTest.cpp
+++ b/src/test/storm/parser/JaniParserTest.cpp
@@ -422,6 +422,6 @@ TEST(JaniParser, TrigonometryAndTranscendentalNumbersTest) {
     auto& properties = result.second;
     EXPECT_EQ(storm::jani::ModelType::DTMC, model.getModelType());
     EXPECT_EQ(model.getNumberOfAutomata(), 1U);
-    EXPECT_EQ(properties.size(), 1U);
+    EXPECT_EQ(properties.size(), 2U);
     EXPECT_NO_THROW(model.substitute({}, true));
 }


### PR DESCRIPTION
This PR introduces support to the `sin` and `cos` operators, and to the PI and Euler number constants.

In particular, for the sin and cos operators I introduced a new expression type called `trigonometric`, that can be used later on in case other trigonometric operators will be integrated in storm. 

Please let me know if I missed any additional place where the aforementioned operators need to be defined.