### PR TITLE
Follow general output precision in DFT approximation

### DIFF
--- a/src/storm-dft/modelchecker/DFTModelChecker.cpp
+++ b/src/storm-dft/modelchecker/DFTModelChecker.cpp
@@ -371,13 +371,11 @@ typename DFTModelChecker<ValueType>::dft_results DFTModelChecker<ValueType>::che
                              "Under-approximation " << approxResult.first << " is greater than over-approximation " << approxResult.second);
             totalTimer.stop();
             if (printInfo && dftIOSettings.isShowDftStatisticsSet()) {
-                std::cout << "Result after iteration " << (iteration + 1) << ": (" << std::setprecision(10) << approxResult.first << ", " << approxResult.second
-                          << ")\n";
+                std::cout << "Result after iteration " << (iteration + 1) << ": (" << approxResult.first << ", " << approxResult.second << ")\n";
                 printTimings();
                 std::cout << '\n';
             } else {
-                STORM_LOG_DEBUG("Result after iteration " << (iteration + 1) << ": (" << std::setprecision(10) << approxResult.first << ", "
-                                                          << approxResult.second << ")");
+                STORM_LOG_DEBUG("Result after iteration " << (iteration + 1) << ": (" << approxResult.first << ", " << approxResult.second << ")");
             }
 
             totalTimer.start();

--- a/src/storm/utility/initialize.cpp
+++ b/src/storm/utility/initialize.cpp
@@ -21,6 +21,14 @@ void initializeLogger() {
     sink->setFormatter(fptr);
 }
 
+/*!
+ * Set number of digits for printing output.
+ * @param digits Number of digits to print.
+ */
+void setOutputDigits(int digits) {
+    std::cout.precision(digits);
+}
+
 void setUp() {
     initializeLogger();
     setOutputDigits(10);
@@ -28,10 +36,6 @@ void setUp() {
 
 void cleanUp() {
     // Intentionally left empty.
-}
-
-void setOutputDigits(int digits) {
-    std::cout.precision(digits);
 }
 
 void setOutputDigitsFromGeneralPrecision(double precision) {

--- a/src/storm/utility/initialize.h
+++ b/src/storm/utility/initialize.h
@@ -20,12 +20,6 @@ void setUp();
 void cleanUp();
 
 /*!
- * Set number of digits for printing output.
- * @param digits Number of digits to print.
- */
-void setOutputDigits(int digits);
-
-/*!
  * Set number of digits for printing output from given precision requirement.
  * For a precision of 1e-n we output at least n digits.
  * @param precision General precision.


### PR DESCRIPTION
- The DFTModelChecker specified its own precision instead of following the default.
- Made `setOutputDigits` private.