### PR TITLE
Use 4 threads in CI

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -11,8 +11,8 @@ on:
   pull_request:
 
 env:
-  # GitHub runners currently have two cores
-  NR_JOBS: "2"
+  # GitHub runners currently have 4 cores
+  NR_JOBS: "4"
 
 jobs:
   # Perform in-depth tests with different configurations

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -12,8 +12,8 @@ env:
   BASE_IMG: "movesrwth/carl-storm:ci-release"
   STORM_GIT_URL: "${{ github.server_url }}/${{ github.repository }}.git"
   STORM_BRANCH: "master"
-  # github runners currently have two cores
-  NR_JOBS: "2"
+  # GitHub runners currently have 4 cores
+  NR_JOBS: "4"
 
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
     if: github.repository_owner == 'moves-rwth'
     steps:
       - name: Init Docker
-        run: sudo docker run -d -it --name storm --privileged ${BASE_IMG}
+        run: sudo docker run -d -it --name storm ${BASE_IMG}
 
         # We should not do partial updates :/
         # but we need to install some dependencies

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -10,8 +10,8 @@ on:
         default: 'x.y.z'
 
 env:
-  # GitHub runners currently have two cores
-  NR_JOBS: "2"
+  # GitHub runners currently have 4 cores
+  NR_JOBS: "4"
 
 jobs:
   deploy:

--- a/doc/offline_package.md
+++ b/doc/offline_package.md
@@ -51,7 +51,7 @@ cd storm
 mkdir -p build
 cd build
 cmake ..
-make storm-main -j$THREADS
+make storm-cli -j$THREADS
 cd ../../
 
 echo "Installation successfull."


### PR DESCRIPTION
Increased number of Github runners from 2 to 4. Leads to faster CI runs (see [old](https://github.com/moves-rwth/storm/actions/runs/10026195486/usage) and [new](https://github.com/volkm/storm/actions/runs/10056576731/usage) timings).