### PR TITLE
Require explicitly providing bucketSize for BitVectorHashMap

### DIFF
--- a/src/storm/simulator/PrismProgramSimulator.cpp
+++ b/src/storm/simulator/PrismProgramSimulator.cpp
@@ -15,11 +15,10 @@ DiscreteTimePrismProgramSimulator<ValueType>::DiscreteTimePrismProgramSimulator(
       currentState(),
       stateGenerator(std::make_shared<storm::generator::PrismNextStateGenerator<ValueType, uint32_t>>(program, options)),
       zeroRewards(stateGenerator->getNumberOfRewardModels(), storm::utility::zero<ValueType>()),
-      lastActionRewards(zeroRewards) {
+      lastActionRewards(zeroRewards),
+      stateToId(stateGenerator->getStateSize()),
+      idToState() {
     // Current state needs to be overwritten to actual initial state.
-    // But first, let us create a state generator.
-
-    clearStateCaches();
     resetToInitial();
 }
 

--- a/src/storm/storage/BitVectorHashMap.h
+++ b/src/storm/storage/BitVectorHashMap.h
@@ -57,7 +57,7 @@ class BitVectorHashMap {
      * @param loadFactor The load factor that determines at which point the size of the underlying storage is
      * increased.
      */
-    BitVectorHashMap(uint64_t bucketSize = 64, uint64_t initialSize = 1000, double loadFactor = 0.75);
+    BitVectorHashMap(uint64_t bucketSize, uint64_t initialSize = 1000, double loadFactor = 0.75);
 
     BitVectorHashMap(BitVectorHashMap const&) = default;
     BitVectorHashMap(BitVectorHashMap&&) = default;


### PR DESCRIPTION
Should prevent the issue raised in https://github.com/moves-rwth/storm/issues/607 in the future.