### PR TITLE
Support for discounted properties in MDPs and DTMCs

### DIFF
--- a/resources/examples/testfiles/mdp/small_discount.nm
+++ b/resources/examples/testfiles/mdp/small_discount.nm
@@ -1,0 +1,17 @@
+mdp
+
+module discounting
+
+s : [0..3] init 0;
+[a] s=0 -> (s'=1);
+[b] s=0 -> (s'=2);
+[] s=1 -> (s'=3);
+[] s=2 -> 0.8 : (s'=2) + 0.2 : (s'=3);
+[] s=3 -> true;
+
+endmodule
+
+rewards
+ [] s=1 : 4;
+ [] s=2 : 1;
+endrewards

--- a/src/storm-parsers/parser/FormulaParserGrammar.cpp
+++ b/src/storm-parsers/parser/FormulaParserGrammar.cpp
@@ -59,7 +59,8 @@ void FormulaParserGrammar::initialize() {
     operatorSubFormula =
         (((qi::eps(qi::_r1 == storm::logic::FormulaContext::Probability) > formula(FormulaKind::Path, qi::_r1)) |
           (qi::eps(qi::_r1 == storm::logic::FormulaContext::Reward) >
-           (longRunAverageRewardFormula | eventuallyFormula(qi::_r1) | cumulativeRewardFormula | instantaneousRewardFormula | totalRewardFormula)) |
+           (longRunAverageRewardFormula | eventuallyFormula(qi::_r1) | discountedCumulativeRewardFormula | discountedTotalRewardFormula |
+            cumulativeRewardFormula | instantaneousRewardFormula | totalRewardFormula)) |
           (qi::eps(qi::_r1 == storm::logic::FormulaContext::Time) > eventuallyFormula(qi::_r1)) |
           (qi::eps(qi::_r1 == storm::logic::FormulaContext::LongRunAverage) > formula(FormulaKind::State, storm::logic::FormulaContext::LongRunAverage))) >>
          -(qi::lit("||") >
@@ -174,6 +175,14 @@ void FormulaParserGrammar::initialize() {
     pathFormula.name("path formula");
 
     // Quantitative path formulae (reward)
+    discountedCumulativeRewardFormula =
+        (qi::lit("Cdiscount=") >> expressionParser >>
+         timeBounds)[qi::_val = phoenix::bind(&FormulaParserGrammar::createDiscountedCumulativeRewardFormula, phoenix::ref(*this), qi::_1, qi::_2)];
+    discountedCumulativeRewardFormula.name("discounted cumulative reward formula");
+    discountedTotalRewardFormula =
+        (qi::lit("Cdiscount=") >>
+         expressionParser)[qi::_val = phoenix::bind(&FormulaParserGrammar::createDiscountedTotalRewardFormula, phoenix::ref(*this), qi::_1)];
+    discountedTotalRewardFormula.name("discounted total reward formula");
     longRunAverageRewardFormula = (qi::lit("LRA") | qi::lit("S") |
                                    qi::lit("MP"))[qi::_val = phoenix::bind(&FormulaParserGrammar::createLongRunAverageRewardFormula, phoenix::ref(*this))];
     longRunAverageRewardFormula.name("long run average reward formula");
@@ -278,6 +287,8 @@ void FormulaParserGrammar::initialize() {
     //            debug(filterProperty)
     //            debug(constantDefinition )
     //            debug(start)
+    //            debug(discountedCumulativeRewardFormula)
+    //            debug(discountedTotalRewardFormula)
 
     // Enable error reporting.
     qi::on_error<qi::fail>(rewardModelName, handler(qi::_1, qi::_2, qi::_3, qi::_4));
@@ -305,6 +316,8 @@ void FormulaParserGrammar::initialize() {
     qi::on_error<qi::fail>(instantaneousRewardFormula, handler(qi::_1, qi::_2, qi::_3, qi::_4));
     qi::on_error<qi::fail>(cumulativeRewardFormula, handler(qi::_1, qi::_2, qi::_3, qi::_4));
     qi::on_error<qi::fail>(totalRewardFormula, handler(qi::_1, qi::_2, qi::_3, qi::_4));
+    qi::on_error<qi::fail>(discountedCumulativeRewardFormula, handler(qi::_1, qi::_2, qi::_3, qi::_4));
+    qi::on_error<qi::fail>(discountedTotalRewardFormula, handler(qi::_1, qi::_2, qi::_3, qi::_4));
     qi::on_error<qi::fail>(playerCoalition, handler(qi::_1, qi::_2, qi::_3, qi::_4));
     qi::on_error<qi::fail>(gameFormula, handler(qi::_1, qi::_2, qi::_3, qi::_4));
     qi::on_error<qi::fail>(multiOperatorFormula, handler(qi::_1, qi::_2, qi::_3, qi::_4));
@@ -402,8 +415,28 @@ std::shared_ptr<storm::logic::Formula const> FormulaParserGrammar::createCumulat
     return std::shared_ptr<storm::logic::Formula const>(new storm::logic::CumulativeRewardFormula(bounds, timeBoundReferences));
 }
 
+std::shared_ptr<storm::logic::Formula const> FormulaParserGrammar::createDiscountedCumulativeRewardFormula(
+    storm::expressions::Expression const& discountFactor,
+    std::vector<std::tuple<boost::optional<storm::logic::TimeBound>, boost::optional<storm::logic::TimeBound>,
+                           std::shared_ptr<storm::logic::TimeBoundReference>>> const& timeBounds) const {
+    std::vector<storm::logic::TimeBound> bounds;
+    std::vector<storm::logic::TimeBoundReference> timeBoundReferences;
+    for (auto const& timeBound : timeBounds) {
+        STORM_LOG_THROW(!std::get<0>(timeBound), storm::exceptions::WrongFormatException, "Cumulative reward formulas with lower time bound are not allowed.");
+        STORM_LOG_THROW(std::get<1>(timeBound), storm::exceptions::WrongFormatException, "Cumulative reward formulas require an upper bound.");
+        bounds.push_back(std::get<1>(timeBound).get());
+        timeBoundReferences.emplace_back(*std::get<2>(timeBound));
+    }
+    return std::shared_ptr<storm::logic::Formula const>(new storm::logic::DiscountedCumulativeRewardFormula(discountFactor, bounds, timeBoundReferences));
+}
+
 std::shared_ptr<storm::logic::Formula const> FormulaParserGrammar::createTotalRewardFormula() const {
     return std::shared_ptr<storm::logic::Formula const>(new storm::logic::TotalRewardFormula());
+}
+
+std::shared_ptr<storm::logic::Formula const> FormulaParserGrammar::createDiscountedTotalRewardFormula(
+    storm::expressions::Expression const& discountFactor) const {
+    return std::shared_ptr<storm::logic::Formula const>(new storm::logic::DiscountedTotalRewardFormula(discountFactor));
 }
 
 std::shared_ptr<storm::logic::Formula const> FormulaParserGrammar::createLongRunAverageRewardFormula() const {

--- a/src/storm-parsers/parser/FormulaParserGrammar.h
+++ b/src/storm-parsers/parser/FormulaParserGrammar.h
@@ -169,6 +169,8 @@ class FormulaParserGrammar : public qi::grammar<Iterator, std::vector<storm::jan
     qi::rule<Iterator, std::shared_ptr<storm::logic::Formula const>(), Skipper> instantaneousRewardFormula;
     qi::rule<Iterator, std::shared_ptr<storm::logic::Formula const>(), Skipper> cumulativeRewardFormula;
     qi::rule<Iterator, std::shared_ptr<storm::logic::Formula const>(), Skipper> totalRewardFormula;
+    qi::rule<Iterator, std::shared_ptr<storm::logic::Formula const>(), Skipper> discountedCumulativeRewardFormula;
+    qi::rule<Iterator, std::shared_ptr<storm::logic::Formula const>(), Skipper> discountedTotalRewardFormula;
 
     // Game Formulae
     qi::rule<Iterator, storm::logic::PlayerCoalition(), qi::locals<std::vector<std::variant<std::string, storm::storage::PlayerIndex>>>, Skipper>
@@ -218,7 +220,12 @@ class FormulaParserGrammar : public qi::grammar<Iterator, std::vector<storm::jan
     std::shared_ptr<storm::logic::Formula const> createCumulativeRewardFormula(
         std::vector<std::tuple<boost::optional<storm::logic::TimeBound>, boost::optional<storm::logic::TimeBound>,
                                std::shared_ptr<storm::logic::TimeBoundReference>>> const& timeBounds) const;
+    std::shared_ptr<storm::logic::Formula const> createDiscountedCumulativeRewardFormula(
+        storm::expressions::Expression const& discountFactor,
+        std::vector<std::tuple<boost::optional<storm::logic::TimeBound>, boost::optional<storm::logic::TimeBound>,
+                               std::shared_ptr<storm::logic::TimeBoundReference>>> const& timeBounds) const;
     std::shared_ptr<storm::logic::Formula const> createTotalRewardFormula() const;
+    std::shared_ptr<storm::logic::Formula const> createDiscountedTotalRewardFormula(storm::expressions::Expression const& discountFactor) const;
     std::shared_ptr<storm::logic::Formula const> createLongRunAverageRewardFormula() const;
     std::shared_ptr<storm::logic::Formula const> createAtomicExpressionFormula(storm::expressions::Expression const& expression) const;
     std::shared_ptr<storm::logic::Formula const> createBooleanLiteralFormula(bool literal) const;

--- a/src/storm-pomdp/analysis/FormulaInformation.cpp
+++ b/src/storm-pomdp/analysis/FormulaInformation.cpp
@@ -25,8 +25,9 @@ FormulaInformation::FormulaInformation() : type(Type::Unsupported) {
 
 FormulaInformation::FormulaInformation(Type const& type, storm::solver::OptimizationDirection const& dir, std::optional<std::string> const& rewardModelName)
     : type(type), optimizationDirection(dir), rewardModelName(rewardModelName) {
-    STORM_LOG_ASSERT(!this->rewardModelName.has_value() || this->type == Type::NonNestedExpectedRewardFormula,
-                     "Got a reward model name for a non-reward formula.");
+    STORM_LOG_ASSERT(
+        !this->rewardModelName.has_value() || this->type == Type::NonNestedExpectedRewardFormula || this->type == Type::DiscountedTotalRewardFormula,
+        "Got a reward model name for a non-reward formula.");
 }
 
 FormulaInformation::Type const& FormulaInformation::getType() const {
@@ -39,6 +40,10 @@ bool FormulaInformation::isNonNestedReachabilityProbability() const {
 
 bool FormulaInformation::isNonNestedExpectedRewardFormula() const {
     return type == Type::NonNestedExpectedRewardFormula;
+}
+
+bool FormulaInformation::isDiscountedTotalRewardFormula() const {
+    return type == Type::DiscountedTotalRewardFormula;
 }
 
 bool FormulaInformation::isUnsupported() const {
@@ -57,7 +62,8 @@ typename FormulaInformation::StateSet const& FormulaInformation::getSinkStates()
 }
 
 std::string const& FormulaInformation::getRewardModelName() const {
-    STORM_LOG_ASSERT(this->type == Type::NonNestedExpectedRewardFormula, "Reward model requested for unexpected formula type.");
+    STORM_LOG_ASSERT(this->type == Type::NonNestedExpectedRewardFormula || this->type == Type::DiscountedTotalRewardFormula,
+                     "Reward model requested for unexpected formula type.");
     return rewardModelName.value();
 }
 

--- a/src/storm-pomdp/analysis/FormulaInformation.h
+++ b/src/storm-pomdp/analysis/FormulaInformation.h
@@ -28,6 +28,7 @@ class FormulaInformation {
     enum class Type {
         NonNestedReachabilityProbability,  // e.g. 'Pmax=? [F "target"]' or 'Pmin=? [!"sink" U "target"]'
         NonNestedExpectedRewardFormula,    // e.g. 'Rmin=? [F x>0 ]'
+        DiscountedTotalRewardFormula,      // e.g. 'Rmax=? [Cdiscount=9/10}]'
         Unsupported                        // The formula type is unsupported
     };
 
@@ -37,6 +38,7 @@ class FormulaInformation {
     Type const& getType() const;
     bool isNonNestedReachabilityProbability() const;
     bool isNonNestedExpectedRewardFormula() const;
+    bool isDiscountedTotalRewardFormula() const;
     bool isUnsupported() const;
     StateSet const& getTargetStates() const;
     StateSet const& getSinkStates() const;          // Shall not be called for reward formulas

--- a/src/storm/logic/CloneVisitor.cpp
+++ b/src/storm/logic/CloneVisitor.cpp
@@ -169,5 +169,13 @@ boost::any CloneVisitor::visit(HOAPathFormula const& f, boost::any const& data) 
     }
     return std::static_pointer_cast<Formula>(result);
 }
+
+boost::any CloneVisitor::visit(DiscountedCumulativeRewardFormula const& f, boost::any const&) const {
+    return std::static_pointer_cast<Formula>(std::make_shared<DiscountedCumulativeRewardFormula>(f));
+}
+
+boost::any CloneVisitor::visit(DiscountedTotalRewardFormula const& f, boost::any const&) const {
+    return std::static_pointer_cast<Formula>(std::make_shared<DiscountedTotalRewardFormula>(f));
+}
 }  // namespace logic
 }  // namespace storm

--- a/src/storm/logic/CloneVisitor.h
+++ b/src/storm/logic/CloneVisitor.h
@@ -37,6 +37,8 @@ class CloneVisitor : public FormulaVisitor {
     virtual boost::any visit(UnaryBooleanPathFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(UntilFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(HOAPathFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedCumulativeRewardFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedTotalRewardFormula const& f, boost::any const& data) const override;
 };
 
 }  // namespace logic

--- a/src/storm/logic/DiscountedCumulativeRewardFormula.cpp
+++ b/src/storm/logic/DiscountedCumulativeRewardFormula.cpp
@@ -1,0 +1,243 @@
+#include "storm/logic/DiscountedCumulativeRewardFormula.h"
+#include <boost/any.hpp>
+#include <ostream>
+
+#include "storm/adapters/RationalNumberAdapter.h"
+#include "storm/logic/FormulaVisitor.h"
+
+#include "storm/exceptions/InvalidOperationException.h"
+#include "storm/exceptions/InvalidPropertyException.h"
+#include "storm/utility/constants.h"
+#include "storm/utility/macros.h"
+
+namespace storm {
+namespace logic {
+DiscountedCumulativeRewardFormula::DiscountedCumulativeRewardFormula(storm::expressions::Expression const discountFactor, TimeBound const& bound,
+                                                                     TimeBoundReference const& timeBoundReference,
+                                                                     boost::optional<RewardAccumulation> rewardAccumulation)
+    : discountFactor(discountFactor), timeBoundReferences({timeBoundReference}), bounds({bound}), rewardAccumulation(rewardAccumulation) {
+    // Intentionally left empty.
+}
+
+DiscountedCumulativeRewardFormula::DiscountedCumulativeRewardFormula(storm::expressions::Expression const discountFactor, std::vector<TimeBound> const& bounds,
+                                                                     std::vector<TimeBoundReference> const& timeBoundReferences,
+                                                                     boost::optional<RewardAccumulation> rewardAccumulation)
+    : discountFactor(discountFactor), timeBoundReferences(timeBoundReferences), bounds(bounds), rewardAccumulation(rewardAccumulation) {
+    STORM_LOG_ASSERT(this->timeBoundReferences.size() == this->bounds.size(), "Number of time bounds and number of time bound references does not match.");
+    STORM_LOG_ASSERT(!this->timeBoundReferences.empty(), "No time bounds given.");
+}
+
+bool DiscountedCumulativeRewardFormula::isDiscountedCumulativeRewardFormula() const {
+    return true;
+}
+
+bool DiscountedCumulativeRewardFormula::isCumulativeRewardFormula() const {
+    return true;
+}
+
+bool DiscountedCumulativeRewardFormula::isRewardPathFormula() const {
+    return true;
+}
+
+bool DiscountedCumulativeRewardFormula::isMultiDimensional() const {
+    return getDimension() > 1;
+}
+
+unsigned DiscountedCumulativeRewardFormula::getDimension() const {
+    return timeBoundReferences.size();
+}
+
+boost::any DiscountedCumulativeRewardFormula::accept(FormulaVisitor const& visitor, boost::any const& data) const {
+    return visitor.visit(*this, data);
+}
+
+void DiscountedCumulativeRewardFormula::gatherReferencedRewardModels(std::set<std::string>& referencedRewardModels) const {
+    for (unsigned i = 0; i < this->getDimension(); ++i) {
+        if (getTimeBoundReference(i).isRewardBound()) {
+            referencedRewardModels.insert(this->getTimeBoundReference(i).getRewardName());
+        }
+    }
+}
+
+void DiscountedCumulativeRewardFormula::gatherUsedVariables(std::set<storm::expressions::Variable>& usedVariables) const {
+    for (unsigned i = 0; i < this->getDimension(); ++i) {
+        this->getBound(i).gatherVariables(usedVariables);
+    }
+}
+
+TimeBoundReference const& DiscountedCumulativeRewardFormula::getTimeBoundReference() const {
+    STORM_LOG_ASSERT(!isMultiDimensional(), "Cumulative Reward Formula is multi-dimensional.");
+    return getTimeBoundReference(0);
+}
+
+TimeBoundReference const& DiscountedCumulativeRewardFormula::getTimeBoundReference(unsigned i) const {
+    return timeBoundReferences.at(i);
+}
+
+bool DiscountedCumulativeRewardFormula::isBoundStrict() const {
+    STORM_LOG_ASSERT(!isMultiDimensional(), "Cumulative Reward Formula is multi-dimensional.");
+    return isBoundStrict(0);
+}
+
+bool DiscountedCumulativeRewardFormula::isBoundStrict(unsigned i) const {
+    return bounds.at(i).isStrict();
+}
+
+bool DiscountedCumulativeRewardFormula::hasIntegerBound() const {
+    STORM_LOG_ASSERT(!isMultiDimensional(), "Cumulative Reward Formula is multi-dimensional.");
+    return hasIntegerBound(0);
+}
+
+bool DiscountedCumulativeRewardFormula::hasIntegerBound(unsigned i) const {
+    return bounds.at(i).getBound().hasIntegerType();
+}
+
+storm::expressions::Expression const& DiscountedCumulativeRewardFormula::getBound() const {
+    STORM_LOG_ASSERT(!isMultiDimensional(), "Cumulative Reward Formula is multi-dimensional.");
+    return getBound(0);
+}
+
+storm::expressions::Expression const& DiscountedCumulativeRewardFormula::getBound(unsigned i) const {
+    return bounds.at(i).getBound();
+}
+
+template<typename ValueType>
+ValueType DiscountedCumulativeRewardFormula::getBound() const {
+    STORM_LOG_ASSERT(!isMultiDimensional(), "Cumulative Reward Formula is multi-dimensional.");
+    return getBound<ValueType>(0);
+}
+
+template<>
+double DiscountedCumulativeRewardFormula::getBound(unsigned i) const {
+    checkNoVariablesInBound(bounds.at(i).getBound());
+    double value = bounds.at(i).getBound().evaluateAsDouble();
+    return value;
+}
+
+template<>
+storm::RationalNumber DiscountedCumulativeRewardFormula::getBound(unsigned i) const {
+    checkNoVariablesInBound(bounds.at(i).getBound());
+    storm::RationalNumber value = bounds.at(i).getBound().evaluateAsRational();
+    return value;
+}
+
+template<>
+uint64_t DiscountedCumulativeRewardFormula::getBound(unsigned i) const {
+    checkNoVariablesInBound(bounds.at(i).getBound());
+    uint64_t value = bounds.at(i).getBound().evaluateAsInt();
+    return value;
+}
+
+template<>
+double DiscountedCumulativeRewardFormula::getNonStrictBound() const {
+    STORM_LOG_ASSERT(!isMultiDimensional(), "Cumulative Reward Formula is multi-dimensional.");
+    double bound = getBound<double>();
+    STORM_LOG_THROW(bound > 0, storm::exceptions::InvalidPropertyException, "Cannot retrieve non-strict bound from strict zero-bound.");
+    return bound;
+}
+
+template<>
+uint64_t DiscountedCumulativeRewardFormula::getNonStrictBound() const {
+    STORM_LOG_ASSERT(!isMultiDimensional(), "Cumulative Reward Formula is multi-dimensional.");
+    int_fast64_t bound = getBound<uint64_t>();
+    if (isBoundStrict()) {
+        STORM_LOG_THROW(bound > 0, storm::exceptions::InvalidPropertyException, "Cannot retrieve non-strict bound from strict zero-bound.");
+        return bound - 1;
+    } else {
+        return bound;
+    }
+}
+
+std::vector<TimeBound> const& DiscountedCumulativeRewardFormula::getBounds() const {
+    return bounds;
+}
+
+void DiscountedCumulativeRewardFormula::checkNoVariablesInBound(storm::expressions::Expression const& bound) {
+    STORM_LOG_THROW(!bound.containsVariables(), storm::exceptions::InvalidOperationException,
+                    "Cannot evaluate time-bound '" << bound << "' as it contains undefined constants.");
+}
+
+void DiscountedCumulativeRewardFormula::checkNoVariablesInDiscountFactor(storm::expressions::Expression const& factor) {
+    STORM_LOG_THROW(!factor.containsVariables(), storm::exceptions::InvalidOperationException,
+                    "Cannot evaluate discount factor '" << factor << "' as it contains undefined constants.");
+}
+
+storm::expressions::Expression const& DiscountedCumulativeRewardFormula::getDiscountFactor() const {
+    return discountFactor;
+}
+
+template<>
+double DiscountedCumulativeRewardFormula::getDiscountFactor() const {
+    checkNoVariablesInDiscountFactor(discountFactor);
+    double value = discountFactor.evaluateAsDouble();
+    return value;
+}
+
+template<>
+storm::RationalNumber DiscountedCumulativeRewardFormula::getDiscountFactor() const {
+    checkNoVariablesInDiscountFactor(discountFactor);
+    storm::RationalNumber value = discountFactor.evaluateAsRational();
+    return value;
+}
+
+bool DiscountedCumulativeRewardFormula::hasRewardAccumulation() const {
+    return rewardAccumulation.is_initialized();
+}
+
+RewardAccumulation const& DiscountedCumulativeRewardFormula::getRewardAccumulation() const {
+    return rewardAccumulation.get();
+}
+
+std::shared_ptr<DiscountedCumulativeRewardFormula const> DiscountedCumulativeRewardFormula::stripRewardAccumulation() const {
+    return std::make_shared<DiscountedCumulativeRewardFormula const>(discountFactor, bounds, timeBoundReferences);
+}
+
+std::shared_ptr<DiscountedCumulativeRewardFormula const> DiscountedCumulativeRewardFormula::restrictToDimension(unsigned i) const {
+    return std::make_shared<DiscountedCumulativeRewardFormula const>(discountFactor, bounds.at(i), getTimeBoundReference(i), rewardAccumulation);
+}
+
+std::ostream& DiscountedCumulativeRewardFormula::writeToStream(std::ostream& out, bool /*allowParentheses*/) const {
+    // No parentheses necessary
+    out << "Cdiscount=";
+    out << discountFactor;
+    if (hasRewardAccumulation()) {
+        out << "[" << getRewardAccumulation() << "]";
+    }
+    if (this->isMultiDimensional()) {
+        out << "^{";
+    }
+    for (unsigned i = 0; i < this->getDimension(); ++i) {
+        if (i > 0) {
+            out << ", ";
+        }
+        if (this->getTimeBoundReference(i).isRewardBound()) {
+            out << "rew";
+            if (this->getTimeBoundReference(i).hasRewardAccumulation()) {
+                out << "[" << this->getTimeBoundReference(i).getRewardAccumulation() << "]";
+            }
+            out << "{\"" << this->getTimeBoundReference(i).getRewardName() << "\"}";
+        } else if (this->getTimeBoundReference(i).isStepBound()) {
+            out << "steps";
+            //} else if (this->getTimeBoundReference(i).isStepBound())
+            //  Note: the 'time' keyword is optional.
+            //    out << "time";
+        }
+        if (this->isBoundStrict(i)) {
+            out << "<";
+        } else {
+            out << "<=";
+        }
+        out << this->getBound(i);
+    }
+    if (this->isMultiDimensional()) {
+        out << "}";
+    }
+    return out;
+}
+
+template uint64_t DiscountedCumulativeRewardFormula::getBound<uint64_t>() const;
+template double DiscountedCumulativeRewardFormula::getBound<double>() const;
+template storm::RationalNumber DiscountedCumulativeRewardFormula::getBound<storm::RationalNumber>() const;
+
+}  // namespace logic
+}  // namespace storm

--- a/src/storm/logic/DiscountedCumulativeRewardFormula.h
+++ b/src/storm/logic/DiscountedCumulativeRewardFormula.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "storm/logic/PathFormula.h"
+
+#include "storm/logic/TimeBound.h"
+#include "storm/logic/TimeBoundType.h"
+
+namespace storm {
+namespace logic {
+class DiscountedCumulativeRewardFormula : public PathFormula {
+   public:
+    DiscountedCumulativeRewardFormula(storm::expressions::Expression const discountFactor, TimeBound const& bound,
+                                      TimeBoundReference const& timeBoundReference = TimeBoundReference(TimeBoundType::Time),
+                                      boost::optional<RewardAccumulation> rewardAccumulation = boost::none);
+    DiscountedCumulativeRewardFormula(storm::expressions::Expression const discountFactor, std::vector<TimeBound> const& bounds,
+                                      std::vector<TimeBoundReference> const& timeBoundReferences,
+                                      boost::optional<RewardAccumulation> rewardAccumulation = boost::none);
+
+    virtual ~DiscountedCumulativeRewardFormula() = default;
+
+    virtual bool isDiscountedCumulativeRewardFormula() const override;
+    virtual bool isCumulativeRewardFormula() const override;
+    virtual bool isRewardPathFormula() const override;
+
+    bool isMultiDimensional() const;
+    unsigned getDimension() const;
+
+    virtual boost::any accept(FormulaVisitor const& visitor, boost::any const& data) const override;
+
+    virtual void gatherReferencedRewardModels(std::set<std::string>& referencedRewardModels) const override;
+    virtual void gatherUsedVariables(std::set<storm::expressions::Variable>& usedVariables) const override;
+
+    virtual std::ostream& writeToStream(std::ostream& out, bool allowParentheses = false) const override;
+
+    TimeBoundReference const& getTimeBoundReference() const;
+    TimeBoundReference const& getTimeBoundReference(unsigned i) const;
+
+    bool isBoundStrict() const;
+    bool isBoundStrict(unsigned i) const;
+    bool hasIntegerBound() const;
+    bool hasIntegerBound(unsigned i) const;
+
+    storm::expressions::Expression const& getBound() const;
+    storm::expressions::Expression const& getBound(unsigned i) const;
+
+    storm::expressions::Expression const& getDiscountFactor() const;
+
+    template<typename ValueType>
+    ValueType getBound() const;
+
+    template<typename ValueType>
+    ValueType getBound(unsigned i) const;
+
+    template<typename ValueType>
+    ValueType getDiscountFactor() const;
+
+    template<typename ValueType>
+    ValueType getNonStrictBound() const;
+
+    std::vector<TimeBound> const& getBounds() const;
+
+    bool hasRewardAccumulation() const;
+    RewardAccumulation const& getRewardAccumulation() const;
+    std::shared_ptr<DiscountedCumulativeRewardFormula const> stripRewardAccumulation() const;
+
+    std::shared_ptr<DiscountedCumulativeRewardFormula const> restrictToDimension(unsigned i) const;
+
+   private:
+    static void checkNoVariablesInBound(storm::expressions::Expression const& bound);
+    static void checkNoVariablesInDiscountFactor(storm::expressions::Expression const& factor);
+
+    storm::expressions::Expression const discountFactor;
+    std::vector<TimeBoundReference> timeBoundReferences;
+    std::vector<TimeBound> bounds;
+    boost::optional<RewardAccumulation> rewardAccumulation;
+};
+}  // namespace logic
+}  // namespace storm

--- a/src/storm/logic/DiscountedTotalRewardFormula.cpp
+++ b/src/storm/logic/DiscountedTotalRewardFormula.cpp
@@ -1,0 +1,83 @@
+#include "storm/logic/DiscountedTotalRewardFormula.h"
+#include <boost/any.hpp>
+
+#include <ostream>
+
+#include "storm/adapters/RationalNumberAdapter.h"
+
+#include "storm/exceptions/InvalidOperationException.h"
+#include "storm/logic/FormulaVisitor.h"
+
+#include "storm/utility/macros.h"
+
+namespace storm {
+namespace logic {
+DiscountedTotalRewardFormula::DiscountedTotalRewardFormula(storm::expressions::Expression const discountFactor,
+                                                           boost::optional<RewardAccumulation> rewardAccumulation)
+    : discountFactor(discountFactor), rewardAccumulation(rewardAccumulation) {
+    // Intentionally left empty.
+}
+
+bool DiscountedTotalRewardFormula::isDiscountedTotalRewardFormula() const {
+    return true;
+}
+
+bool DiscountedTotalRewardFormula::isTotalRewardFormula() const {
+    return true;
+}
+
+bool DiscountedTotalRewardFormula::isRewardPathFormula() const {
+    return true;
+}
+
+bool DiscountedTotalRewardFormula::hasRewardAccumulation() const {
+    return rewardAccumulation.is_initialized();
+}
+
+RewardAccumulation const& DiscountedTotalRewardFormula::getRewardAccumulation() const {
+    return rewardAccumulation.get();
+}
+
+std::shared_ptr<DiscountedTotalRewardFormula const> DiscountedTotalRewardFormula::stripRewardAccumulation() const {
+    return std::make_shared<DiscountedTotalRewardFormula>(discountFactor);
+}
+
+boost::any DiscountedTotalRewardFormula::accept(FormulaVisitor const& visitor, boost::any const& data) const {
+    return visitor.visit(*this, data);
+}
+
+std::ostream& DiscountedTotalRewardFormula::writeToStream(std::ostream& out, bool /* allowParentheses */) const {
+    // No parentheses necessary
+    out << "Cdiscount=";
+    out << discountFactor.toString();
+    if (hasRewardAccumulation()) {
+        out << "[" << getRewardAccumulation() << "]";
+    }
+    return out;
+}
+
+storm::expressions::Expression const& DiscountedTotalRewardFormula::getDiscountFactor() const {
+    return discountFactor;
+}
+
+template<>
+double DiscountedTotalRewardFormula::getDiscountFactor() const {
+    checkNoVariablesInDiscountFactor(discountFactor);
+    double value = discountFactor.evaluateAsDouble();
+    return value;
+}
+
+template<>
+storm::RationalNumber DiscountedTotalRewardFormula::getDiscountFactor() const {
+    checkNoVariablesInDiscountFactor(discountFactor);
+    storm::RationalNumber value = discountFactor.evaluateAsRational();
+    return value;
+}
+
+void DiscountedTotalRewardFormula::checkNoVariablesInDiscountFactor(storm::expressions::Expression const& factor) {
+    STORM_LOG_THROW(!factor.containsVariables(), storm::exceptions::InvalidOperationException,
+                    "Cannot evaluate discount factor '" << factor << "' as it contains undefined constants.");
+}
+
+}  // namespace logic
+}  // namespace storm

--- a/src/storm/logic/DiscountedTotalRewardFormula.h
+++ b/src/storm/logic/DiscountedTotalRewardFormula.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <boost/optional.hpp>
+
+#include "storm/logic/PathFormula.h"
+#include "storm/logic/RewardAccumulation.h"
+#include "storm/storage/expressions/Expression.h"
+
+namespace storm {
+namespace logic {
+class DiscountedTotalRewardFormula : public PathFormula {
+   public:
+    DiscountedTotalRewardFormula(storm::expressions::Expression const discountFactor, boost::optional<RewardAccumulation> rewardAccumulation = boost::none);
+
+    virtual ~DiscountedTotalRewardFormula() {
+        // Intentionally left empty.
+    }
+
+    virtual bool isDiscountedTotalRewardFormula() const override;
+    virtual bool isTotalRewardFormula() const override;
+
+    virtual bool isRewardPathFormula() const override;
+    bool hasRewardAccumulation() const;
+    RewardAccumulation const& getRewardAccumulation() const;
+    std::shared_ptr<DiscountedTotalRewardFormula const> stripRewardAccumulation() const;
+
+    virtual boost::any accept(FormulaVisitor const& visitor, boost::any const& data) const override;
+
+    virtual std::ostream& writeToStream(std::ostream& out, bool allowParentheses = false) const override;
+
+    storm::expressions::Expression const& getDiscountFactor() const;
+
+    template<typename ValueType>
+    ValueType getDiscountFactor() const;
+
+   private:
+    static void checkNoVariablesInDiscountFactor(storm::expressions::Expression const& factor);
+
+    storm::expressions::Expression const discountFactor;
+    boost::optional<RewardAccumulation> rewardAccumulation;
+};
+}  // namespace logic
+}  // namespace storm

--- a/src/storm/logic/ExpressionSubstitutionVisitor.cpp
+++ b/src/storm/logic/ExpressionSubstitutionVisitor.cpp
@@ -97,6 +97,22 @@ boost::any ExpressionSubstitutionVisitor::visit(CumulativeRewardFormula const& f
     return std::static_pointer_cast<Formula>(std::make_shared<CumulativeRewardFormula>(bounds, timeBoundReferences, optionalRewardAccumulation));
 }
 
+boost::any ExpressionSubstitutionVisitor::visit(DiscountedCumulativeRewardFormula const& f, boost::any const& data) const {
+    auto const& substitutionFunction = *boost::any_cast<std::function<storm::expressions::Expression(storm::expressions::Expression const&)> const*>(data);
+    std::vector<TimeBound> bounds;
+    std::vector<TimeBoundReference> timeBoundReferences;
+    for (uint64_t i = 0; i < f.getDimension(); ++i) {
+        bounds.emplace_back(TimeBound(f.isBoundStrict(i), substitutionFunction(f.getBound(i))));
+        timeBoundReferences.push_back(f.getTimeBoundReference(i));
+    }
+    boost::optional<RewardAccumulation> optionalRewardAccumulation;
+    if (f.hasRewardAccumulation()) {
+        optionalRewardAccumulation = f.getRewardAccumulation();
+    }
+    return std::static_pointer_cast<Formula>(
+        std::make_shared<DiscountedCumulativeRewardFormula>(f.getDiscountFactor(), bounds, timeBoundReferences, optionalRewardAccumulation));
+}
+
 boost::any ExpressionSubstitutionVisitor::visit(InstantaneousRewardFormula const& f, boost::any const& data) const {
     auto const& substitutionFunction = *boost::any_cast<std::function<storm::expressions::Expression(storm::expressions::Expression const&)> const*>(data);
     return std::static_pointer_cast<Formula>(std::make_shared<InstantaneousRewardFormula>(substitutionFunction(f.getBound()), f.getTimeBoundType()));

--- a/src/storm/logic/ExpressionSubstitutionVisitor.h
+++ b/src/storm/logic/ExpressionSubstitutionVisitor.h
@@ -24,6 +24,7 @@ class ExpressionSubstitutionVisitor : public CloneVisitor {
     virtual boost::any visit(RewardOperatorFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(BoundedUntilFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(CumulativeRewardFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedCumulativeRewardFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(InstantaneousRewardFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(AtomicExpressionFormula const& f, boost::any const& data) const override;
 };

--- a/src/storm/logic/Formula.cpp
+++ b/src/storm/logic/Formula.cpp
@@ -145,6 +145,10 @@ bool Formula::isCumulativeRewardFormula() const {
     return false;
 }
 
+bool Formula::isDiscountedCumulativeRewardFormula() const {
+    return false;
+}
+
 bool Formula::isInstantaneousRewardFormula() const {
     return false;
 }
@@ -158,6 +162,10 @@ bool Formula::isLongRunAverageRewardFormula() const {
 }
 
 bool Formula::isTotalRewardFormula() const {
+    return false;
+}
+
+bool Formula::isDiscountedTotalRewardFormula() const {
     return false;
 }
 
@@ -432,6 +440,21 @@ TotalRewardFormula& Formula::asTotalRewardFormula() {
 
 TotalRewardFormula const& Formula::asTotalRewardFormula() const {
     return dynamic_cast<TotalRewardFormula const&>(*this);
+}
+
+DiscountedCumulativeRewardFormula& Formula::asDiscountedCumulativeRewardFormula() {
+    return dynamic_cast<DiscountedCumulativeRewardFormula&>(*this);
+}
+
+DiscountedCumulativeRewardFormula const& Formula::asDiscountedCumulativeRewardFormula() const {
+    return dynamic_cast<DiscountedCumulativeRewardFormula const&>(*this);
+}
+
+DiscountedTotalRewardFormula& Formula::asDiscountedTotalRewardFormula() {
+    return dynamic_cast<DiscountedTotalRewardFormula&>(*this);
+}
+DiscountedTotalRewardFormula const& Formula::asDiscountedTotalRewardFormula() const {
+    return dynamic_cast<DiscountedTotalRewardFormula const&>(*this);
 }
 
 InstantaneousRewardFormula& Formula::asInstantaneousRewardFormula() {

--- a/src/storm/logic/Formula.h
+++ b/src/storm/logic/Formula.h
@@ -80,10 +80,12 @@ class Formula : public std::enable_shared_from_this<Formula> {
 
     // Reward formulas.
     virtual bool isCumulativeRewardFormula() const;
+    virtual bool isDiscountedCumulativeRewardFormula() const;
     virtual bool isInstantaneousRewardFormula() const;
     virtual bool isReachabilityRewardFormula() const;
     virtual bool isLongRunAverageRewardFormula() const;
     virtual bool isTotalRewardFormula() const;
+    virtual bool isDiscountedTotalRewardFormula() const;
 
     // Expected time formulas.
     virtual bool isReachabilityTimeFormula() const;
@@ -195,6 +197,12 @@ class Formula : public std::enable_shared_from_this<Formula> {
 
     TotalRewardFormula& asTotalRewardFormula();
     TotalRewardFormula const& asTotalRewardFormula() const;
+
+    DiscountedCumulativeRewardFormula& asDiscountedCumulativeRewardFormula();
+    DiscountedCumulativeRewardFormula const& asDiscountedCumulativeRewardFormula() const;
+
+    DiscountedTotalRewardFormula& asDiscountedTotalRewardFormula();
+    DiscountedTotalRewardFormula const& asDiscountedTotalRewardFormula() const;
 
     InstantaneousRewardFormula& asInstantaneousRewardFormula();
     InstantaneousRewardFormula const& asInstantaneousRewardFormula() const;

--- a/src/storm/logic/FormulaInformationVisitor.cpp
+++ b/src/storm/logic/FormulaInformationVisitor.cpp
@@ -197,5 +197,20 @@ boost::any FormulaInformationVisitor::visit(HOAPathFormula const& f, boost::any 
     return info;
 }
 
+boost::any FormulaInformationVisitor::visit(DiscountedCumulativeRewardFormula const& f, boost::any const&) const {
+    FormulaInformation result;
+    result.setContainsCumulativeRewardFormula(true);
+    for (unsigned i = 0; i < f.getDimension(); ++i) {
+        if (f.getTimeBoundReference(i).isRewardBound()) {
+            result.setContainsRewardBoundedFormula(true);
+        }
+    }
+    return result;
+}
+
+boost::any FormulaInformationVisitor::visit(DiscountedTotalRewardFormula const&, boost::any const&) const {
+    return FormulaInformation();
+}
+
 }  // namespace logic
 }  // namespace storm

--- a/src/storm/logic/FormulaInformationVisitor.h
+++ b/src/storm/logic/FormulaInformationVisitor.h
@@ -42,6 +42,8 @@ class FormulaInformationVisitor : public FormulaVisitor {
     virtual boost::any visit(UnaryBooleanPathFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(UntilFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(HOAPathFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedCumulativeRewardFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedTotalRewardFormula const& f, boost::any const& data) const override;
 
    private:
     bool recurseIntoOperators;

--- a/src/storm/logic/FormulaVisitor.h
+++ b/src/storm/logic/FormulaVisitor.h
@@ -38,6 +38,8 @@ class FormulaVisitor {
     virtual boost::any visit(UnaryBooleanPathFormula const& f, boost::any const& data) const = 0;
     virtual boost::any visit(UntilFormula const& f, boost::any const& data) const = 0;
     virtual boost::any visit(HOAPathFormula const& f, boost::any const& data) const = 0;
+    virtual boost::any visit(DiscountedCumulativeRewardFormula const& f, boost::any const& data) const = 0;
+    virtual boost::any visit(DiscountedTotalRewardFormula const& f, boost::any const& data) const = 0;
 };
 
 }  // namespace logic

--- a/src/storm/logic/Formulas.h
+++ b/src/storm/logic/Formulas.h
@@ -9,6 +9,8 @@
 #include "storm/logic/ComparisonType.h"
 #include "storm/logic/ConditionalFormula.h"
 #include "storm/logic/CumulativeRewardFormula.h"
+#include "storm/logic/DiscountedCumulativeRewardFormula.h"
+#include "storm/logic/DiscountedTotalRewardFormula.h"
 #include "storm/logic/EventuallyFormula.h"
 #include "storm/logic/Formula.h"
 #include "storm/logic/GameFormula.h"

--- a/src/storm/logic/FormulasForwardDeclarations.h
+++ b/src/storm/logic/FormulasForwardDeclarations.h
@@ -38,6 +38,8 @@ class UnaryPathFormula;
 class UnaryStateFormula;
 class UntilFormula;
 class HOAPathFormula;
+class DiscountedCumulativeRewardFormula;
+class DiscountedTotalRewardFormula;
 }  // namespace logic
 }  // namespace storm
 

--- a/src/storm/logic/FragmentChecker.cpp
+++ b/src/storm/logic/FragmentChecker.cpp
@@ -340,5 +340,35 @@ boost::any FragmentChecker::visit(HOAPathFormula const& f, boost::any const& dat
     }
     return result;
 }
+
+boost::any FragmentChecker::visit(DiscountedCumulativeRewardFormula const& f, boost::any const& data) const {
+    InheritedInformation const& inherited = boost::any_cast<InheritedInformation const&>(data);
+
+    bool result = inherited.getSpecification().areDiscountedCumulativeRewardFormulasAllowed();
+    result = result && (!f.isMultiDimensional() || inherited.getSpecification().areMultiDimensionalCumulativeRewardFormulasAllowed());
+    result = result && (!f.hasRewardAccumulation() || inherited.getSpecification().isRewardAccumulationAllowed());
+    for (uint64_t i = 0; i < f.getDimension(); ++i) {
+        auto tbr = f.getTimeBoundReference(i);
+        if (tbr.isStepBound()) {
+            result = result && inherited.getSpecification().areStepBoundedCumulativeRewardFormulasAllowed();
+        } else if (tbr.isTimeBound()) {
+            result = result && inherited.getSpecification().areTimeBoundedCumulativeRewardFormulasAllowed();
+        } else {
+            assert(tbr.isRewardBound());
+            result = result && inherited.getSpecification().areRewardBoundedCumulativeRewardFormulasAllowed();
+            if (tbr.hasRewardAccumulation()) {
+                result = result && inherited.getSpecification().isRewardAccumulationAllowed();
+            }
+        }
+    }
+    return result;
+}
+
+boost::any FragmentChecker::visit(DiscountedTotalRewardFormula const& f, boost::any const& data) const {
+    InheritedInformation const& inherited = boost::any_cast<InheritedInformation const&>(data);
+    bool result = (!f.hasRewardAccumulation() || inherited.getSpecification().isRewardAccumulationAllowed());
+    result = result && inherited.getSpecification().areDiscountedTotalRewardFormulasAllowed();
+    return result;
+}
 }  // namespace logic
 }  // namespace storm

--- a/src/storm/logic/FragmentChecker.h
+++ b/src/storm/logic/FragmentChecker.h
@@ -37,6 +37,8 @@ class FragmentChecker : public FormulaVisitor {
     virtual boost::any visit(UnaryBooleanPathFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(UntilFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(HOAPathFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedCumulativeRewardFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedTotalRewardFormula const& f, boost::any const& data) const override;
 };
 
 }  // namespace logic

--- a/src/storm/logic/FragmentSpecification.cpp
+++ b/src/storm/logic/FragmentSpecification.cpp
@@ -299,6 +299,9 @@ FragmentSpecification::FragmentSpecification() {
     quantileFormulaAtTopLevelRequired = false;
 
     rewardAccumulation = false;
+
+    discountedCumulativeRewardFormula = false;
+    discountedTotalRewardFormula = false;
 }
 
 FragmentSpecification FragmentSpecification::copy() const {
@@ -753,6 +756,24 @@ bool FragmentSpecification::areGameFormulasAllowed() const {
 
 FragmentSpecification& FragmentSpecification::setGameFormulasAllowed(bool newValue) {
     gameFormula = newValue;
+    return *this;
+}
+
+bool FragmentSpecification::areDiscountedCumulativeRewardFormulasAllowed() const {
+    return discountedCumulativeRewardFormula;
+}
+
+FragmentSpecification& FragmentSpecification::setDiscountedCumulativeRewardFormulasAllowed(bool newValue) {
+    this->discountedCumulativeRewardFormula = newValue;
+    return *this;
+}
+
+bool FragmentSpecification::areDiscountedTotalRewardFormulasAllowed() const {
+    return discountedTotalRewardFormula;
+}
+
+FragmentSpecification& FragmentSpecification::setDiscountedTotalRewardFormulasAllowed(bool newValue) {
+    this->discountedTotalRewardFormula = newValue;
     return *this;
 }
 

--- a/src/storm/logic/FragmentSpecification.h
+++ b/src/storm/logic/FragmentSpecification.h
@@ -162,6 +162,12 @@ class FragmentSpecification {
     bool areGameFormulasAllowed() const;
     FragmentSpecification& setGameFormulasAllowed(bool newValue);
 
+    bool areDiscountedCumulativeRewardFormulasAllowed() const;
+    FragmentSpecification& setDiscountedCumulativeRewardFormulasAllowed(bool newValue);
+
+    bool areDiscountedTotalRewardFormulasAllowed() const;
+    FragmentSpecification& setDiscountedTotalRewardFormulasAllowed(bool newValue);
+
     FragmentSpecification& setOperatorsAllowed(bool newValue);
     FragmentSpecification& setTimeAllowed(bool newValue);
     FragmentSpecification& setLongRunAverageProbabilitiesAllowed(bool newValue);
@@ -226,6 +232,9 @@ class FragmentSpecification {
     bool operatorsAtTopLevelOfMultiObjectiveFormulasRequired;
 
     bool rewardAccumulation;
+
+    bool discountedCumulativeRewardFormula;
+    bool discountedTotalRewardFormula;
 };
 
 // Propositional.

--- a/src/storm/logic/LiftableTransitionRewardsVisitor.cpp
+++ b/src/storm/logic/LiftableTransitionRewardsVisitor.cpp
@@ -149,6 +149,19 @@ boost::any LiftableTransitionRewardsVisitor::visit(HOAPathFormula const& f, boos
     return true;
 }
 
+boost::any LiftableTransitionRewardsVisitor::visit(DiscountedCumulativeRewardFormula const& f, boost::any const&) const {
+    for (unsigned i = 0; i < f.getDimension(); ++i) {
+        if (f.getTimeBoundReference(i).isRewardBound() && rewardModelHasTransitionRewards(f.getTimeBoundReference(i).getRewardName())) {
+            return false;
+        }
+    }
+    return true;
+}
+
+boost::any LiftableTransitionRewardsVisitor::visit(DiscountedTotalRewardFormula const&, boost::any const&) const {
+    return true;
+}
+
 bool LiftableTransitionRewardsVisitor::rewardModelHasTransitionRewards(std::string const& rewardModelName) const {
     if (symbolicModelDescription.hasModel()) {
         if (symbolicModelDescription.isJaniModel()) {

--- a/src/storm/logic/LiftableTransitionRewardsVisitor.h
+++ b/src/storm/logic/LiftableTransitionRewardsVisitor.h
@@ -42,6 +42,8 @@ class LiftableTransitionRewardsVisitor : public FormulaVisitor {
     virtual boost::any visit(UnaryBooleanPathFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(UntilFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(HOAPathFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedCumulativeRewardFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedTotalRewardFormula const& f, boost::any const& data) const override;
 
    private:
     storm::storage::SymbolicModelDescription const& symbolicModelDescription;

--- a/src/storm/logic/RewardAccumulationEliminationVisitor.h
+++ b/src/storm/logic/RewardAccumulationEliminationVisitor.h
@@ -29,6 +29,8 @@ class RewardAccumulationEliminationVisitor : public CloneVisitor {
     virtual boost::any visit(LongRunAverageRewardFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(RewardOperatorFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(TotalRewardFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedCumulativeRewardFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedTotalRewardFormula const& f, boost::any const& data) const override;
 
    private:
     bool canEliminate(storm::logic::RewardAccumulation const& accumulation, boost::optional<std::string> rewardModelName) const;

--- a/src/storm/logic/RewardModelNameSubstitutionVisitor.cpp
+++ b/src/storm/logic/RewardModelNameSubstitutionVisitor.cpp
@@ -95,5 +95,25 @@ std::string const& RewardModelNameSubstitutionVisitor::getNewName(std::string co
     }
 }
 
+boost::any RewardModelNameSubstitutionVisitor::visit(DiscountedCumulativeRewardFormula const& f, boost::any const&) const {
+    // Data is unused; no children to pass this on.
+    std::vector<TimeBound> bounds;
+    std::vector<TimeBoundReference> timeBoundReferences;
+    for (uint64_t i = 0; i < f.getDimension(); ++i) {
+        bounds.emplace_back(TimeBound(f.isBoundStrict(i), f.getBound(i)));
+        storm::logic::TimeBoundReference tbr = f.getTimeBoundReference(i);
+        if (tbr.isRewardBound()) {
+            tbr = storm::logic::TimeBoundReference(getNewName(tbr.getRewardName()), tbr.getOptionalRewardAccumulation());
+        }
+        timeBoundReferences.push_back(std::move(tbr));
+    }
+    if (f.hasRewardAccumulation()) {
+        return std::static_pointer_cast<Formula>(
+            std::make_shared<DiscountedCumulativeRewardFormula>(f.getDiscountFactor(), bounds, timeBoundReferences, f.getRewardAccumulation()));
+    } else {
+        return std::static_pointer_cast<Formula>(std::make_shared<DiscountedCumulativeRewardFormula>(f.getDiscountFactor(), bounds, timeBoundReferences));
+    }
+}
+
 }  // namespace logic
 }  // namespace storm

--- a/src/storm/logic/RewardModelNameSubstitutionVisitor.h
+++ b/src/storm/logic/RewardModelNameSubstitutionVisitor.h
@@ -18,6 +18,7 @@ class RewardModelNameSubstitutionVisitor : public CloneVisitor {
     virtual boost::any visit(BoundedUntilFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(CumulativeRewardFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(RewardOperatorFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedCumulativeRewardFormula const& f, boost::any const& data) const override;
 
    private:
     std::string const& getNewName(std::string const& oldName) const;

--- a/src/storm/logic/ToExpressionVisitor.cpp
+++ b/src/storm/logic/ToExpressionVisitor.cpp
@@ -138,5 +138,13 @@ boost::any ToExpressionVisitor::visit(UntilFormula const&, boost::any const&) co
 boost::any ToExpressionVisitor::visit(HOAPathFormula const&, boost::any const&) const {
     STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Cannot assemble expression from formula that contains illegal elements.");
 }
+
+boost::any ToExpressionVisitor::visit(DiscountedCumulativeRewardFormula const&, boost::any const&) const {
+    STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Cannot assemble expression from formula that contains illegal elements.");
+}
+
+boost::any ToExpressionVisitor::visit(DiscountedTotalRewardFormula const&, boost::any const&) const {
+    STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Cannot assemble expression from formula that contains illegal elements.");
+}
 }  // namespace logic
 }  // namespace storm

--- a/src/storm/logic/ToExpressionVisitor.h
+++ b/src/storm/logic/ToExpressionVisitor.h
@@ -37,6 +37,8 @@ class ToExpressionVisitor : public FormulaVisitor {
     virtual boost::any visit(UnaryBooleanPathFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(UntilFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(HOAPathFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedCumulativeRewardFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedTotalRewardFormula const& f, boost::any const& data) const override;
 };
 
 }  // namespace logic

--- a/src/storm/logic/ToPrefixStringVisitor.cpp
+++ b/src/storm/logic/ToPrefixStringVisitor.cpp
@@ -193,5 +193,13 @@ boost::any ToPrefixStringVisitor::visit(UntilFormula const& f, boost::any const&
 boost::any ToPrefixStringVisitor::visit(HOAPathFormula const&, boost::any const&) const {
     STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Can not convert to prefix string");
 }
+
+boost::any ToPrefixStringVisitor::visit(DiscountedCumulativeRewardFormula const&, boost::any const&) const {
+    STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Can not convert to prefix string");
+}
+
+boost::any ToPrefixStringVisitor::visit(DiscountedTotalRewardFormula const&, boost::any const&) const {
+    STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Can not convert to prefix string");
+}
 }  // namespace logic
 }  // namespace storm

--- a/src/storm/logic/ToPrefixStringVisitor.h
+++ b/src/storm/logic/ToPrefixStringVisitor.h
@@ -36,6 +36,8 @@ class ToPrefixStringVisitor : public FormulaVisitor {
     virtual boost::any visit(UnaryBooleanPathFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(UntilFormula const& f, boost::any const& data) const override;
     virtual boost::any visit(HOAPathFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedCumulativeRewardFormula const& f, boost::any const& data) const override;
+    virtual boost::any visit(DiscountedTotalRewardFormula const& f, boost::any const& data) const override;
 };
 
 }  // namespace logic

--- a/src/storm/modelchecker/AbstractModelChecker.cpp
+++ b/src/storm/modelchecker/AbstractModelChecker.cpp
@@ -164,13 +164,21 @@ std::unique_ptr<CheckResult> AbstractModelChecker<ModelType>::computeRewards(Env
                                                                              CheckTask<storm::logic::Formula, SolutionType> const& checkTask) {
     storm::logic::Formula const& rewardFormula = checkTask.getFormula();
     if (rewardFormula.isCumulativeRewardFormula()) {
-        return this->computeCumulativeRewards(env, checkTask.substituteFormula(rewardFormula.asCumulativeRewardFormula()));
+        if (rewardFormula.isDiscountedCumulativeRewardFormula()) {
+            return this->computeDiscountedCumulativeRewards(env, checkTask.substituteFormula(rewardFormula.asDiscountedCumulativeRewardFormula()));
+        } else {
+            return this->computeCumulativeRewards(env, checkTask.substituteFormula(rewardFormula.asCumulativeRewardFormula()));
+        }
     } else if (rewardFormula.isInstantaneousRewardFormula()) {
         return this->computeInstantaneousRewards(env, checkTask.substituteFormula(rewardFormula.asInstantaneousRewardFormula()));
     } else if (rewardFormula.isReachabilityRewardFormula()) {
         return this->computeReachabilityRewards(env, checkTask.substituteFormula(rewardFormula.asReachabilityRewardFormula()));
     } else if (rewardFormula.isTotalRewardFormula()) {
-        return this->computeTotalRewards(env, checkTask.substituteFormula(rewardFormula.asTotalRewardFormula()));
+        if (rewardFormula.isDiscountedTotalRewardFormula()) {
+            return this->computeDiscountedTotalRewards(env, checkTask.substituteFormula(rewardFormula.asDiscountedTotalRewardFormula()));
+        } else {
+            return this->computeTotalRewards(env, checkTask.substituteFormula(rewardFormula.asTotalRewardFormula()));
+        }
     } else if (rewardFormula.isLongRunAverageRewardFormula()) {
         return this->computeLongRunAverageRewards(env, checkTask.substituteFormula(rewardFormula.asLongRunAverageRewardFormula()));
     } else if (rewardFormula.isConditionalRewardFormula()) {
@@ -224,6 +232,20 @@ std::unique_ptr<CheckResult> AbstractModelChecker<ModelType>::computeLongRunAver
 template<typename ModelType>
 std::unique_ptr<CheckResult> AbstractModelChecker<ModelType>::computeLongRunAverageProbabilities(
     Environment const&, CheckTask<storm::logic::StateFormula, SolutionType> const& checkTask) {
+    STORM_LOG_THROW(false, storm::exceptions::NotImplementedException,
+                    "This model checker (" << getClassName() << ") does not support the formula: " << checkTask.getFormula() << ".");
+}
+
+template<typename ModelType>
+std::unique_ptr<CheckResult> AbstractModelChecker<ModelType>::computeDiscountedCumulativeRewards(
+    Environment const&, CheckTask<storm::logic::DiscountedCumulativeRewardFormula, SolutionType> const& checkTask) {
+    STORM_LOG_THROW(false, storm::exceptions::NotImplementedException,
+                    "This model checker (" << getClassName() << ") does not support the formula: " << checkTask.getFormula() << ".");
+}
+
+template<typename ModelType>
+std::unique_ptr<CheckResult> AbstractModelChecker<ModelType>::computeDiscountedTotalRewards(
+    Environment const&, CheckTask<storm::logic::DiscountedTotalRewardFormula, SolutionType> const& checkTask) {
     STORM_LOG_THROW(false, storm::exceptions::NotImplementedException,
                     "This model checker (" << getClassName() << ") does not support the formula: " << checkTask.getFormula() << ".");
 }

--- a/src/storm/modelchecker/AbstractModelChecker.h
+++ b/src/storm/modelchecker/AbstractModelChecker.h
@@ -83,6 +83,10 @@ class AbstractModelChecker {
                                                              CheckTask<storm::logic::TotalRewardFormula, SolutionType> const& checkTask);
     virtual std::unique_ptr<CheckResult> computeLongRunAverageRewards(Environment const& env,
                                                                       CheckTask<storm::logic::LongRunAverageRewardFormula, SolutionType> const& checkTask);
+    virtual std::unique_ptr<CheckResult> computeDiscountedCumulativeRewards(
+        Environment const& env, CheckTask<storm::logic::DiscountedCumulativeRewardFormula, SolutionType> const& checkTask);
+    virtual std::unique_ptr<CheckResult> computeDiscountedTotalRewards(Environment const& env,
+                                                                       CheckTask<storm::logic::DiscountedTotalRewardFormula, SolutionType> const& checkTask);
 
     // The methods to compute the long-run average probabilities and timing measures.
     virtual std::unique_ptr<CheckResult> computeLongRunAverageProbabilities(Environment const& env,

--- a/src/storm/modelchecker/helper/DiscountingHelper.cpp
+++ b/src/storm/modelchecker/helper/DiscountingHelper.cpp
@@ -1,0 +1,146 @@
+#include "DiscountingHelper.h"
+#include "storm/environment/solver/MinMaxSolverEnvironment.h"
+#include "storm/exceptions/IllegalFunctionCallException.h"
+#include "storm/solver/helper/DiscountedValueIterationHelper.h"
+#include "storm/solver/helper/SchedulerTrackingHelper.h"
+#include "storm/storage/SparseMatrix.h"
+
+namespace storm {
+namespace modelchecker {
+namespace helper {
+
+template<typename ValueType, bool TrivialRowGrouping>
+DiscountingHelper<ValueType, TrivialRowGrouping>::DiscountingHelper(storm::storage::SparseMatrix<ValueType> const& A, ValueType discountFactor)
+    : localA(nullptr), A(&A), discountFactor(discountFactor) {
+    progressMeasurement = storm::utility::ProgressMeasurement("iterations");
+    storm::storage::SparseMatrix<ValueType> discountedMatrix(A);
+    discountedMatrix.scaleRowsInPlace(std::vector<ValueType>(discountedMatrix.getRowCount(), discountFactor));
+    discountedA = discountedMatrix;
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+DiscountingHelper<ValueType, TrivialRowGrouping>::DiscountingHelper(storm::storage::SparseMatrix<ValueType> const& A, ValueType discountFactor,
+                                                                    bool trackScheduler)
+    : localA(nullptr), A(&A), discountFactor(discountFactor), trackScheduler(trackScheduler) {
+    progressMeasurement = storm::utility::ProgressMeasurement("iterations");
+    storm::storage::SparseMatrix<ValueType> discountedMatrix(A);
+    discountedMatrix.scaleRowsInPlace(std::vector<ValueType>(discountedMatrix.getRowCount(), discountFactor));
+    discountedA = discountedMatrix;
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+void DiscountingHelper<ValueType, TrivialRowGrouping>::setUpViOperator() const {
+    if (!viOperator) {
+        viOperator = std::make_shared<solver::helper::ValueIterationOperator<ValueType, TrivialRowGrouping>>();
+        viOperator->setMatrixBackwards(this->discountedA);
+    }
+    /*if (this->choiceFixedForRowGroup) {
+        // Ignore those rows that are not selected
+        assert(this->initialScheduler);
+        auto callback = [&](uint64_t groupIndex, uint64_t localRowIndex) {
+            return this->choiceFixedForRowGroup->get(groupIndex) && this->initialScheduler->at(groupIndex) != localRowIndex;
+        };
+        viOperator->setIgnoredRows(true, callback);
+    }*/
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+void DiscountingHelper<ValueType, TrivialRowGrouping>::showProgressIterative(uint64_t iteration) const {
+    progressMeasurement->updateProgress(iteration);
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+bool DiscountingHelper<ValueType, TrivialRowGrouping>::solveWithDiscountedValueIteration(storm::Environment const& env,
+                                                                                         std::optional<OptimizationDirection> dir, std::vector<ValueType>& x,
+                                                                                         std::vector<ValueType> const& b) const {
+    storm::solver::helper::DiscountedValueIterationHelper<ValueType, TrivialRowGrouping> viHelper(viOperator);
+    uint64_t numIterations{0};
+    auto viCallback = [&](solver::SolverStatus const& current) {
+        return current;
+        showProgressIterative(numIterations);
+        // return this->updateStatus(current, x, guarantee, numIterations, env.solver().minMax().getMaximalNumberOfIterations());
+    };
+    auto maximalAbsoluteReward = storm::utility::zero<ValueType>();
+    for (auto const& entry : b) {
+        if (storm::utility::abs(entry) > maximalAbsoluteReward) {
+            maximalAbsoluteReward = storm::utility::abs(entry);
+        }
+    }
+    progressMeasurement->startNewMeasurement(0);
+    auto status = viHelper.DiscountedVI(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(),
+                                        storm::utility::convertNumber<ValueType>(env.solver().minMax().getPrecision()), discountFactor, maximalAbsoluteReward,
+                                        dir, viCallback, env.solver().minMax().getMultiplicationStyle());
+
+    // this->reportStatus(status, numIterations);
+
+    // If requested, we store the scheduler for retrieval.
+    if (this->isTrackSchedulerSet()) {
+        this->extractScheduler(x, b, dir.value(), true);
+    }
+    return status == solver::SolverStatus::Converged || status == solver::SolverStatus::TerminatedEarly;
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+storm::storage::Scheduler<ValueType> DiscountingHelper<ValueType, TrivialRowGrouping>::computeScheduler() const {
+    STORM_LOG_THROW(hasScheduler(), storm::exceptions::IllegalFunctionCallException, "Cannot retrieve scheduler, because none was generated.");
+    storm::storage::Scheduler<ValueType> result(schedulerChoices->size());
+    uint_fast64_t state = 0;
+    for (auto const& schedulerChoice : schedulerChoices.get()) {
+        result.setChoice(schedulerChoice, state);
+        ++state;
+    }
+    return result;
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+bool DiscountingHelper<ValueType, TrivialRowGrouping>::hasScheduler() const {
+    return static_cast<bool>(schedulerChoices);
+}
+
+template<>
+void DiscountingHelper<double, true>::extractScheduler(std::vector<double>& x, std::vector<double> const& b, OptimizationDirection const& dir,
+                                                       bool robust) const {}
+
+template<>
+void DiscountingHelper<storm::RationalNumber, true>::extractScheduler(std::vector<storm::RationalNumber>& x, std::vector<storm::RationalNumber> const& b,
+                                                                      OptimizationDirection const& dir, bool robust) const {}
+
+template<typename ValueType, bool TrivialRowGrouping>
+void DiscountingHelper<ValueType, TrivialRowGrouping>::extractScheduler(std::vector<ValueType>& x, std::vector<ValueType> const& b,
+                                                                        OptimizationDirection const& dir, bool robust) const {
+    // Make sure that storage for scheduler choices is available
+    if (!this->schedulerChoices) {
+        this->schedulerChoices = std::vector<uint64_t>(x.size(), 0);
+    } else {
+        this->schedulerChoices->resize(x.size(), 0);
+    }
+    // Set the correct choices.
+    STORM_LOG_WARN_COND(viOperator, "Expected VI operator to be initialized for scheduler extraction. Initializing now, but this is inefficient.");
+    if (!viOperator) {
+        setUpViOperator();
+    }
+    storm::solver::helper::SchedulerTrackingHelper<ValueType> schedHelper(viOperator);
+    schedHelper.computeScheduler(x, b, dir, *this->schedulerChoices, robust, nullptr);
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+void DiscountingHelper<ValueType, TrivialRowGrouping>::setTrackScheduler(bool trackScheduler) {
+    this->trackScheduler = trackScheduler;
+    if (!this->trackScheduler) {
+        schedulerChoices = boost::none;
+    }
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+bool DiscountingHelper<ValueType, TrivialRowGrouping>::isTrackSchedulerSet() const {
+    return this->trackScheduler;
+}
+
+template class DiscountingHelper<double>;
+template class DiscountingHelper<storm::RationalNumber>;
+
+template class DiscountingHelper<double, true>;
+template class DiscountingHelper<storm::RationalNumber, true>;
+}  // namespace helper
+}  // namespace modelchecker
+}  // namespace storm

--- a/src/storm/modelchecker/helper/DiscountingHelper.h
+++ b/src/storm/modelchecker/helper/DiscountingHelper.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "SingleValueModelCheckerHelper.h"
+#include "storm/solver/helper/ValueIterationOperator.h"
+#include "storm/storage/Scheduler.h"
+#include "storm/utility/ProgressMeasurement.h"
+
+namespace storm {
+class Environment;
+namespace modelchecker {
+namespace helper {
+template<typename ValueType, bool TrivialRowGrouping = false>
+class DiscountingHelper : public SingleValueModelCheckerHelper<ValueType, storm::models::ModelRepresentation::Sparse> {
+   public:
+    DiscountingHelper(storm::storage::SparseMatrix<ValueType> const& A, ValueType discountFactor);
+    DiscountingHelper(storm::storage::SparseMatrix<ValueType> const& A, ValueType discountFactor, bool trackScheduler);
+
+    void setUpViOperator() const;
+
+    bool solveWithDiscountedValueIteration(Environment const& env, std::optional<OptimizationDirection> dir, std::vector<ValueType>& x,
+                                           std::vector<ValueType> const& b) const;
+
+    /*!
+     * Retrieves the generated scheduler. Note: it is only legal to call this function if a scheduler was generated.
+     */
+    storm::storage::Scheduler<ValueType> computeScheduler() const;
+
+    /*!
+     * Retrieves whether the solver generated a scheduler.
+     */
+    bool hasScheduler() const;
+
+    void setTrackScheduler(bool trackScheduler);
+
+    bool isTrackSchedulerSet() const;
+
+   private:
+    void showProgressIterative(uint64_t iteration) const;
+
+    void extractScheduler(std::vector<ValueType>& x, std::vector<ValueType> const& b, OptimizationDirection const& dir, bool robust) const;
+
+    mutable std::shared_ptr<storm::solver::helper::ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator;
+    mutable std::unique_ptr<std::vector<ValueType>> auxiliaryRowGroupVector;
+
+    mutable boost::optional<storm::utility::ProgressMeasurement> progressMeasurement;
+
+    // If the solver takes posession of the matrix, we store the moved matrix in this member, so it gets deleted
+    // when the solver is destructed.
+    std::unique_ptr<storm::storage::SparseMatrix<ValueType>> localA;
+
+    // A reference to the original sparse matrix given to this solver. If the solver takes posession of the matrix
+    // the reference refers to localA.
+    storm::storage::SparseMatrix<ValueType> const* A;
+
+    storm::storage::SparseMatrix<ValueType> discountedA;
+
+    ValueType discountFactor;
+
+    /// Whether we generate a scheduler during solving.
+    bool trackScheduler = false;
+
+    /// The scheduler choices that induce the optimal values (if they could be successfully generated).
+    mutable boost::optional<std::vector<uint_fast64_t>> schedulerChoices;
+};
+}  // namespace helper
+}  // namespace modelchecker
+}  // namespace storm

--- a/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.h
+++ b/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.h
@@ -41,12 +41,16 @@ class SparseDtmcPrctlModelChecker : public SparsePropositionalModelChecker<Spars
 
     virtual std::unique_ptr<CheckResult> computeCumulativeRewards(Environment const& env,
                                                                   CheckTask<storm::logic::CumulativeRewardFormula, ValueType> const& checkTask) override;
+    virtual std::unique_ptr<CheckResult> computeDiscountedCumulativeRewards(
+        Environment const& env, CheckTask<storm::logic::DiscountedCumulativeRewardFormula, ValueType> const& checkTask) override;
     virtual std::unique_ptr<CheckResult> computeInstantaneousRewards(Environment const& env,
                                                                      CheckTask<storm::logic::InstantaneousRewardFormula, ValueType> const& checkTask) override;
     virtual std::unique_ptr<CheckResult> computeReachabilityRewards(Environment const& env,
                                                                     CheckTask<storm::logic::EventuallyFormula, ValueType> const& checkTask) override;
     virtual std::unique_ptr<CheckResult> computeTotalRewards(Environment const& env,
                                                              CheckTask<storm::logic::TotalRewardFormula, ValueType> const& checkTask) override;
+    virtual std::unique_ptr<CheckResult> computeDiscountedTotalRewards(
+        Environment const& env, CheckTask<storm::logic::DiscountedTotalRewardFormula, ValueType> const& checkTask) override;
     virtual std::unique_ptr<CheckResult> computeConditionalRewards(Environment const& env,
                                                                    CheckTask<storm::logic::ConditionalFormula, ValueType> const& checkTask) override;
     virtual std::unique_ptr<CheckResult> computeLongRunAverageRewards(

--- a/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.h
+++ b/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.h
@@ -38,10 +38,14 @@ class SparseMdpPrctlModelChecker : public SparsePropositionalModelChecker<Sparse
                                                                          CheckTask<storm::logic::ConditionalFormula, SolutionType> const& checkTask) override;
     virtual std::unique_ptr<CheckResult> computeCumulativeRewards(Environment const& env,
                                                                   CheckTask<storm::logic::CumulativeRewardFormula, SolutionType> const& checkTask) override;
+    virtual std::unique_ptr<CheckResult> computeDiscountedCumulativeRewards(
+        Environment const& env, CheckTask<storm::logic::DiscountedCumulativeRewardFormula, SolutionType> const& checkTask) override;
     virtual std::unique_ptr<CheckResult> computeInstantaneousRewards(
         Environment const& env, CheckTask<storm::logic::InstantaneousRewardFormula, SolutionType> const& checkTask) override;
     virtual std::unique_ptr<CheckResult> computeTotalRewards(Environment const& env,
                                                              CheckTask<storm::logic::TotalRewardFormula, SolutionType> const& checkTask) override;
+    virtual std::unique_ptr<CheckResult> computeDiscountedTotalRewards(
+        Environment const& env, CheckTask<storm::logic::DiscountedTotalRewardFormula, SolutionType> const& checkTask) override;
     virtual std::unique_ptr<CheckResult> computeReachabilityRewards(Environment const& env,
                                                                     CheckTask<storm::logic::EventuallyFormula, SolutionType> const& checkTask) override;
     virtual std::unique_ptr<CheckResult> computeReachabilityTimes(Environment const& env,

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -14,6 +14,7 @@
 #include "storm/solver/LinearEquationSolver.h"
 #include "storm/solver/multiplier/Multiplier.h"
 
+#include "storm/modelchecker/helper/DiscountingHelper.h"
 #include "storm/modelchecker/hints/ExplicitModelCheckerHint.h"
 #include "storm/modelchecker/prctl/helper/DsMpiUpperRewardBoundsComputer.h"
 #include "storm/modelchecker/prctl/helper/rewardbounded/MultiDimensionalRewardUnfolding.h"
@@ -377,6 +378,61 @@ std::vector<ValueType> SparseDtmcPrctlHelper<ValueType, RewardModelType>::comput
     storm::storage::BitVector rew0States = storm::utility::graph::performProbGreater0(backwardTransitions, statesWithoutReward, ~statesWithoutReward);
     rew0States.complement();
     return computeReachabilityRewards(env, std::move(goal), transitionMatrix, backwardTransitions, rewardModel, rew0States, qualitative, hint);
+}
+
+template<>
+std::vector<storm::RationalFunction> SparseDtmcPrctlHelper<storm::RationalFunction>::computeDiscountedCumulativeRewards(
+    Environment const& env, storm::solver::SolveGoal<storm::RationalFunction>&& goal,
+    storm::storage::SparseMatrix<storm::RationalFunction> const& transitionMatrix,
+    storm::models::sparse::StandardRewardModel<storm::RationalFunction> const& rewardModel, uint_fast64_t stepBound, storm::RationalFunction discountFactor) {
+    STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "The specified property is not supported by this value type.");
+    return {};
+}
+
+template<typename ValueType, typename RewardModelType>
+std::vector<ValueType> SparseDtmcPrctlHelper<ValueType, RewardModelType>::computeDiscountedCumulativeRewards(
+    Environment const& env, storm::solver::SolveGoal<ValueType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+    RewardModelType const& rewardModel, uint_fast64_t stepBound, ValueType discountFactor) {
+    // Only compute the result if the model has at least one reward this->getModel().
+    STORM_LOG_THROW(!rewardModel.empty(), storm::exceptions::InvalidPropertyException, "Missing reward model for formula. Skipping formula.");
+
+    // Compute the reward vector to add in each step based on the available reward models.
+    std::vector<ValueType> totalRewardVector = rewardModel.getTotalRewardVector(transitionMatrix);
+
+    // Initialize result to the zero vector.
+    std::vector<ValueType> result(transitionMatrix.getRowGroupCount(), storm::utility::zero<ValueType>());
+
+    auto multiplier = storm::solver::MultiplierFactory<ValueType>().create(env, transitionMatrix);
+    multiplier->repeatedMultiplyAndReduce(env, goal.direction(), result, &totalRewardVector, stepBound);
+
+    return result;
+}
+
+template<>
+std::vector<storm::RationalFunction> SparseDtmcPrctlHelper<storm::RationalFunction>::computeDiscountedTotalRewards(
+    Environment const& env, storm::solver::SolveGoal<storm::RationalFunction>&& goal,
+    storm::storage::SparseMatrix<storm::RationalFunction> const& transitionMatrix,
+    storm::storage::SparseMatrix<storm::RationalFunction> const& backwardTransitions,
+    storm::models::sparse::StandardRewardModel<storm::RationalFunction> const& rewardModel, bool qualitative, storm::RationalFunction discountFactor,
+    ModelCheckerHint const& hint) {
+    STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "The specified property is not supported by this value type.");
+    return {};
+}
+
+template<typename ValueType, typename RewardModelType>
+std::vector<ValueType> SparseDtmcPrctlHelper<ValueType, RewardModelType>::computeDiscountedTotalRewards(
+    Environment const& env, storm::solver::SolveGoal<ValueType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+    storm::storage::SparseMatrix<ValueType> const& backwardTransitions, RewardModelType const& rewardModel, bool qualitative, ValueType discountFactor,
+    ModelCheckerHint const& hint) {
+    // Reduce to reachability rewards
+    std::vector<ValueType> b;
+
+    std::vector<ValueType> x = std::vector<ValueType>(transitionMatrix.getRowGroupCount(), storm::utility::zero<ValueType>());
+    b = rewardModel.getTotalRewardVector(transitionMatrix);
+    storm::modelchecker::helper::DiscountingHelper<ValueType, true> discountingHelper(transitionMatrix, discountFactor);
+    discountingHelper.setUpViOperator();
+    discountingHelper.solveWithDiscountedValueIteration(env, std::nullopt, x, b);
+    return std::vector<ValueType>(std::move(x));
 }
 
 template<typename ValueType, typename RewardModelType>

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
@@ -62,6 +62,16 @@ class SparseDtmcPrctlHelper {
                                                       storm::storage::SparseMatrix<ValueType> const& backwardTransitions, RewardModelType const& rewardModel,
                                                       bool qualitative, ModelCheckerHint const& hint = ModelCheckerHint());
 
+    static std::vector<ValueType> computeDiscountedCumulativeRewards(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
+                                                                     storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+                                                                     RewardModelType const& rewardModel, uint_fast64_t stepBound, ValueType discountFactor);
+
+    static std::vector<ValueType> computeDiscountedTotalRewards(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
+                                                                storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+                                                                storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
+                                                                RewardModelType const& rewardModel, bool qualitative, ValueType discountFactor,
+                                                                ModelCheckerHint const& hint = ModelCheckerHint());
+
     static std::vector<ValueType> computeReachabilityRewards(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
                                                              storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                              storm::storage::SparseMatrix<ValueType> const& backwardTransitions,

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -4,6 +4,7 @@
 
 #include "storm/modelchecker/prctl/helper/SemanticSolutionType.h"
 
+#include "storm/modelchecker/helper/DiscountingHelper.h"
 #include "storm/modelchecker/hints/ExplicitModelCheckerHint.h"
 #include "storm/modelchecker/prctl/helper/BaierUpperRewardBoundsComputer.h"
 #include "storm/modelchecker/prctl/helper/DsMpiUpperRewardBoundsComputer.h"
@@ -982,6 +983,52 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
 
 template<typename ValueType, typename SolutionType>
 template<typename RewardModelType>
+std::vector<SolutionType> SparseMdpPrctlHelper<ValueType, SolutionType>::computeDiscountedCumulativeRewards(
+    Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+    RewardModelType const& rewardModel, uint_fast64_t stepBound, ValueType discountFactor) {
+    // Only compute the result if the model has at least one reward this->getModel().
+    STORM_LOG_THROW(!rewardModel.empty(), storm::exceptions::InvalidPropertyException, "Missing reward model for formula. Skipping formula.");
+
+    // Compute the reward vector to add in each step based on the available reward models.
+    std::vector<SolutionType> totalRewardVector = rewardModel.getTotalRewardVector(transitionMatrix);
+
+    // Initialize result to the zero vector.
+    std::vector<SolutionType> result(transitionMatrix.getRowGroupCount(), storm::utility::zero<ValueType>());
+
+    auto multiplier = storm::solver::MultiplierFactory<ValueType>().create(env, transitionMatrix);
+    multiplier->repeatedMultiplyAndReduceWithFactor(env, goal.direction(), result, &totalRewardVector, stepBound, discountFactor);
+
+    return result;
+}
+
+template<typename ValueType, typename SolutionType>
+template<typename RewardModelType>
+MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueType, SolutionType>::computeDiscountedTotalRewards(
+    Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+    storm::storage::SparseMatrix<ValueType> const& backwardTransitions, RewardModelType const& rewardModel, bool qualitative, bool produceScheduler,
+    ValueType discountFactor, ModelCheckerHint const& hint) {
+    std::vector<ValueType> b;
+
+    std::vector<SolutionType> x = std::vector<SolutionType>(transitionMatrix.getRowGroupCount(), storm::utility::zero<SolutionType>());
+    b = rewardModel.getTotalRewardVector(transitionMatrix);
+    storm::modelchecker::helper::DiscountingHelper<ValueType> discountingHelper(transitionMatrix, discountFactor, produceScheduler);
+    discountingHelper.setUpViOperator();
+
+    discountingHelper.solveWithDiscountedValueIteration(env, goal.direction(), x, b);
+
+    std::unique_ptr<storm::storage::Scheduler<SolutionType>> scheduler;
+    if (produceScheduler) {
+        scheduler = std::make_unique<storm::storage::Scheduler<ValueType>>(discountingHelper.computeScheduler());
+    }
+    STORM_LOG_ASSERT(!produceScheduler || scheduler, "Expected that a scheduler was obtained.");
+    STORM_LOG_ASSERT((!produceScheduler && !scheduler) || !scheduler->isPartialScheduler(), "Expected a fully defined scheduler");
+    STORM_LOG_ASSERT((!produceScheduler && !scheduler) || scheduler->isDeterministicScheduler(), "Expected a deterministic scheduler");
+    STORM_LOG_ASSERT((!produceScheduler && !scheduler) || scheduler->isMemorylessScheduler(), "Expected a memoryless scheduler");
+    return MDPSparseModelCheckingHelperReturnType<SolutionType>(std::move(x), std::move(scheduler));
+}
+
+template<typename ValueType, typename SolutionType>
+template<typename RewardModelType>
 MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueType, SolutionType>::computeReachabilityRewards(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, RewardModelType const& rewardModel, storm::storage::BitVector const& targetStates,
@@ -1620,6 +1667,9 @@ template std::vector<double> SparseMdpPrctlHelper<double>::computeCumulativeRewa
                                                                                     storm::storage::SparseMatrix<double> const& transitionMatrix,
                                                                                     storm::models::sparse::StandardRewardModel<double> const& rewardModel,
                                                                                     uint_fast64_t stepBound);
+template std::vector<double> SparseMdpPrctlHelper<double>::computeDiscountedCumulativeRewards(
+    Environment const& env, storm::solver::SolveGoal<double>&& goal, storm::storage::SparseMatrix<double> const& transitionMatrix,
+    storm::models::sparse::StandardRewardModel<double> const& rewardModel, uint_fast64_t stepBound, double discountFactor);
 template MDPSparseModelCheckingHelperReturnType<double> SparseMdpPrctlHelper<double>::computeReachabilityRewards(
     Environment const& env, storm::solver::SolveGoal<double>&& goal, storm::storage::SparseMatrix<double> const& transitionMatrix,
     storm::storage::SparseMatrix<double> const& backwardTransitions, storm::models::sparse::StandardRewardModel<double> const& rewardModel,
@@ -1628,6 +1678,10 @@ template MDPSparseModelCheckingHelperReturnType<double> SparseMdpPrctlHelper<dou
     Environment const& env, storm::solver::SolveGoal<double>&& goal, storm::storage::SparseMatrix<double> const& transitionMatrix,
     storm::storage::SparseMatrix<double> const& backwardTransitions, storm::models::sparse::StandardRewardModel<double> const& rewardModel, bool qualitative,
     bool produceScheduler, ModelCheckerHint const& hint);
+template MDPSparseModelCheckingHelperReturnType<double> SparseMdpPrctlHelper<double>::computeDiscountedTotalRewards(
+    Environment const& env, storm::solver::SolveGoal<double>&& goal, storm::storage::SparseMatrix<double> const& transitionMatrix,
+    storm::storage::SparseMatrix<double> const& backwardTransitions, storm::models::sparse::StandardRewardModel<double> const& rewardModel, bool qualitative,
+    bool produceScheduler, double discountFactor, ModelCheckerHint const& hint);
 
 #ifdef STORM_HAVE_CARL
 template class SparseMdpPrctlHelper<storm::RationalNumber>;
@@ -1637,6 +1691,9 @@ template std::vector<storm::RationalNumber> SparseMdpPrctlHelper<storm::Rational
 template std::vector<storm::RationalNumber> SparseMdpPrctlHelper<storm::RationalNumber>::computeCumulativeRewards(
     Environment const& env, storm::solver::SolveGoal<storm::RationalNumber>&& goal, storm::storage::SparseMatrix<storm::RationalNumber> const& transitionMatrix,
     storm::models::sparse::StandardRewardModel<storm::RationalNumber> const& rewardModel, uint_fast64_t stepBound);
+template std::vector<storm::RationalNumber> SparseMdpPrctlHelper<storm::RationalNumber>::computeDiscountedCumulativeRewards(
+    Environment const& env, storm::solver::SolveGoal<storm::RationalNumber>&& goal, storm::storage::SparseMatrix<storm::RationalNumber> const& transitionMatrix,
+    storm::models::sparse::StandardRewardModel<storm::RationalNumber> const& rewardModel, uint_fast64_t stepBound, storm::RationalNumber discountFactor);
 template MDPSparseModelCheckingHelperReturnType<storm::RationalNumber> SparseMdpPrctlHelper<storm::RationalNumber>::computeReachabilityRewards(
     Environment const& env, storm::solver::SolveGoal<storm::RationalNumber>&& goal, storm::storage::SparseMatrix<storm::RationalNumber> const& transitionMatrix,
     storm::storage::SparseMatrix<storm::RationalNumber> const& backwardTransitions,
@@ -1647,6 +1704,11 @@ template MDPSparseModelCheckingHelperReturnType<storm::RationalNumber> SparseMdp
     storm::storage::SparseMatrix<storm::RationalNumber> const& backwardTransitions,
     storm::models::sparse::StandardRewardModel<storm::RationalNumber> const& rewardModel, bool qualitative, bool produceScheduler,
     ModelCheckerHint const& hint);
+template MDPSparseModelCheckingHelperReturnType<storm::RationalNumber> SparseMdpPrctlHelper<storm::RationalNumber>::computeDiscountedTotalRewards(
+    Environment const& env, storm::solver::SolveGoal<storm::RationalNumber>&& goal, storm::storage::SparseMatrix<storm::RationalNumber> const& transitionMatrix,
+    storm::storage::SparseMatrix<storm::RationalNumber> const& backwardTransitions,
+    storm::models::sparse::StandardRewardModel<storm::RationalNumber> const& rewardModel, bool qualitative, bool produceScheduler,
+    storm::RationalNumber discountFactor, ModelCheckerHint const& hint);
 #endif
 
 template class SparseMdpPrctlHelper<storm::Interval, double>;

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.h
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.h
@@ -74,6 +74,16 @@ class SparseMdpPrctlHelper {
                                                                                     storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                                     RewardModelType const& rewardModel, bool qualitative, bool produceScheduler,
                                                                                     ModelCheckerHint const& hint = ModelCheckerHint());
+    template<typename RewardModelType>
+    static std::vector<SolutionType> computeDiscountedCumulativeRewards(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
+                                                                        storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+                                                                        RewardModelType const& rewardModel, uint_fast64_t stepBound, ValueType discountFactor);
+
+    template<typename RewardModelType>
+    static MDPSparseModelCheckingHelperReturnType<SolutionType> computeDiscountedTotalRewards(
+        Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+        storm::storage::SparseMatrix<ValueType> const& backwardTransitions, RewardModelType const& rewardModel, bool qualitative, bool produceScheduler,
+        ValueType discountFactor, ModelCheckerHint const& hint = ModelCheckerHint());
 
     template<typename RewardModelType>
     static MDPSparseModelCheckingHelperReturnType<SolutionType> computeReachabilityRewards(

--- a/src/storm/solver/helper/DiscountedValueIterationHelper.cpp
+++ b/src/storm/solver/helper/DiscountedValueIterationHelper.cpp
@@ -1,0 +1,150 @@
+#include "storm/solver/helper/DiscountedValueIterationHelper.h"
+
+#include "storm/adapters/RationalNumberAdapter.h"
+#include "storm/solver/helper/ValueIterationOperator.h"
+#include "storm/utility/Extremum.h"
+
+namespace storm::solver::helper {
+
+template<typename ValueType, storm::OptimizationDirection Dir, bool Relative>
+class DiscountedVIOperatorBackend {
+   public:
+    DiscountedVIOperatorBackend(ValueType const& precision, ValueType const& discountFactor, ValueType const& maximalAbsoluteReward)
+        : precision{precision},
+          discountFactor{discountFactor},
+          bound{(((storm::utility::one<ValueType>() - discountFactor) * precision) / (2 * discountFactor))} {
+        // Intentionally left empty
+        auto upper = storm::utility::log<ValueType>((2 * maximalAbsoluteReward) / (precision * (1 - discountFactor)));
+        maxIterations = storm::utility::convertNumber<uint64_t>(storm::utility::ceil<ValueType>(upper / -storm::utility::log(discountFactor)));
+        STORM_LOG_DEBUG("Maximum number of iterations: " << maxIterations);
+    }
+
+    void startNewIteration() {
+        isConverged = true;
+    }
+
+    void firstRow(ValueType&& value, [[maybe_unused]] uint64_t rowGroup, [[maybe_unused]] uint64_t row) {
+        best = std::move(value);
+    }
+
+    void nextRow(ValueType&& value, [[maybe_unused]] uint64_t rowGroup, [[maybe_unused]] uint64_t row) {
+        best &= value;
+    }
+
+    void applyUpdate(ValueType& currValue, [[maybe_unused]] uint64_t rowGroup) {
+        if (isConverged) {
+            if constexpr (Relative) {
+                isConverged = storm::utility::abs<ValueType>(currValue - *best) <= storm::utility::abs<ValueType>(bound * currValue);
+            } else {
+                isConverged = storm::utility::abs<ValueType>(currValue - *best) <= bound;
+            }
+            // isConverged = currentIteration >= maxIterations;
+        }
+        currValue = std::move(*best);
+    }
+
+    void endOfIteration() {
+        ++currentIteration;
+    }
+
+    bool converged() const {
+        return isConverged;
+    }
+
+    bool constexpr abort() const {
+        return false;
+    }
+
+   private:
+    storm::utility::Extremum<Dir, ValueType> best;
+    uint64_t currentIteration = 0;
+    uint64_t maxIterations = 0;
+    ValueType const precision;
+    ValueType const discountFactor;
+    ValueType const bound;
+    bool isConverged{true};
+};
+
+template<typename ValueType, bool TrivialRowGrouping>
+DiscountedValueIterationHelper<ValueType, TrivialRowGrouping>::DiscountedValueIterationHelper(
+    std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator)
+    : viOperator(viOperator) {
+    // Intentionally left empty
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+template<storm::OptimizationDirection Dir, bool Relative>
+SolverStatus DiscountedValueIterationHelper<ValueType, TrivialRowGrouping>::DiscountedVI(
+    std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, ValueType const& precision,
+    ValueType const& discountFactor, ValueType const& maximalAbsoluteReward, std::function<SolverStatus(SolverStatus const&)> const& iterationCallback,
+    MultiplicationStyle mult) const {
+    DiscountedVIOperatorBackend<ValueType, Dir, Relative> backend{precision, discountFactor, maximalAbsoluteReward};
+    std::vector<ValueType>* operand1{&operand};
+    std::vector<ValueType>* operand2{&operand};
+    if (mult == MultiplicationStyle::Regular) {
+        operand2 = &viOperator->allocateAuxiliaryVector(operand.size());
+    }
+    bool resultInAuxVector{false};
+    SolverStatus status{SolverStatus::InProgress};
+    while (status == SolverStatus::InProgress) {
+        ++numIterations;
+        if (viOperator->template apply(*operand1, *operand2, offsets, backend)) {
+            status = SolverStatus::Converged;
+        } else if (iterationCallback) {
+            status = iterationCallback(status);
+        }
+        if (mult == MultiplicationStyle::Regular) {
+            std::swap(operand1, operand2);
+            resultInAuxVector = !resultInAuxVector;
+        }
+    }
+    if (mult == MultiplicationStyle::Regular) {
+        if (resultInAuxVector) {
+            STORM_LOG_ASSERT(&operand == operand2, "Unexpected operand address");
+            std::swap(*operand1, *operand2);
+        }
+        viOperator->freeAuxiliaryVector();
+    }
+    return status;
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+SolverStatus DiscountedValueIterationHelper<ValueType, TrivialRowGrouping>::DiscountedVI(
+    std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
+    ValueType const& discountFactor, ValueType const& maximalAbsoluteReward, std::optional<storm::OptimizationDirection> const& dir,
+    std::function<SolverStatus(SolverStatus const&)> const& iterationCallback, MultiplicationStyle mult) const {
+    STORM_LOG_ASSERT(TrivialRowGrouping || dir.has_value(), "no optimization direction given!");
+    if (!dir.has_value() || maximize(*dir)) {
+        if (relative) {
+            return DiscountedVI<storm::OptimizationDirection::Maximize, true>(operand, offsets, numIterations, precision, discountFactor, maximalAbsoluteReward,
+                                                                              iterationCallback, mult);
+        } else {
+            return DiscountedVI<storm::OptimizationDirection::Maximize, false>(operand, offsets, numIterations, precision, discountFactor,
+                                                                               maximalAbsoluteReward, iterationCallback, mult);
+        }
+    } else {
+        if (relative) {
+            return DiscountedVI<storm::OptimizationDirection::Minimize, true>(operand, offsets, numIterations, precision, discountFactor, maximalAbsoluteReward,
+                                                                              iterationCallback, mult);
+        } else {
+            return DiscountedVI<storm::OptimizationDirection::Minimize, false>(operand, offsets, numIterations, precision, discountFactor,
+                                                                               maximalAbsoluteReward, iterationCallback, mult);
+        }
+    }
+}
+
+template<typename ValueType, bool TrivialRowGrouping>
+SolverStatus DiscountedValueIterationHelper<ValueType, TrivialRowGrouping>::DiscountedVI(
+    std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision, ValueType const& discountFactor,
+    ValueType const& maximalAbsoluteReward, std::optional<storm::OptimizationDirection> const& dir,
+    std::function<SolverStatus(SolverStatus const&)> const& iterationCallback, MultiplicationStyle mult) const {
+    uint64_t numIterations = 0;
+    return DiscountedVI(operand, offsets, numIterations, relative, precision, discountFactor, maximalAbsoluteReward, dir, iterationCallback, mult);
+}
+
+template class DiscountedValueIterationHelper<double, true>;
+template class DiscountedValueIterationHelper<double, false>;
+template class DiscountedValueIterationHelper<storm::RationalNumber, true>;
+template class DiscountedValueIterationHelper<storm::RationalNumber, false>;
+
+}  // namespace storm::solver::helper

--- a/src/storm/solver/helper/DiscountedValueIterationHelper.h
+++ b/src/storm/solver/helper/DiscountedValueIterationHelper.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "storm/solver/MultiplicationStyle.h"
+#include "storm/solver/OptimizationDirection.h"
+#include "storm/solver/SolverStatus.h"
+#include "storm/solver/helper/ValueIterationOperatorForward.h"
+
+namespace storm::solver::helper {
+
+template<typename ValueType, bool TrivialRowGrouping>
+class DiscountedValueIterationHelper {
+   public:
+    explicit DiscountedValueIterationHelper(std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator);
+
+    template<storm::OptimizationDirection Dir, bool Relative>
+    SolverStatus DiscountedVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, ValueType const& precision,
+                              ValueType const& discountFactor, ValueType const& maximalAbsoluteReward,
+                              std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {},
+                              MultiplicationStyle mult = MultiplicationStyle::GaussSeidel) const;
+
+    SolverStatus DiscountedVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative,
+                              ValueType const& precision, ValueType const& discountFactor, ValueType const& maximalAbsoluteReward,
+                              std::optional<storm::OptimizationDirection> const& dir = {},
+                              std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {},
+                              MultiplicationStyle mult = MultiplicationStyle::GaussSeidel) const;
+
+    SolverStatus DiscountedVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
+                              ValueType const& discountFactor, ValueType const& maximalAbsoluteReward,
+                              std::optional<storm::OptimizationDirection> const& dir = {},
+                              std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {},
+                              MultiplicationStyle mult = MultiplicationStyle::GaussSeidel) const;
+
+   private:
+    std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator;
+};
+
+}  // namespace storm::solver::helper

--- a/src/storm/solver/multiplier/Multiplier.cpp
+++ b/src/storm/solver/multiplier/Multiplier.cpp
@@ -74,6 +74,22 @@ void Multiplier<ValueType>::repeatedMultiplyAndReduce(Environment const& env, Op
 }
 
 template<typename ValueType>
+void Multiplier<ValueType>::repeatedMultiplyAndReduceWithFactor(Environment const& env, OptimizationDirection const& dir, std::vector<ValueType>& x,
+                                                                std::vector<ValueType> const* b, uint64_t n, ValueType factor) const {
+    storm::utility::ProgressMeasurement progress("multiplications");
+    progress.setMaxCount(n);
+    progress.startNewMeasurement(0);
+    for (uint64_t i = 0; i < n; ++i) {
+        multiplyAndReduce(env, dir, x, b, x);
+        std::transform(x.begin(), x.end(), x.begin(), [factor](ValueType& c) { return c * factor; });
+        if (storm::utility::resources::isTerminate()) {
+            STORM_LOG_WARN("Aborting after " << i << " of " << n << " multiplications");
+            break;
+        }
+    }
+}
+
+template<typename ValueType>
 void Multiplier<ValueType>::multiplyRow2(uint64_t const& rowIndex, std::vector<ValueType> const& x1, ValueType& val1, std::vector<ValueType> const& x2,
                                          ValueType& val2) const {
     multiplyRow(rowIndex, x1, val1);

--- a/src/storm/solver/multiplier/Multiplier.h
+++ b/src/storm/solver/multiplier/Multiplier.h
@@ -123,6 +123,23 @@ class Multiplier {
                                    uint64_t n) const;
 
     /*!
+     * Performs repeated matrix-vector multiplication x' = A*x + b, minimizes/maximizes over the row groups
+     * so that the resulting vector has the size of number of row groups of A and multiplies the vector by a scalar factor.
+     *
+     * @param dir The direction for the reduction step.
+     * @param x The input vector with which to multiply the matrix. Its length must be equal
+     * to the number of columns of A.
+     * @param b If non-null, this vector is added after the multiplication. If given, its length must be equal
+     * to the number of rows of A.
+     * @param result The target vector into which to write the multiplication result. Its length must be equal
+     * to the number of rows of A.
+     * @param n The number of times to perform the multiplication.
+     * @param factor The scalar to multiply with in each iteration.
+     */
+    void repeatedMultiplyAndReduceWithFactor(Environment const& env, OptimizationDirection const& dir, std::vector<ValueType>& x,
+                                             std::vector<ValueType> const* b, uint64_t n, ValueType factor) const;
+
+    /*!
      * Multiplies the row with the given index with x and adds the result to the provided value
      * @param rowIndex The index of the considered row
      * @param x The input vector with which the row is multiplied

--- a/src/storm/storage/jani/visitor/JSONExporter.cpp
+++ b/src/storm/storage/jani/visitor/JSONExporter.cpp
@@ -583,6 +583,14 @@ boost::any FormulaToJaniJson::visit(storm::logic::HOAPathFormula const&, boost::
     STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "Jani currently does not support HOA path formulae");
 }
 
+boost::any FormulaToJaniJson::visit(storm::logic::DiscountedCumulativeRewardFormula const&, boost::any const&) const {
+    STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "Jani currently does not support discounted cumulative reward formulae");
+}
+
+boost::any FormulaToJaniJson::visit(storm::logic::DiscountedTotalRewardFormula const&, boost::any const&) const {
+    STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "Jani currently does not support discounted total reward formulae");
+}
+
 std::string operatorTypeToJaniString(storm::expressions::OperatorType optype) {
     using OpType = storm::expressions::OperatorType;
     switch (optype) {

--- a/src/storm/storage/jani/visitor/JSONExporter.h
+++ b/src/storm/storage/jani/visitor/JSONExporter.h
@@ -75,6 +75,8 @@ class FormulaToJaniJson : public storm::logic::FormulaVisitor {
     virtual boost::any visit(storm::logic::UnaryBooleanPathFormula const& f, boost::any const& data) const;
     virtual boost::any visit(storm::logic::UntilFormula const& f, boost::any const& data) const;
     virtual boost::any visit(storm::logic::HOAPathFormula const& f, boost::any const& data) const;
+    virtual boost::any visit(storm::logic::DiscountedCumulativeRewardFormula const& f, boost::any const& data) const;
+    virtual boost::any visit(storm::logic::DiscountedTotalRewardFormula const& f, boost::any const& data) const;
 
    private:
     FormulaToJaniJson(storm::jani::Model const& model) : model(model), stateExitRewards(false) {}

--- a/src/test/storm/modelchecker/prctl/mdp/MdpPrctlModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/prctl/mdp/MdpPrctlModelCheckerTest.cpp
@@ -870,4 +870,33 @@ TYPED_TEST(MdpPrctlModelCheckerTest, HOADice) {
     }
 }
 
+TYPED_TEST(MdpPrctlModelCheckerTest, SmallDiscount) {
+    std::string formulasString = "Rmax=? [ C ]";
+    formulasString += "; Rmax=? [ Cdiscount=9/10 ]";
+    formulasString += "; Rmax=? [ Cdiscount=15/16 ]";
+    auto modelFormulas = this->buildModelFormulas(STORM_TEST_RESOURCES_DIR "/mdp/small_discount.nm", formulasString);
+    auto model = std::move(modelFormulas.first);
+    auto tasks = this->getTasks(modelFormulas.second);
+    EXPECT_EQ(4, model->getNumberOfStates());
+    EXPECT_EQ(6ul, model->getNumberOfTransitions());
+    ASSERT_EQ(model->getType(), storm::models::ModelType::Mdp);
+    auto checker = this->createModelChecker(model);
+    std::unique_ptr<storm::modelchecker::CheckResult> result;
+
+    // This example considers a discounted expected total reward formula, which is not supported in all engines
+
+    if (TypeParam::engine == MdpEngine::PrismSparse || TypeParam::engine == MdpEngine::JaniSparse) {
+        result = checker->check(this->env(), tasks[0]);
+        EXPECT_NEAR(this->parseNumber("5"), this->getQuantitativeResultAtInitialState(model, result), this->precision());
+        result = checker->check(this->env(), tasks[1]);
+        EXPECT_NEAR(this->parseNumber("18/5"), this->getQuantitativeResultAtInitialState(model, result), this->precision());
+        result = checker->check(this->env(), tasks[2]);
+        EXPECT_NEAR(this->parseNumber("15/4"), this->getQuantitativeResultAtInitialState(model, result), this->precision());
+    } else {
+        EXPECT_FALSE(checker->canHandle(tasks[0]));
+        EXPECT_FALSE(checker->canHandle(tasks[1]));
+        EXPECT_FALSE(checker->canHandle(tasks[2]));
+    }
+}
+
 }  // namespace


### PR DESCRIPTION
This PR adds support for checking cumulative and total reward properties with a given discount factor on MDPs and DTMCs.
- Extends the parser to allow discounted properties, proposed syntax is ``R=? [Cdiscount=_factor_]``
- Introduces helper classes for checking discounted properties
- Extends the respective PCTL model checking classes with support for discounted cumulative and total reward properties, implemented analogous to the existing undiscounted implementations