### PR TITLE
Add --not-graph-preserving flag

### DIFF
--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -572,14 +572,14 @@ std::shared_ptr<storm::models::sparse::Model<ValueType>> preprocessSparseMarkovA
 template<typename ValueType>
 std::shared_ptr<storm::models::sparse::Model<ValueType>> preprocessSparseModelBisimulation(
     std::shared_ptr<storm::models::sparse::Model<ValueType>> const& model, SymbolicInput const& input,
-    storm::settings::modules::BisimulationSettings const& bisimulationSettings) {
+    storm::settings::modules::BisimulationSettings const& bisimulationSettings, bool graphPreserving = true) {
     storm::storage::BisimulationType bisimType = storm::storage::BisimulationType::Strong;
     if (bisimulationSettings.isWeakBisimulationSet()) {
         bisimType = storm::storage::BisimulationType::Weak;
     }
 
     STORM_LOG_INFO("Performing bisimulation minimization...");
-    return storm::api::performBisimulationMinimization<ValueType>(model, createFormulasToRespect(input.properties), bisimType);
+    return storm::api::performBisimulationMinimization<ValueType>(model, createFormulasToRespect(input.properties), bisimType, graphPreserving);
 }
 
 template<typename ValueType>

--- a/src/storm-pars-cli/storm-pars.cpp
+++ b/src/storm-pars-cli/storm-pars.cpp
@@ -82,6 +82,19 @@ std::vector<storm::storage::ParameterRegion<ValueType>> parseRegions(std::shared
     } else if (regionSettings.isRegionBoundSet()) {
         result = storm::api::createRegion<ValueType>(regionSettings.getRegionBoundString(), *model);
     }
+    if (!regionSettings.isNotGraphPreservingSet()) {
+        for (auto const& region : result) {
+            for (auto const& variable : region.getVariables()) {
+                if (region.getLowerBoundary(variable) <= storm::utility::zero<typename storm::utility::parametric::CoefficientType<ValueType>::type>() ||
+                    region.getUpperBoundary(variable) >= storm::utility::one<typename storm::utility::parametric::CoefficientType<ValueType>::type>()) {
+                    STORM_LOG_WARN(
+                        "Region" << region
+                                 << " appears to not preserve the graph structure of the parametric model. If this is the case, --not-graph-preserving.");
+                    break;
+                }
+            }
+        }
+    }
     return result;
 }
 
