### PR TITLE
Added output of MEC statistics.

### DIFF
--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -646,6 +646,7 @@ boost::optional<SparseMdpEndComponentInformation<ValueType>> computeFixedPointSy
     if (doDecomposition) {
         // Compute the states that are in MECs.
         endComponentDecomposition = storm::storage::MaximalEndComponentDecomposition<ValueType>(transitionMatrix, backwardTransitions, candidateStates);
+        STORM_LOG_INFO(endComponentDecomposition.statistics(transitionMatrix.getRowGroupCount()));
     }
 
     // Only do more work if there are actually end-components.
@@ -1237,6 +1238,7 @@ boost::optional<SparseMdpEndComponentInformation<ValueType>> computeFixedPointSy
         // Then compute the states that are in MECs with zero reward.
         endComponentDecomposition =
             storm::storage::MaximalEndComponentDecomposition<ValueType>(transitionMatrix, backwardTransitions, candidateStates, zeroRewardChoices);
+        STORM_LOG_INFO(endComponentDecomposition.statistics(transitionMatrix.getRowGroupCount()));
     }
 
     // Only do more work if there are actually end-components.

--- a/src/storm/storage/MaximalEndComponentDecomposition.h
+++ b/src/storm/storage/MaximalEndComponentDecomposition.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "storm/models/sparse/NondeterministicModel.h"
 #include "storm/storage/Decomposition.h"
 #include "storm/storage/MaximalEndComponent.h"
@@ -95,6 +97,13 @@ class MaximalEndComponentDecomposition : public Decomposition<MaximalEndComponen
      * @param other The MEC decomposition from which to move-assign.
      */
     MaximalEndComponentDecomposition& operator=(MaximalEndComponentDecomposition&& other);
+
+    /*!
+     * Returns a string containing statistics about the MEC decomposition, e.g., the number of (trivial/non-trivial) MECs, the percentage of states on a MEC,
+     * etc.
+     * @param totalNumberOfStates the total number of states in the model
+     */
+    std::string statistics(uint64_t totalNumberOfStates) const;
 
    private:
     /*!


### PR DESCRIPTION
When computing reachability probabilities or expected total reachability rewards, the MEC quotient of the "maybestates"-subsystem might be computed (either because it is required by the used algorithm or because the user has set the `--force-require-unique`. If this is the case and the `--verbose` has been set, some interesting statistics on the MECs will now be printed.

This is only relevant for `Pmax` or `Rmin` queries.

```
storm-debug --prism sen3.prism --prop 'Pmax=? [ F  x=1 ]' --force-require-unique --verbose
Storm 1.8.2 (dev)
DEBUG BUILD

Date: Wed May 29 09:38:50 2024
Command line arguments: --prism sen3.prism --prop 'Pmax=? [ F  x=1 ]' --force-require-unique --verbose
Current working directory: /Users/tim/git/diss/benchmarking/multi/models/sen

Time for model input parsing: 0.024s.

Time for model construction: 2.153s.

-------------------------------------------------------------- 
Model type: 	MDP (sparse)
States: 	66051
Transitions: 	263526
Choices: 	245802
Reward Models:  none
State Labels: 	3 labels
   * init -> 1 item(s)
   * deadlock -> 0 item(s)
   * (x = 1) -> 2508 item(s)
Choice Labels: 	none
-------------------------------------------------------------- 

Model checking property "1": Pmax=? [F (x = 1)] ...
 INFO (SparseMdpPrctlHelper.cpp:699): Preprocessing: 5016 states with probability 1, 12969 with probability 0 (48066 states remaining).
 INFO (SparseMdpPrctlHelper.cpp:649): MEC decomposition statistics: There are 21016 MECs out of which 18108 are trivial, i.e., consist of a single state. 38868 out of 66051 states (58.8454%) are on some MEC. 20760 states (31.4303%) are on a non-trivial mec. The smallest non-trivial MEC has 2 states and the largest non-trivial MEC has 330 states.
 INFO (TopologicalMinMaxLinearEquationSolver.cpp:69): SCC decomposition computed in 0.021s. Found 29410 SCC(s) containing a total of 30214 states. Average SCC size is 1.02734.
Result (for initial states): 0.992
Time for model checking: 3.895s.
```