### PR TITLE
Add warning in API concerning properties containing model variables

### DIFF
--- a/src/storm-parsers/api/properties.cpp
+++ b/src/storm-parsers/api/properties.cpp
@@ -10,6 +10,8 @@
 #include "storm/storage/jani/Property.h"
 #include "storm/storage/prism/Program.h"
 
+#include "storm/exceptions/WrongFormatException.h"
+
 #include "storm/logic/Formula.h"
 
 #include "storm/utility/cli.h"
@@ -43,10 +45,14 @@ std::vector<storm::jani::Property> parseProperties(storm::parser::FormulaParser&
 std::vector<storm::jani::Property> parseProperties(std::string const& inputString, boost::optional<std::set<std::string>> const& propertyFilter) {
     auto exprManager = std::make_shared<storm::expressions::ExpressionManager>();
     storm::parser::FormulaParser formulaParser(exprManager);
-    STORM_LOG_WARN(
-        "Parsing properties using only a string as input does not have access to model variables. Properties containing model variables will not be parsed "
-        "correctly.");
-    return parseProperties(formulaParser, inputString, propertyFilter);
+    try {
+        return parseProperties(formulaParser, inputString, propertyFilter);
+    } catch (storm::exceptions::WrongFormatException const& e) {
+        STORM_LOG_THROW(false, storm::exceptions::WrongFormatException,
+                        e.what() << "Note that the used API function does not have access to model variables. If the property you tried to parse contains "
+                                    "model variables, it will not "
+                                    "be parsed correctly.");
+    }
 }
 
 std::vector<storm::jani::Property> parsePropertiesForJaniModel(std::string const& inputString, storm::jani::Model const& model,

--- a/src/storm-parsers/api/properties.cpp
+++ b/src/storm-parsers/api/properties.cpp
@@ -43,6 +43,9 @@ std::vector<storm::jani::Property> parseProperties(storm::parser::FormulaParser&
 std::vector<storm::jani::Property> parseProperties(std::string const& inputString, boost::optional<std::set<std::string>> const& propertyFilter) {
     auto exprManager = std::make_shared<storm::expressions::ExpressionManager>();
     storm::parser::FormulaParser formulaParser(exprManager);
+    STORM_LOG_WARN(
+        "Parsing properties using only a string as input does not have access to model variables. Properties containing model variables will not be parsed "
+        "correctly.");
     return parseProperties(formulaParser, inputString, propertyFilter);
 }
 


### PR DESCRIPTION
The parseProperties function taking only a string as input is not able to parse properties containing model variables as these are not registered with the created ExpressionManager.
This is expected behaviour, however, the resulting error message of the form
```
ERROR (SpiritErrorHandler.h:27): Parsing error at 1:2:  expecting <basic path formula>, here:
	X (var = 0)]
	 ^
```
does not point to the actual problem, making debugging the issue difficult, in particular for inexperienced users.
This PR adds a warning to the function that makes the issue more apparent.

Thanks to @SvStein for bringing this to my attention.
