### PR TITLE
Minor improvements for steady-state properties:

### DIFF
--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -954,20 +954,26 @@ inline void printModelCheckingProperty(storm::jani::Property const& property) {
 }
 
 template<typename ValueType>
-void printResult(std::unique_ptr<storm::modelchecker::CheckResult> const& result, storm::jani::Property const& property,
-                 storm::utility::Stopwatch* watch = nullptr) {
+void printResult(std::unique_ptr<storm::modelchecker::CheckResult> const& result, storm::logic::Formula const& filterStatesFormula,
+                 storm::modelchecker::FilterType const& filterType, storm::utility::Stopwatch* watch = nullptr) {
     if (result) {
         std::stringstream ss;
-        ss << "'" << *property.getFilter().getStatesFormula() << "'";
+        ss << "'" << filterStatesFormula << "'";
         STORM_PRINT((storm::utility::resources::isTerminate() ? "Result till abort" : "Result")
-                    << " (for " << (property.getFilter().getStatesFormula()->isInitialFormula() ? "initial" : ss.str()) << " states): ");
-        printFilteredResult<ValueType>(result, property.getFilter().getFilterType());
+                    << " (for " << (filterStatesFormula.isInitialFormula() ? "initial" : ss.str()) << " states): ");
+        printFilteredResult<ValueType>(result, filterType);
         if (watch) {
             STORM_PRINT("Time for model checking: " << *watch << ".\n");
         }
     } else {
         STORM_LOG_ERROR("Property is unsupported by selected engine/settings.\n");
     }
+}
+
+template<typename ValueType>
+void printResult(std::unique_ptr<storm::modelchecker::CheckResult> const& result, storm::jani::Property const& property,
+                 storm::utility::Stopwatch* watch = nullptr) {
+    printResult<ValueType>(result, *property.getFilter().getStatesFormula(), property.getFilter().getFilterType(), watch);
 }
 
 using VerificationCallbackType = std::function<std::unique_ptr<storm::modelchecker::CheckResult>(std::shared_ptr<storm::logic::Formula const> const& formula,
@@ -1062,38 +1068,32 @@ void computeStateValues(std::string const& description, std::function<std::uniqu
         STORM_LOG_ERROR("Computation had no result.");
         return;
     }
-    watch.stop();
     // Now process the (potentially filtered) result
     if (input.properties.empty()) {
         // Do not apply any filtering, consider result for *all* states
         postprocessingCallback(result);
-        STORM_PRINT((storm::utility::resources::isTerminate() ? "Result till abort: " : "Result: ") << *result << '\n');
-        STORM_PRINT("Time for model checking: " << watch << ".\n");
+        printResult<ValueType>(result, *storm::logic::Formula::getTrueFormula(), storm::modelchecker::FilterType::VALUES, &watch);
     } else {
         // Each property identifies a subset of states to which we restrict (aka filter) the state-value result to
         auto const& properties = input.preprocessedProperties ? input.preprocessedProperties.get() : input.properties;
-        for (auto const& property : properties) {
+        for (uint64_t propertyIndex = 0; propertyIndex < properties.size(); ++propertyIndex) {
+            auto const& property = properties[propertyIndex];
             // As the property serves as filter, it should (a) be qualitative and should (b) not consider a filter itself.
             if (!property.getRawFormula()->hasQualitativeResult()) {
                 STORM_LOG_ERROR("Property " << property.getRawFormula() << " can not be used for filtering states as it does not have a qualitative result.");
                 continue;
             }
-            STORM_LOG_WARN_COND(property.getFilter().isDefault(), "Ignoring filter of property " << property << " as those are unsupported in this context.");
 
             // Invoke verification algorithm on filtering property
-            printModelCheckingProperty(property);
-            storm::utility::Stopwatch propertyWatch(true);
             auto propertyFilter = verifyProperty<ValueType>(property.getRawFormula(), storm::logic::Formula::getTrueFormula(), verificationCallback);
-            propertyWatch.stop();
-            propertyWatch.add(watch);
 
             if (propertyFilter) {
                 // Filter and process result
                 std::unique_ptr<storm::modelchecker::CheckResult> filteredResult = result->clone();
                 filteredResult->filter(propertyFilter->asQualitativeCheckResult());
                 postprocessingCallback(filteredResult);
-                STORM_PRINT((storm::utility::resources::isTerminate() ? "Result till abort: " : "Result: ") << *filteredResult << '\n');
-                STORM_PRINT("Time for model checking: " << propertyWatch << ".\n");
+                printResult<ValueType>(filteredResult, *property.getRawFormula(), property.getFilter().getFilterType(),
+                                       propertyIndex == properties.size() - 1 ? &watch : nullptr);
             }
         }
     }


### PR DESCRIPTION
* Allow using topological solvers when computing steady-state probabilities in a BSCC with the EVT-based approach.
* Streamline CLI output and handle non-default filter types

For example, this invocation shows us the fraction of time each individual philosopher eats:

```console
storm-debug --jani philosophers4.jani --steadystate  --exact --prop 'filter(sum,eat1=1,true); filter(sum,eat2=1,true); filter(sum,eat3=1,true); filter(sum,eat4=1,true)'
Storm 1.8.2 (dev)
DEBUG BUILD

Date: Tue Aug 20 11:30:08 2024
Command line arguments: --jani philosophers4.jani --steadystate --exact --prop 'filter(sum,eat1=1,true); filter(sum,eat2=1,true); filter(sum,eat3=1,true); filter(sum,eat4=1,true)'
Current working directory: /Users/tim/philosophers

Time for model input parsing: 0.003s.

Time for model construction: 0.016s.

-------------------------------------------------------------- 
Model type: 	CTMC (sparse)
States: 	29
Transitions: 	72
Reward Models:  none
State Labels: 	6 labels
   * deadlock -> 0 item(s)
   * init -> 1 item(s)
   * (eat4 = 1) -> 7 item(s)
   * (eat3 = 1) -> 4 item(s)
   * (eat2 = 1) -> 3 item(s)
   * (eat1 = 1) -> 5 item(s)
Choice Labels: 	none
-------------------------------------------------------------- 

Computing steady-state probabilities ...
Result (for '(eat1 = 1)' states): 1264485277/16384334634 (approx. 0.07717648017)
Result (for '(eat2 = 1)' states): 1264485277/16384334634 (approx. 0.07717648017)
Result (for '(eat3 = 1)' states): 2498293909/16384334634 (approx. 0.1524806448)
Result (for '(eat4 = 1)' states): 726880166/2730722439 (approx. 0.2661860303)
Time for model checking: 0.002s.
```