### PR TITLE
Made BitVector conform to the std::ranges::range concept

### DIFF
--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -103,7 +103,7 @@ BitVector::const_reverse_iterator& BitVector::const_reverse_iterator::operator++
     currentIndex = getNextIndexWithValue<true, true>(dataPtr, lowerBound, --currentIndex);
     return *this;
 }
-BitVector::const_reverse_iterator& BitVector::const_reverse_iterator::operator++(int) {
+BitVector::const_reverse_iterator BitVector::const_reverse_iterator::operator++(int) {
     BitVector::const_reverse_iterator copy{*this};
     ++(*this);
     return copy;

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -16,6 +16,8 @@
 namespace storm {
 namespace storage {
 
+BitVector::const_iterator::const_iterator() : dataPtr(nullptr), currentIndex(0), endIndex(0) {};
+
 BitVector::const_iterator::const_iterator(uint64_t const* dataPtr, uint_fast64_t startIndex, uint_fast64_t endIndex, bool setOnFirstBit)
     : dataPtr(dataPtr), endIndex(endIndex) {
     if (setOnFirstBit) {
@@ -45,6 +47,12 @@ BitVector::const_iterator& BitVector::const_iterator::operator++() {
     return *this;
 }
 
+BitVector::const_iterator BitVector::const_iterator::operator++(int) {
+    BitVector::const_iterator copy{*this};
+    ++(*this);
+    return copy;
+}
+
 BitVector::const_iterator& BitVector::const_iterator::operator+=(size_t n) {
     for (size_t i = 0; i < n; ++i) {
         currentIndex = getNextIndexWithValue<true>(dataPtr, ++currentIndex, endIndex);
@@ -64,6 +72,9 @@ bool BitVector::const_iterator::operator==(const_iterator const& other) const {
     return currentIndex == other.currentIndex;
 }
 
+BitVector::const_reverse_iterator::const_reverse_iterator() : dataPtr(nullptr), currentIndex(0), lowerBound(0) {};
+
+
 BitVector::const_reverse_iterator::const_reverse_iterator(uint64_t const* dataPtr, uint64_t upperBound, uint64_t lowerBound, bool setOnFirstBit)
     : dataPtr(dataPtr), lowerBound(lowerBound) {
     if (setOnFirstBit) {
@@ -73,6 +84,7 @@ BitVector::const_reverse_iterator::const_reverse_iterator(uint64_t const* dataPt
         currentIndex = upperBound;
     }
 }
+
 
 BitVector::const_reverse_iterator::const_reverse_iterator(const_reverse_iterator const& other)
     : dataPtr(other.dataPtr), currentIndex(other.currentIndex), lowerBound(other.lowerBound) {
@@ -92,6 +104,11 @@ BitVector::const_reverse_iterator& BitVector::const_reverse_iterator::operator=(
 BitVector::const_reverse_iterator& BitVector::const_reverse_iterator::operator++() {
     currentIndex = getNextIndexWithValue<true, true>(dataPtr, lowerBound, --currentIndex);
     return *this;
+}
+BitVector::const_reverse_iterator& BitVector::const_reverse_iterator::operator++(int) {
+    BitVector::const_reverse_iterator copy{*this};
+    ++(*this);
+    return copy;
 }
 
 BitVector::const_reverse_iterator& BitVector::const_reverse_iterator::operator+=(size_t n) {

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -16,7 +16,7 @@
 namespace storm {
 namespace storage {
 
-BitVector::const_iterator::const_iterator() : dataPtr(nullptr), currentIndex(0), endIndex(0){};
+BitVector::const_iterator::const_iterator() : dataPtr(nullptr), currentIndex(0), endIndex(0) {};
 
 BitVector::const_iterator::const_iterator(uint64_t const* dataPtr, uint_fast64_t startIndex, uint_fast64_t endIndex, bool setOnFirstBit)
     : dataPtr(dataPtr), endIndex(endIndex) {
@@ -72,7 +72,7 @@ bool BitVector::const_iterator::operator==(const_iterator const& other) const {
     return currentIndex == other.currentIndex;
 }
 
-BitVector::const_reverse_iterator::const_reverse_iterator() : dataPtr(nullptr), currentIndex(0), lowerBound(0){};
+BitVector::const_reverse_iterator::const_reverse_iterator() : dataPtr(nullptr), currentIndex(0), lowerBound(0) {};
 
 BitVector::const_reverse_iterator::const_reverse_iterator(uint64_t const* dataPtr, uint64_t upperBound, uint64_t lowerBound, bool setOnFirstBit)
     : dataPtr(dataPtr), lowerBound(lowerBound) {

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -16,7 +16,7 @@
 namespace storm {
 namespace storage {
 
-BitVector::const_iterator::const_iterator() : dataPtr(nullptr), currentIndex(0), endIndex(0) {};
+BitVector::const_iterator::const_iterator() : dataPtr(nullptr), currentIndex(0), endIndex(0){};
 
 BitVector::const_iterator::const_iterator(uint64_t const* dataPtr, uint_fast64_t startIndex, uint_fast64_t endIndex, bool setOnFirstBit)
     : dataPtr(dataPtr), endIndex(endIndex) {
@@ -72,8 +72,7 @@ bool BitVector::const_iterator::operator==(const_iterator const& other) const {
     return currentIndex == other.currentIndex;
 }
 
-BitVector::const_reverse_iterator::const_reverse_iterator() : dataPtr(nullptr), currentIndex(0), lowerBound(0) {};
-
+BitVector::const_reverse_iterator::const_reverse_iterator() : dataPtr(nullptr), currentIndex(0), lowerBound(0){};
 
 BitVector::const_reverse_iterator::const_reverse_iterator(uint64_t const* dataPtr, uint64_t upperBound, uint64_t lowerBound, bool setOnFirstBit)
     : dataPtr(dataPtr), lowerBound(lowerBound) {
@@ -84,7 +83,6 @@ BitVector::const_reverse_iterator::const_reverse_iterator(uint64_t const* dataPt
         currentIndex = upperBound;
     }
 }
-
 
 BitVector::const_reverse_iterator::const_reverse_iterator(const_reverse_iterator const& other)
     : dataPtr(other.dataPtr), currentIndex(other.currentIndex), lowerBound(other.lowerBound) {

--- a/src/storm/storage/BitVector.h
+++ b/src/storm/storage/BitVector.h
@@ -158,7 +158,7 @@ class BitVector {
          * Lets the iterator point to the previous bit with value 1
          * @return A copy of the iterator before incrementing.
          */
-        const_reverse_iterator& operator++(int);
+        const_reverse_iterator operator++(int);
 
         /*!
          * Lets the iterator point to the n'th previous bit with value 1

--- a/src/storm/storage/BitVector.h
+++ b/src/storm/storage/BitVector.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <iterator>
 #include <ostream>
+#include <ranges>
 #include <vector>
 
 namespace storm {
@@ -27,7 +28,7 @@ class BitVector {
 
        public:
         // Define iterator
-        using iterator_category = std::input_iterator_tag;
+        using iterator_category = std::forward_iterator_tag;
         using value_type = uint_fast64_t;
         using difference_type = std::ptrdiff_t;
         using pointer = uint_fast64_t*;
@@ -127,7 +128,7 @@ class BitVector {
 
        public:
         // Define iterator
-        using iterator_category = std::input_iterator_tag;
+        using iterator_category = std::forward_iterator_tag;
         using value_type = uint_fast64_t;
         using difference_type = std::ptrdiff_t;
         using pointer = uint_fast64_t*;
@@ -777,6 +778,8 @@ class BitVector {
     // A bit mask that can be used to reduce a modulo 64 operation to a logical "and".
     static const uint_fast64_t mod64mask = (1 << 6) - 1;
 };
+
+static_assert(std::ranges::forward_range<BitVector>);
 
 struct FNV1aBitVectorHash {
     std::size_t operator()(storm::storage::BitVector const& bv) const;

--- a/src/storm/storage/BitVector.h
+++ b/src/storm/storage/BitVector.h
@@ -33,6 +33,8 @@ class BitVector {
         using pointer = uint_fast64_t*;
         using reference = uint_fast64_t&;
 
+        const_iterator();
+
         /*!
          * Constructs an iterator over the indices of the set bits in the given bit vector, starting and
          * stopping, respectively, at the given indices.
@@ -66,6 +68,14 @@ class BitVector {
          * @return A reference to this iterator.
          */
         const_iterator& operator++();
+
+        /*!
+         * Increases the position of the iterator to the position of the next bit that is set to true in the
+         * underlying bit vector.
+         *
+         * @return A copy of the iterator before incrementing
+         */
+        const_iterator operator++(int);
 
         /*!
          * Increases the position of the iterator to the position of the n'th next bit that is set to true in the
@@ -133,6 +143,7 @@ class BitVector {
          * first bit upon construction.
          * @param lowerBound The index at which to abort the iteration process.
          */
+        const_reverse_iterator();
         const_reverse_iterator(uint64_t const* dataPtr, uint64_t upperBound, uint64_t lowerBound = 0ull, bool setOnFirstBit = true);
         const_reverse_iterator(const_reverse_iterator const& other);
         const_reverse_iterator& operator=(const_reverse_iterator const& other);
@@ -142,6 +153,12 @@ class BitVector {
          * @return A reference to this iterator.
          */
         const_reverse_iterator& operator++();
+
+        /*!
+         * Lets the iterator point to the previous bit with value 1
+         * @return A copy of the iterator before incrementing.
+         */
+        const_reverse_iterator& operator++(int);
 
         /*!
          * Lets the iterator point to the n'th previous bit with value 1


### PR DESCRIPTION
The BitVector iterators weren't default-construtable and were missing postfix increment operators and thus not fulfilling the range concept (https://en.cppreference.com/w/cpp/ranges/range). Changing this makes it possible to use BitVector with C++20s range adaptors. E.g. for code like this:

```c++
for (auto i : some_bitvector | std::views::filter(some_lambda)) {
  do_something(i);
}
```