### PR TITLE
Part of a fix for a double free issue in StormPy

### DIFF
--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -1458,6 +1458,11 @@ BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefMDPTyp
 }
 
 template<typename PomdpModelType, typename BeliefValueType, typename BeliefMDPType>
+void BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefMDPType>::setFMSchedValueList(std::vector<std::vector<std::unordered_map<uint64_t, ValueType>>> valueList) {
+    this->interactiveUnderApproximationExplorer->setFMSchedValueList(valueList);
+}
+
+template<typename PomdpModelType, typename BeliefValueType, typename BeliefMDPType>
 BeliefValueType BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefMDPType>::rateObservation(
     typename ExplorerType::SuccessorObservationInformation const& info, BeliefValueType const& observationResolution, BeliefValueType const& maxResolution) {
     auto n = storm::utility::convertNumber<BeliefValueType, uint64_t>(info.support.size());

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -1460,7 +1460,7 @@ BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefMDPTyp
 template<typename PomdpModelType, typename BeliefValueType, typename BeliefMDPType>
 void BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefMDPType>::setFMSchedValueList(
     std::vector<std::vector<std::unordered_map<uint64_t, ValueType>>> valueList) {
-    this->interactiveUnderApproximationExplorer->setFMSchedValueList(valueList);
+    interactiveUnderApproximationExplorer->setFMSchedValueList(valueList);
 }
 
 template<typename PomdpModelType, typename BeliefValueType, typename BeliefMDPType>

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -1458,7 +1458,8 @@ BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefMDPTyp
 }
 
 template<typename PomdpModelType, typename BeliefValueType, typename BeliefMDPType>
-void BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefMDPType>::setFMSchedValueList(std::vector<std::vector<std::unordered_map<uint64_t, ValueType>>> valueList) {
+void BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefMDPType>::setFMSchedValueList(
+    std::vector<std::vector<std::unordered_map<uint64_t, ValueType>>> valueList) {
     this->interactiveUnderApproximationExplorer->setFMSchedValueList(valueList);
 }
 

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.h
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.h
@@ -186,6 +186,8 @@ class BeliefExplorationPomdpModelChecker {
      */
     std::shared_ptr<ExplorerType> getInteractiveBeliefExplorer();
 
+    void setFMSchedValueList(std::vector<std::vector<std::unordered_map<uint64_t, ValueType>>> valueList);
+
     /**
      * Get the current status of the interactive unfolding
      * @return the interactive unfolding


### PR DESCRIPTION
Read more information here: https://github.com/moves-rwth/stormpy/pull/185

In short, pybind11 can cause problems while exposing smart pointer objects. With this change we don't need to access the BeliefMdpExplorer object via the function getInteractiveBeliefExplorer anymore, as the only functionality we needed in that object (that is the setFMSchedValueList function) is being exposed into the BeliefExplorationPomdpModelChecker class.