### PR TITLE
Limit Sylvan threads to 1 on Apple Silicon

### DIFF
--- a/src/storm/utility/OsDetection.h
+++ b/src/storm/utility/OsDetection.h
@@ -16,6 +16,9 @@
 #define MACOS
 #define NOEXCEPT noexcept
 #define _DARWIN_USE_64_BIT_INODE
+#ifdef __arm64__
+#define APPLE_SILICON
+#endif
 #include <cxxabi.h>    // Required by ErrorHandling.h
 #include <execinfo.h>  // Required by ErrorHandling.h
 #include <sys/mman.h>


### PR DESCRIPTION
Follows the suggestion in https://github.com/moves-rwth/storm/issues/600.

Workaround for https://github.com/moves-rwth/storm/issues/523.