### PR TITLE
Bump build system

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -174,7 +174,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: ["debian-11", "debian-12", "ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04"]
+        distro: ["debian-12", "ubuntu-22.04", "ubuntu-24.04"]
         buildType: ["Release"]
     steps:
       - name: Git clone

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.22)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 # Set project name
 project (storm CXX C)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,39 +157,30 @@ set(STORM_TEST_RESOURCES_DIR "${PROJECT_SOURCE_DIR}/resources/examples/testfiles
 # Auto-detect operating system.
 set(MACOSX 0)
 set(LINUX 0)
+set(APPLE_SILICON 0)
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	# Mac OS
 	set(OPERATING_SYSTEM "Mac OS")
         set(MACOSX 1)
+	if(${CMAKE_SYSTEM_PROCESSOR} MATCHES arm64)
+		set(APPLE_SILICON 1)
+	endif()
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    # Linux
+	# Linux
 	set(OPERATING_SYSTEM "Linux")
         set(LINUX 1)
 elseif(WIN32)
-    # Assuming Windows.
-    set(OPERATING_SYSTEM "Windows")
+	# Assuming Windows.
+	set(OPERATING_SYSTEM "Windows")
 else()
-    message(WARNING "We are unsure about your operating system.")
-    set(OPERATING_SYSTEM "Linux")
-    set(LINUX 1)
+	message(WARNING "We are unsure about your operating system.")
+	set(OPERATING_SYSTEM "Linux")
+	set(LINUX 1)
 ENDIF()
 message(STATUS "Storm - Detected operating system ${OPERATING_SYSTEM}.")
 
 set(SHIPPED_CARL_USE_CLN_NUMBERS ON)
 set(SHIPPED_CARL_USE_GINAC ON)
-# Detect Apple Silicon and adjust settings
-if(APPLE AND ${CMAKE_SYSTEM_PROCESSOR} MATCHES arm64)
-	message(STATUS "Storm - Detected that target system uses Apple Silicon.")
-	message(WARNING "Compiling natively on Apple Silicon is experimental. Please report issues to support@stormchecker.org. For more information visit https://www.stormchecker.org/documentation/obtain-storm/apple-silicon.html")
-	set(APPLE_SILICON 1)
-	if(STORM_USE_CLN_EA OR STORM_USE_CLN_RF)
-		message(WARNING "CLN and GiNaC are currently not supported on Apple Silicon-based architectures. Disabling Storm and carl usage of the libraries.")
-		set(STORM_USE_CLN_EA OFF)
-		set(STORM_USE_CLN_RF OFF)
-	endif()
-	set(SHIPPED_CARL_USE_CLN_NUMBERS OFF)
-	set(SHIPPED_CARL_USE_GINAC OFF)
-endif()
 
 set(DYNAMIC_EXT ".so")
 set(STATIC_EXT ".a")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,12 @@ message(STATUS "Storm - Detected operating system ${OPERATING_SYSTEM}.")
 set(SHIPPED_CARL_USE_CLN_NUMBERS ON)
 set(SHIPPED_CARL_USE_GINAC ON)
 
+# Warning for Apple Silicon
+if(APPLE_SILICON)
+	message(WARNING "Compiling natively on Apple Silicon is experimental. Please report any issues to support@stormchecker.org.")
+endif()
+
+
 set(DYNAMIC_EXT ".so")
 set(STATIC_EXT ".a")
 set(LIB_PREFIX "lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.16)
+cmake_minimum_required (VERSION 3.22)
 
 set(CMAKE_CXX_STANDARD 17)
 

--- a/src/storm/modelchecker/multiobjective/preprocessing/SparseMultiObjectiveRewardAnalysis.cpp
+++ b/src/storm/modelchecker/multiobjective/preprocessing/SparseMultiObjectiveRewardAnalysis.cpp
@@ -3,6 +3,10 @@
 #include <algorithm>
 #include <set>
 
+#include "storm/adapters/RationalNumberAdapter.h"
+#include "storm/exceptions/InvalidPropertyException.h"
+#include "storm/exceptions/NotImplementedException.h"
+#include "storm/exceptions/UnexpectedException.h"
 #include "storm/modelchecker/prctl/helper/BaierUpperRewardBoundsComputer.h"
 #include "storm/modelchecker/propositional/SparsePropositionalModelChecker.h"
 #include "storm/modelchecker/results/ExplicitQualitativeCheckResult.h"
@@ -15,10 +19,6 @@
 #include "storm/utility/graph.h"
 #include "storm/utility/macros.h"
 #include "storm/utility/vector.h"
-
-#include "storm/exceptions/InvalidPropertyException.h"
-#include "storm/exceptions/NotImplementedException.h"
-#include "storm/exceptions/UnexpectedException.h"
 
 namespace storm {
 namespace modelchecker {

--- a/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.cpp
@@ -1,6 +1,6 @@
 #include "storm/adapters/RationalNumberAdapter.h"  // Must come first
 
-#include "ExplicitQualitativeCheckResult.h"
+#include "storm/modelchecker/results/ExplicitQualitativeCheckResult.h"
 
 #include "storm/adapters/JsonAdapter.h"
 #include "storm/exceptions/InvalidOperationException.h"

--- a/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.cpp
@@ -1,4 +1,6 @@
-#include "storm/modelchecker/results/ExplicitQualitativeCheckResult.h"
+#include "storm/adapters/RationalNumberAdapter.h"  // Must come first
+
+#include "ExplicitQualitativeCheckResult.h"
 
 #include "storm/adapters/JsonAdapter.h"
 #include "storm/exceptions/InvalidOperationException.h"

--- a/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.h
@@ -1,6 +1,4 @@
-#ifndef STORM_MODELCHECKER_EXPLICITQUALITATIVECHECKRESULT_H_
-#define STORM_MODELCHECKER_EXPLICITQUALITATIVECHECKRESULT_H_
-
+#pragma once
 #include <boost/variant.hpp>
 #include <functional>
 #include <map>
@@ -76,5 +74,3 @@ class ExplicitQualitativeCheckResult : public QualitativeCheckResult {
 };
 }  // namespace modelchecker
 }  // namespace storm
-
-#endif /* STORM_MODELCHECKER_EXPLICITQUALITATIVECHECKRESULT_H_ */

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -1,4 +1,6 @@
-#include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
+#include "storm/adapters/RationalNumberAdapter.h"  // Must come first
+
+#include "ExplicitQuantitativeCheckResult.h"
 
 #include "storm/adapters/JsonAdapter.h"
 #include "storm/adapters/RationalFunctionAdapter.h"

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -1,6 +1,6 @@
 #include "storm/adapters/RationalNumberAdapter.h"  // Must come first
 
-#include "ExplicitQuantitativeCheckResult.h"
+#include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
 
 #include "storm/adapters/JsonAdapter.h"
 #include "storm/adapters/RationalFunctionAdapter.h"

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -1,6 +1,4 @@
-#ifndef STORM_MODELCHECKER_EXPLICITQUANTITATIVECHECKRESULT_H_
-#define STORM_MODELCHECKER_EXPLICITQUANTITATIVECHECKRESULT_H_
-
+#pragma once
 #include <boost/optional.hpp>
 #include <boost/variant.hpp>
 #include <map>
@@ -93,5 +91,3 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
 };
 }  // namespace modelchecker
 }  // namespace storm
-
-#endif /* STORM_MODELCHECKER_EXPLICITQUANTITATIVECHECKRESULT_H_ */


### PR DESCRIPTION
- Use C++20 and fixed some includes (resolves #286)
- Bump CMake to 3.22
- Removed support for Debian 11 and Ubuntu 20.04
- Regularly enable CLN and Ginac again for Apple Silicon