@@ -202,6 +215,7 @@ PreprocessResult preprocessSparseModel(std::shared_ptr<storm::models::sparse::Mo
     auto parametricSettings = storm::settings::getModule<storm::settings::modules::ParametricSettings>();
     auto transformationSettings = storm::settings::getModule<storm::settings::modules::TransformationSettings>();
     auto monSettings = storm::settings::getModule<storm::settings::modules::MonotonicitySettings>();
+    auto regionSettings = storm::settings::getModule<storm::settings::modules::RegionSettings>();
 
     PreprocessResult result(model, false);
     // TODO: why only simplify in these modes
@@ -218,8 +232,8 @@ PreprocessResult preprocessSparseModel(std::shared_ptr<storm::models::sparse::Mo
     }
 
     if (mpi.applyBisimulation) {
-        result.model =
-            storm::cli::preprocessSparseModelBisimulation(result.model->template as<storm::models::sparse::Model<ValueType>>(), input, bisimulationSettings);
+        result.model = storm::cli::preprocessSparseModelBisimulation(result.model->template as<storm::models::sparse::Model<ValueType>>(), input,
+                                                                     bisimulationSettings, !regionSettings.isNotGraphPreservingSet());
         result.changed = true;
     }
 
@@ -394,6 +408,7 @@ void processInputWithValueTypeAndDdlib(cli::SymbolicInput& input, storm::cli::Mo
     auto parSettings = storm::settings::getModule<storm::settings::modules::ParametricSettings>();
     auto monSettings = storm::settings::getModule<storm::settings::modules::MonotonicitySettings>();
     auto sampleSettings = storm::settings::getModule<storm::settings::modules::SamplingSettings>();
+    auto regionSettings = storm::settings::getModule<storm::settings::modules::RegionSettings>();
 
     STORM_LOG_THROW(mpi.engine == storm::utility::Engine::Sparse || mpi.engine == storm::utility::Engine::Hybrid || mpi.engine == storm::utility::Engine::Dd,
                     storm::exceptions::InvalidSettingsException, "The selected engine is not supported for parametric models.");
@@ -457,6 +472,7 @@ void processInputWithValueTypeAndDdlib(cli::SymbolicInput& input, storm::cli::Mo
         STORM_LOG_INFO("Solution function mode started.");
         STORM_LOG_THROW(regions.empty(), storm::exceptions::InvalidSettingsException,
                         "Solution function computations cannot be restricted to specific regions");
+        STORM_LOG_ERROR_COND(!regionSettings.isNotGraphPreservingSet(), "Solution function computations assume graph preservation.");
 
         if (model->isSparseModel()) {
             computeSolutionFunctionsWithSparseEngine(model->as<storm::models::sparse::Model<ValueType>>(), input);

--- a/src/storm-pars/settings/modules/RegionSettings.cpp
+++ b/src/storm-pars/settings/modules/RegionSettings.cpp
@@ -14,6 +14,7 @@ const std::string RegionSettings::moduleName = "region";
 const std::string regionOptionName = "region";
 const std::string regionShortOptionName = "reg";
 const std::string regionBoundOptionName = "regionbound";
+const std::string notGraphPreservingName = "not-graph-preserving";
 
 RegionSettings::RegionSettings() : ModuleSettings(moduleName) {
     this->addOption(storm::settings::OptionBuilder(moduleName, regionOptionName, false, "Sets the region(s) considered for analysis.")
@@ -27,6 +28,10 @@ RegionSettings::RegionSettings() : ModuleSettings(moduleName) {
                         .addArgument(storm::settings::ArgumentBuilder::createStringArgument(
                                          "regionbound", "The bound for the region result for all variables: 0+bound <= var <=1-bound")
                                          .build())
+                        .build());
+
+    this->addOption(storm::settings::OptionBuilder(moduleName, notGraphPreservingName, false,
+                                                   "Enables mode in which the region might not preserve the graph structure of the parametric model.")
                         .build());
 }
 
@@ -44,6 +49,10 @@ bool RegionSettings::isRegionBoundSet() const {
 
 std::string RegionSettings::getRegionBoundString() const {
     return this->getOption(regionBoundOptionName).getArgumentByName("regionbound").getValueAsString();
+}
+
+bool RegionSettings::isNotGraphPreservingSet() const {
+    return this->getOption(notGraphPreservingName).getHasOptionBeenSet();
 }
 
 }  // namespace modules

--- a/src/storm-pars/settings/modules/RegionSettings.h
+++ b/src/storm-pars/settings/modules/RegionSettings.h
@@ -36,6 +36,11 @@ class RegionSettings : public ModuleSettings {
      */
     std::string getRegionBoundString() const;
 
+    /*!
+     * Retrieves whether non-graph-preserving mode is enabled
+     */
+    bool isNotGraphPreservingSet() const;
+
     const static std::string moduleName;
 };
 

--- a/src/storm/api/bisimulation.h
+++ b/src/storm/api/bisimulation.h
@@ -19,9 +19,9 @@ namespace api {
 template<typename ModelType>
 std::shared_ptr<ModelType> performDeterministicSparseBisimulationMinimization(std::shared_ptr<ModelType> model,
                                                                               std::vector<std::shared_ptr<storm::logic::Formula const>> const& formulas,
-                                                                              storm::storage::BisimulationType type) {
+                                                                              storm::storage::BisimulationType type, bool graphPreserving = true) {
     typename storm::storage::DeterministicModelBisimulationDecomposition<ModelType>::Options options;
-    if (!formulas.empty()) {
+    if (!formulas.empty() && graphPreserving) {
         options = typename storm::storage::DeterministicModelBisimulationDecomposition<ModelType>::Options(*model, formulas);
     }
     options.setType(type);
@@ -34,9 +34,9 @@ std::shared_ptr<ModelType> performDeterministicSparseBisimulationMinimization(st
 template<typename ModelType>
 std::shared_ptr<ModelType> performNondeterministicSparseBisimulationMinimization(std::shared_ptr<ModelType> model,
                                                                                  std::vector<std::shared_ptr<storm::logic::Formula const>> const& formulas,
-                                                                                 storm::storage::BisimulationType type) {
+                                                                                 storm::storage::BisimulationType type, bool graphPreserving = true) {
     typename storm::storage::NondeterministicModelBisimulationDecomposition<ModelType>::Options options;
-    if (!formulas.empty()) {
+    if (!formulas.empty() && graphPreserving) {
         options = typename storm::storage::NondeterministicModelBisimulationDecomposition<ModelType>::Options(*model, formulas);
     }
     options.setType(type);
@@ -49,7 +49,7 @@ std::shared_ptr<ModelType> performNondeterministicSparseBisimulationMinimization
 template<typename ValueType>
 std::shared_ptr<storm::models::sparse::Model<ValueType>> performBisimulationMinimization(
     std::shared_ptr<storm::models::sparse::Model<ValueType>> const& model, std::vector<std::shared_ptr<storm::logic::Formula const>> const& formulas,
-    storm::storage::BisimulationType type = storm::storage::BisimulationType::Strong) {
+    storm::storage::BisimulationType type = storm::storage::BisimulationType::Strong, bool graphPreserving = true) {
     STORM_LOG_THROW(
         model->isOfType(storm::models::ModelType::Dtmc) || model->isOfType(storm::models::ModelType::Ctmc) || model->isOfType(storm::models::ModelType::Mdp),
         storm::exceptions::NotSupportedException, "Bisimulation minimization is currently only available for DTMCs, CTMCs and MDPs.");
@@ -59,13 +59,13 @@ std::shared_ptr<storm::models::sparse::Model<ValueType>> performBisimulationMini
 
     if (model->isOfType(storm::models::ModelType::Dtmc)) {
         return performDeterministicSparseBisimulationMinimization<storm::models::sparse::Dtmc<ValueType>>(
-            model->template as<storm::models::sparse::Dtmc<ValueType>>(), formulas, type);
+            model->template as<storm::models::sparse::Dtmc<ValueType>>(), formulas, type, graphPreserving);
     } else if (model->isOfType(storm::models::ModelType::Ctmc)) {
         return performDeterministicSparseBisimulationMinimization<storm::models::sparse::Ctmc<ValueType>>(
-            model->template as<storm::models::sparse::Ctmc<ValueType>>(), formulas, type);
+            model->template as<storm::models::sparse::Ctmc<ValueType>>(), formulas, type, graphPreserving);
     } else {
         return performNondeterministicSparseBisimulationMinimization<storm::models::sparse::Mdp<ValueType>>(
-            model->template as<storm::models::sparse::Mdp<ValueType>>(), formulas, type);
+            model->template as<storm::models::sparse::Mdp<ValueType>>(), formulas, type, graphPreserving);
     }
 }
 


### PR DESCRIPTION
## Why this flag

I ran into the issue that bisimulation chooses the measure-driven initial partition mode for until formulas, which assumes that all instantiations of a parametric model are graph-preserving. I added a flag `--not-graph-preserving` to `storm-pars` which changes this mode to the label-based initial partitions. It further throws an error when trying to compute a solution function, which also assumes that all instantiations are graph-preserving. If the input region appears to be non-graph-preserving (we cannot know for sure) and the flag is not set, I added a warning. This is currently not reachable, as `parseRegions` throws an error anyway, as no methods are currently implemented that support non-graph-preserving regions.

## Demonstration

Consider the following pMC:

```
dtmc

const p;

module nongraphpreserving
	s : [0..3] init 0;
	
	[] s=0 -> p : (s'=1) + 1-p : (s'=3);
	[] s=1 -> p : (s'=1) + 1-p : (s'=2);
	[] s=2 -> 1 : (s'=2);
	[] s=3 -> 1 : (s'=3);
endmodule

label "target" = s=2;
```

Behavior of storm:
```
./bin/storm-pars --prism non_graph_preserving.pm -prop "P=? [F \"target\"]" --mode sampling --samples "p=1"
Result (initial states) for instance [p=1]: 0

# Incorrect result when using bisim without the flag
./bin/storm-pars --prism non_graph_preserving.pm -prop "P=? [F \"target\"]" --mode sampling --samples "p=1" -bisim
Result (initial states) for instance [p=1]: 1

./bin/storm-pars --prism non_graph_preserving.pm -prop "P=? [F \"target\"]" --mode sampling --samples "p=1" -bisim --not-graph-preserving
Result (initial states) for instance [p=1]: 0
```

Original pMC:
![pmc_orig](https://github.com/user-attachments/assets/645fc64e-0adf-4a3d-88db-3c3459f69462)
after incorrect transformation:
![pmc_bisim](https://github.com/user-attachments/assets/0f3158cd-b8f7-4607-ac8c-6b8a8a7fd043)
