### PR TITLE
Two Monotonicity Bugfixes

### DIFF
--- a/src/storm-pars/analysis/OrderExtender.cpp
+++ b/src/storm-pars/analysis/OrderExtender.cpp
@@ -286,7 +286,6 @@ std::tuple<std::shared_ptr<Order>, uint_fast64_t, uint_fast64_t> OrderExtender<V
                 }
                 if (all) {
                     STORM_LOG_INFO("All successors of state " << state << " sorted based on min max values");
-                    order->setDoneState(state);
                 }
                 ++itr;
             }
@@ -340,7 +339,7 @@ std::tuple<std::shared_ptr<Order>, uint_fast64_t, uint_fast64_t> OrderExtender<V
             assert(order->sortStates(&successors).size() == successors.size());
             assert(order->contains(currentState) && order->getNode(currentState) != nullptr);
 
-            if (monRes != nullptr && currentStateMode.second) {
+            if (monRes != nullptr) {
                 for (auto& param : occuringVariablesAtState[currentState]) {
                     checkParOnStateMonRes(currentState, order, param, monRes);
                 }


### PR DESCRIPTION
1.  Bug: Not all states were added to the order properly when using PLA bounds. They were simply set to done when all their successors could be ordered via PLA bounds, but not put into the order. They were at best only added trivially (between top and bottom) when required later as another state's successor. These states are now no longer set to done so that the main loop will still consider them and integrate them into the order properly.
2. Bug: The zeroconf benchmark only resulted in no increasing parameter (with PLA) or one increasing parameter (without PLA), whereas the correct (and previously attained) result is that both parameters are increasing. The order was correct and did lend itself to concluding the correct result but local monotonicity was not checked at all states, specifically not those from the statesToHandle vector (whose purpose is currently unclear). This restriction was now lifted so that local monotonicity is checked on these too if the order has been expanded with them.