### PR TITLE
Misc solver fixes

### DIFF
--- a/src/storm/settings/modules/GmmxxEquationSolverSettings.cpp
+++ b/src/storm/settings/modules/GmmxxEquationSolverSettings.cpp
@@ -25,7 +25,7 @@ const std::string GmmxxEquationSolverSettings::maximalIterationsOptionShortName 
 const std::string GmmxxEquationSolverSettings::precisionOptionName = "precision";
 
 GmmxxEquationSolverSettings::GmmxxEquationSolverSettings() : ModuleSettings(moduleName) {
-    std::vector<std::string> methods = {"bicgstab", "qmr", "gmres", "jacobi"};
+    std::vector<std::string> methods = {"bicgstab", "qmr", "gmres"};
     this->addOption(storm::settings::OptionBuilder(moduleName, techniqueOptionName, true,
                                                    "The method to be used for solving linear equation systems with the gmm++ engine.")
                         .setIsAdvanced()

--- a/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
@@ -367,8 +367,9 @@ MinMaxLinearEquationSolverRequirements IterativeMinMaxLinearEquationSolver<Value
         // Rational search needs to approach the solution from below.
         requirements.requireLowerBounds();
         // The solution needs to be unique in case of minimizing or in cases where we want a scheduler.
-        if (!this->hasUniqueSolution() &&
-            (env.solver().minMax().isForceRequireUnique() || !direction || direction.get() == OptimizationDirection::Minimize || this->isTrackSchedulerSet())) {
+        if (!this->hasUniqueSolution()) {
+            // RationalSearch guesses and verifies a fixpoint and terminates once a fixpoint is found. To ensure that the guessed fixpoint is the
+            // correct one, we enforce uniqueness.
             requirements.requireUniqueSolution();
         }
     } else if (method == MinMaxMethod::PolicyIteration) {


### PR DESCRIPTION
This PR provides minor fixes related to solvers:

- gmmxx settings: removed jacobi method from possible options
- Rational Search always requires a unique solution
- VI2PI: configure VI environment, flag requirements of VI solver as checked