### PR TITLE
Fix handling of SMGs with non-synchronizing but labeled actions.

### DIFF
--- a/resources/examples/testfiles/smg/action_labels.prism
+++ b/resources/examples/testfiles/smg/action_labels.prism
@@ -1,0 +1,19 @@
+smg
+
+global state : [0..2];
+
+player p1 [a1] endplayer
+player p2 [a2] endplayer
+player p3 [a3] endplayer
+
+module m1
+	[a1] state=0 -> 1/2 : (state'=1) + 1/2 : (state'=2);
+endmodule
+
+module m2
+	[a2] state=1 -> 1/2 : (state'=0) + 1/2 : (state'=2);
+endmodule
+
+module m3
+	[a3] state=2 -> 1/2 : (state'=0) + 1/2 : (state'=1);
+endmodule

--- a/src/storm/generator/PrismNextStateGenerator.cpp
+++ b/src/storm/generator/PrismNextStateGenerator.cpp
@@ -659,10 +659,19 @@ std::vector<Choice<ValueType>> PrismNextStateGenerator<ValueType, StateType>::ge
             }
 
             if (program.getModelType() == storm::prism::Program::ModelType::SMG) {
-                storm::storage::PlayerIndex const& playerOfModule = moduleIndexToPlayerIndexMap.at(i);
-                STORM_LOG_THROW(playerOfModule != storm::storage::INVALID_PLAYER_INDEX, storm::exceptions::WrongFormatException,
-                                "Module " << module.getName() << " is not owned by any player but has at least one enabled, unlabeled command.");
-                choice.setPlayerIndex(playerOfModule);
+                if (command.getActionIndex() == 0) {
+                    // Unlabeled command
+                    auto const playerOfModule = moduleIndexToPlayerIndexMap.at(i);
+                    STORM_LOG_THROW(playerOfModule != storm::storage::INVALID_PLAYER_INDEX, storm::exceptions::WrongFormatException,
+                                    "Module " << module.getName() << " is not owned by any player but has at least one enabled, unlabeled command.");
+                    choice.setPlayerIndex(playerOfModule);
+                } else {
+                    // Labelled command (that happens to not synchronize with another command
+                    auto const playerOfAction = actionIndexToPlayerIndexMap.at(command.getActionIndex());
+                    STORM_LOG_THROW(playerOfAction != storm::storage::INVALID_PLAYER_INDEX, storm::exceptions::WrongFormatException,
+                                    "Command with action label '" << program.getActionName(command.getActionIndex()) << "' is not owned by any player.");
+                    choice.setPlayerIndex(playerOfAction);
+                }
             }
 
             if (this->options.isExplorationChecksSet()) {

--- a/src/test/storm/builder/ExplicitPrismModelBuilderTest.cpp
+++ b/src/test/storm/builder/ExplicitPrismModelBuilderTest.cpp
@@ -164,6 +164,15 @@ TEST_F(ExplicitPrismModelBuilderTest, POMdp) {
     model = storm::builder::ExplicitModelBuilder<double>(program).build();
 }
 
+TEST_F(ExplicitPrismModelBuilderTest, SMG) {
+    storm::prism::Program program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/smg/action_labels.prism");
+    program = storm::utility::prism::preprocess(program, "");
+    std::shared_ptr<storm::models::sparse::Model<double>> model = storm::builder::ExplicitModelBuilder<double>(program).build();
+    EXPECT_EQ(3ul, model->getNumberOfStates());
+    EXPECT_EQ(3ul, model->getNumberOfChoices());
+    EXPECT_EQ(6ul, model->getNumberOfTransitions());
+}
+
 TEST_F(ExplicitPrismModelBuilderTest, FailComposition) {
     storm::prism::Program program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/system_composition.nm");
 


### PR DESCRIPTION
Previously, all non-synchronizing commands were  assigned to the player owning the module, even if the command has an action label. However, the correct behavior (as far as I understand the specification) is that only unlabeled commands are associated to the module player.

Relevant snippet from the [PRISM-games website](https://www.prismmodelchecker.org/games/modelling.php#smgs): 
> For a turn-based game, it needs to be specified which player controls each state. In PRISM-games, this is done by proving a list of action names and/or module names for each player. This player then controls any state where all the transitions available are either labelled with one of these actions or are unlabelled and belong to one of these modules

Fixes #609