### PR TITLE
Fixed issue in computation of cumulative rewards

### DIFF
--- a/resources/examples/testfiles/ctmc/simple1.sm
+++ b/resources/examples/testfiles/ctmc/simple1.sm
@@ -1,0 +1,11 @@
+ctmc
+
+module main
+x : [0..1] init 0;
+[] x=0 -> 6 : (x'=1);
+endmodule
+
+rewards
+	x=0: 1;
+endrewards
+

--- a/src/test/storm/modelchecker/csl/CtmcCslModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/csl/CtmcCslModelCheckerTest.cpp
@@ -392,6 +392,39 @@ TYPED_TEST(CtmcCslModelCheckerTest, Tandem) {
     EXPECT_NEAR(this->parseNumber("262.85103824276308"), this->getQuantitativeResultAtInitialState(model, result), this->precision());
 }
 
+TYPED_TEST(CtmcCslModelCheckerTest, simple1) {
+    std::string formulasString = "P=? [ F<=0.5 x=1 ]";
+    formulasString += "; R=? [ C<=0.1 ]";
+    formulasString += "; R=? [ C<=1 ]";
+    formulasString += "; R=? [ C<=10 ]";
+
+    auto modelFormulas = this->buildModelFormulas(STORM_TEST_RESOURCES_DIR "/ctmc/simple1.sm", formulasString);
+    auto model = std::move(modelFormulas.first);
+    auto tasks = this->getTasks(modelFormulas.second);
+    EXPECT_EQ(2ul, model->getNumberOfStates());
+    EXPECT_EQ(2ul, model->getNumberOfTransitions());
+    ASSERT_EQ(model->getType(), storm::models::ModelType::Ctmc);
+    auto checker = this->createModelChecker(model);
+    std::unique_ptr<storm::modelchecker::CheckResult> result;
+
+    uint64_t propertyIndex = 0;
+    auto expected = this->parseNumber("0.9502129316");  // integrate  6* e^(-6*t) dt from 0 to 0.5 = 1 - 1/(e^3)
+    result = checker->check(this->env(), tasks[propertyIndex++]);
+    EXPECT_NEAR(expected, this->getQuantitativeResultAtInitialState(model, result), this->precision());
+
+    expected = this->parseNumber("0.075198060651");  // integrate min(t,0.1) * 6* e^(-6*t) dt from 0 to infty = 1/6 - 1/(6*e^0.6)
+    result = checker->check(this->env(), tasks[propertyIndex++]);
+    EXPECT_NEAR(expected, this->getQuantitativeResultAtInitialState(model, result), this->precision());
+
+    expected = this->parseNumber("0.1662535413");  // =  1/6 - 1/(6*e^6)
+    result = checker->check(this->env(), tasks[propertyIndex++]);
+    EXPECT_NEAR(expected, this->getQuantitativeResultAtInitialState(model, result), this->precision());
+
+    expected = this->parseNumber("0.16666666667");  // = 1/6 - 1/(6*e^60)
+    result = checker->check(this->env(), tasks[propertyIndex++]);
+    EXPECT_NEAR(expected, this->getQuantitativeResultAtInitialState(model, result), this->precision());
+}
+
 TYPED_TEST(CtmcCslModelCheckerTest, simple2) {
     std::string formulasString = "R{\"rew1\"}=? [ C ]";
     formulasString += "; R{\"rew2\"}=? [ C ]";


### PR DESCRIPTION
There was a problem with computing `R=?[C<=t]`-like properties on CTMCs. With the rather simple 2-state model

```
ctmc

module main
x : [0..1] init 0;
[] x=0 -> 6 : (x'=1);
endmodule

rewards
	x=0: 1;
endreward
```

we currently get

```console

Model checking property "1": R=? [C<=1/10] ...
Result (for initial states): inf
Time for model checking: 0.000s.
```

This PR fixes the issue and adds the model as a test case.

The problem was that we are supposed to scale the values obtained *before* the left truncation point. 
However, the case where the left truncation point is 0 was handled incorrectly: Essentially the scaling had been applied twice: once when multiplying with `foxGlynnResult.weights.front()` in what is now line 705 and then again with `foxGlynnResult.totalWeight` in line 737.

I also improved numerical stability in the weight adjustment. The previous implementation sometimes resulted in negative weights because the weights were summed up in a non-optimal order.