### PR TITLE
Fix always introducing the unexplored label. Fixes #559.

### DIFF
--- a/src/storm/generator/NextStateGenerator.cpp
+++ b/src/storm/generator/NextStateGenerator.cpp
@@ -220,7 +220,9 @@ storm::models::sparse::StateLabeling NextStateGenerator<ValueType, StateType>::l
     };
     addSpecialLabel("init", initialStateIndices);
     addSpecialLabel("deadlock", deadlockStateIndices);
-    addSpecialLabel("unexplored", unexploredStateIndices);
+    if (!unexploredStateIndices.empty()) {
+        addSpecialLabel("unexplored", unexploredStateIndices);
+    }
     if (this->options.isAddOverlappingGuardLabelSet()) {
         STORM_LOG_THROW(!result.containsLabel("overlap_guards"), storm::exceptions::WrongFormatException,
                         "Label 'overlap_guards' is reserved when adding overlapping guard labels");


### PR DESCRIPTION
```
./bin/storm --prism ../resources/examples/testfiles/dtmc/die.pm --state-limit 5
```

now introduces the `unexplored` label

```
-------------------------------------------------------------- 
Model type: 	DTMC (sparse)
States: 	5
Transitions: 	7
Reward Models:  none
State Labels: 	3 labels
   * unexplored -> 3 item(s)
   * deadlock -> 0 item(s)
   * init -> 1 item(s)
Choice Labels: 	none
-------------------------------------------------------------- 
```

while the invocation without a state limit does not:

```
 ./bin/storm --prism ../resources/examples/testfiles/dtmc/die.pm                
```

```
-------------------------------------------------------------- 
Model type: 	DTMC (sparse)
States: 	13
Transitions: 	20
Reward Models:  none
State Labels: 	2 labels
   * deadlock -> 0 item(s)
   * init -> 1 item(s)
Choice Labels: 	none
-------------------------------------------------------------- 
```