### PR TITLE
Improved file handling especially property file

### DIFF
--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -635,20 +635,20 @@ void exportSparseModel(std::shared_ptr<storm::models::sparse::Model<ValueType>> 
 
     if (ioSettings.isExportBuildSet()) {
         switch (ioSettings.getExportBuildFormat()) {
-            case storm::exporter::ModelExportFormat::Dot:
+            case storm::io::ModelExportFormat::Dot:
                 storm::api::exportSparseModelAsDot(model, ioSettings.getExportBuildFilename(), ioSettings.getExportDotMaxWidth());
                 break;
-            case storm::exporter::ModelExportFormat::Drn:
+            case storm::io::ModelExportFormat::Drn:
                 storm::api::exportSparseModelAsDrn(model, ioSettings.getExportBuildFilename(),
                                                    input.model ? input.model.get().getParameterNames() : std::vector<std::string>(),
                                                    !ioSettings.isExplicitExportPlaceholdersDisabled());
                 break;
-            case storm::exporter::ModelExportFormat::Json:
+            case storm::io::ModelExportFormat::Json:
                 storm::api::exportSparseModelAsJson(model, ioSettings.getExportBuildFilename());
                 break;
             default:
                 STORM_LOG_THROW(false, storm::exceptions::NotSupportedException,
-                                "Exporting sparse models in " << storm::exporter::toString(ioSettings.getExportBuildFormat()) << " format is not supported.");
+                                "Exporting sparse models in " << storm::io::toString(ioSettings.getExportBuildFormat()) << " format is not supported.");
         }
     }
 
@@ -675,15 +675,15 @@ void exportDdModel(std::shared_ptr<storm::models::symbolic::Model<DdType, ValueT
 
     if (ioSettings.isExportBuildSet()) {
         switch (ioSettings.getExportBuildFormat()) {
-            case storm::exporter::ModelExportFormat::Dot:
+            case storm::io::ModelExportFormat::Dot:
                 storm::api::exportSymbolicModelAsDot(model, ioSettings.getExportBuildFilename());
                 break;
-            case storm::exporter::ModelExportFormat::Drdd:
+            case storm::io::ModelExportFormat::Drdd:
                 storm::api::exportSymbolicModelAsDrdd(model, ioSettings.getExportBuildFilename());
                 break;
             default:
                 STORM_LOG_THROW(false, storm::exceptions::NotSupportedException,
-                                "Exporting symbolic models in " << storm::exporter::toString(ioSettings.getExportBuildFormat()) << " format is not supported.");
+                                "Exporting symbolic models in " << storm::io::toString(ioSettings.getExportBuildFormat()) << " format is not supported.");
         }
     }
 

--- a/src/storm-conv/api/storm-conv.cpp
+++ b/src/storm-conv/api/storm-conv.cpp
@@ -142,17 +142,17 @@ void printJaniToStream(storm::jani::Model const& model, std::vector<storm::jani:
 
 void exportPrismToFile(storm::prism::Program const& program, std::vector<storm::jani::Property> const& properties, std::string const& filename) {
     std::ofstream stream;
-    storm::utility::openFile(filename, stream);
+    storm::io::openFile(filename, stream);
     stream << program << '\n';
-    storm::utility::closeFile(stream);
+    storm::io::closeFile(stream);
 
     if (!properties.empty()) {
-        storm::utility::openFile(filename + ".props", stream);
+        storm::io::openFile(filename + ".props", stream);
         for (auto const& prop : properties) {
             stream << prop.asPrismSyntax() << '\n';
             STORM_LOG_WARN_COND(!prop.containsUndefinedConstants(), "A property contains undefined constants. These might not be exported correctly.");
         }
-        storm::utility::closeFile(stream);
+        storm::io::closeFile(stream);
     }
 }
 void printPrismToStream(storm::prism::Program const& program, std::vector<storm::jani::Property> const& properties, std::ostream& ostream) {

--- a/src/storm-counterexamples/counterexamples/PathCounterexample.cpp
+++ b/src/storm-counterexamples/counterexamples/PathCounterexample.cpp
@@ -29,7 +29,7 @@ void PathCounterexample<ValueType>::writeToStream(std::ostream& out) const {
                 out << ": " << model->getStateValuations().getStateInfo(*it);
             }
             out << ": {";
-            storm::utility::outputFixedWidth(out, model->getLabelsOfState(*it), 0);
+            storm::io::outputFixedWidth(out, model->getLabelsOfState(*it), 0);
             out << "}\n";
         }
     }

--- a/src/storm-dft/modelchecker/DFTASFChecker.cpp
+++ b/src/storm-dft/modelchecker/DFTASFChecker.cpp
@@ -503,7 +503,7 @@ void DFTASFChecker::addMarkovianConstraints() {
 
 void DFTASFChecker::toFile(std::string const &filename) {
     std::ofstream stream;
-    storm::utility::openFile(filename, stream);
+    storm::io::openFile(filename, stream);
     stream << "; time point variables\n";
     for (auto const &timeVarEntry : timePointVariables) {
         stream << "(declare-fun " << varNames[timeVarEntry.second] << "() Int)\n";
@@ -533,7 +533,7 @@ void DFTASFChecker::toFile(std::string const &filename) {
         stream << "(assert " << constraint->toSmtlib2(varNames) << ")\n";
     }
     stream << "(check-sat)\n";
-    storm::utility::closeFile(stream);
+    storm::io::closeFile(stream);
 }
 
 void DFTASFChecker::toSolver() {

--- a/src/storm-dft/parser/DFTGalileoParser.cpp
+++ b/src/storm-dft/parser/DFTGalileoParser.cpp
@@ -23,14 +23,14 @@ storm::dft::storage::DFT<ValueType> DFTGalileoParser<ValueType>::parseDFT(const 
     const std::regex commentRegex("(/\\*([^*]|(\\*+[^*/]))*\\*+/)|(//.*)");
 
     std::ifstream file;
-    storm::utility::openFile(filename, file);
+    storm::io::openFile(filename, file);
 
     std::string line;
     size_t lineNo = 0;
     std::string toplevelId = "";
     bool comment = false;  // Indicates whether the current line is part of a multiline comment
     try {
-        while (storm::utility::getline(file, line)) {
+        while (storm::io::getline(file, line)) {
             ++lineNo;
             // First consider comments
             if (comment) {
@@ -147,7 +147,7 @@ storm::dft::storage::DFT<ValueType> DFTGalileoParser<ValueType>::parseDFT(const 
         STORM_LOG_THROW(false, storm::exceptions::FileIoException, "A parsing exception occurred in line " << lineNo << ": " << exception.what());
     }
     builder.setTopLevel(toplevelId);
-    storm::utility::closeFile(file);
+    storm::io::closeFile(file);
 
     // Build DFT
     storm::dft::storage::DFT<ValueType> dft = builder.build();

--- a/src/storm-dft/parser/DFTJsonParser.cpp
+++ b/src/storm-dft/parser/DFTJsonParser.cpp
@@ -18,10 +18,10 @@ namespace parser {
 template<typename ValueType>
 storm::dft::storage::DFT<ValueType> DFTJsonParser<ValueType>::parseJsonFromFile(std::string const& filename) {
     std::ifstream file;
-    storm::utility::openFile(filename, file);
+    storm::io::openFile(filename, file);
     Json jsonInput;
     file >> jsonInput;
-    storm::utility::closeFile(file);
+    storm::io::closeFile(file);
     return parseJson(jsonInput);
 }
 

--- a/src/storm-dft/storage/DftJsonExporter.cpp
+++ b/src/storm-dft/storage/DftJsonExporter.cpp
@@ -14,9 +14,9 @@ namespace storage {
 template<typename ValueType>
 void DftJsonExporter<ValueType>::toFile(storm::dft::storage::DFT<ValueType> const& dft, std::string const& filepath) {
     std::ofstream stream;
-    storm::utility::openFile(filepath, stream);
+    storm::io::openFile(filepath, stream);
     toStream(dft, stream);
-    storm::utility::closeFile(stream);
+    storm::io::closeFile(stream);
 }
 
 template<typename ValueType>

--- a/src/storm-gamebased-ar/abstraction/MenuGameAbstractor.cpp
+++ b/src/storm-gamebased-ar/abstraction/MenuGameAbstractor.cpp
@@ -75,7 +75,7 @@ template<storm::dd::DdType DdType, typename ValueType>
 void MenuGameAbstractor<DdType, ValueType>::exportToDot(storm::gbar::abstraction::MenuGame<DdType, ValueType> const& currentGame, std::string const& filename,
                                                         storm::dd::Bdd<DdType> const& highlightStatesBdd, storm::dd::Bdd<DdType> const& filter) const {
     std::ofstream out;
-    storm::utility::openFile(filename, out);
+    storm::io::openFile(filename, out);
     AbstractionInformation<DdType> const& abstractionInformation = this->getAbstractionInformation();
 
     storm::dd::Add<DdType, ValueType> filteredTransitions = filter.template toAdd<ValueType>() * currentGame.getTransitionMatrix();
@@ -172,7 +172,7 @@ void MenuGameAbstractor<DdType, ValueType>::exportToDot(storm::gbar::abstraction
     }
 
     out << "}\n";
-    storm::utility::closeFile(out);
+    storm::io::closeFile(out);
 }
 
 template<storm::dd::DdType DdType, typename ValueType>

--- a/src/storm-gamebased-ar/modelchecker/abstraction/GameBasedMdpModelChecker.cpp
+++ b/src/storm-gamebased-ar/modelchecker/abstraction/GameBasedMdpModelChecker.cpp
@@ -1,17 +1,32 @@
 #include "storm-gamebased-ar/modelchecker/abstraction/GameBasedMdpModelChecker.h"
 
+#include "storm-gamebased-ar/abstraction/ExplicitQualitativeGameResultMinMax.h"
+#include "storm-gamebased-ar/abstraction/ExplicitQuantitativeResultMinMax.h"
+#include "storm-gamebased-ar/abstraction/MenuGameRefiner.h"
+#include "storm-gamebased-ar/abstraction/jani/JaniMenuGameAbstractor.h"
+#include "storm-gamebased-ar/abstraction/prism/PrismMenuGameAbstractor.h"
+#include "storm/environment/Environment.h"
+#include "storm/exceptions/InvalidModelException.h"
+#include "storm/exceptions/InvalidPropertyException.h"
+#include "storm/exceptions/NotSupportedException.h"
+#include "storm/io/file.h"
+#include "storm/logic/FragmentSpecification.h"
 #include "storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h"
+#include "storm/modelchecker/results/CheckResult.h"
 #include "storm/modelchecker/results/ExplicitQualitativeCheckResult.h"
 #include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
-
 #include "storm/models/symbolic/Dtmc.h"
 #include "storm/models/symbolic/Mdp.h"
 #include "storm/models/symbolic/StandardRewardModel.h"
-
+#include "storm/settings/SettingsManager.h"
+#include "storm/settings/modules/CoreSettings.h"
+#include "storm/settings/modules/GeneralSettings.h"
+#include "storm/solver/StandardGameSolver.h"
+#include "storm/solver/SymbolicGameSolver.h"
+#include "storm/storage/ExplicitGameStrategyPair.h"
+#include "storm/storage/dd/DdManager.h"
 #include "storm/storage/expressions/ExpressionManager.h"
 #include "storm/storage/expressions/VariableSetPredicateSplitter.h"
-
-#include "storm/storage/ExplicitGameStrategyPair.h"
 #include "storm/storage/jani/Automaton.h"
 #include "storm/storage/jani/AutomatonComposition.h"
 #include "storm/storage/jani/Edge.h"
@@ -20,36 +35,9 @@
 #include "storm/storage/jani/Model.h"
 #include "storm/storage/jani/ParallelComposition.h"
 #include "storm/storage/jani/visitor/CompositionInformationVisitor.h"
-
-#include "storm/storage/dd/DdManager.h"
-
-#include "storm-gamebased-ar/abstraction/MenuGameRefiner.h"
-#include "storm-gamebased-ar/abstraction/jani/JaniMenuGameAbstractor.h"
-#include "storm-gamebased-ar/abstraction/prism/PrismMenuGameAbstractor.h"
-
-#include "storm-gamebased-ar/abstraction/ExplicitQualitativeGameResultMinMax.h"
-#include "storm-gamebased-ar/abstraction/ExplicitQuantitativeResultMinMax.h"
-
-#include "storm/logic/FragmentSpecification.h"
-
-#include "storm/environment/Environment.h"
-#include "storm/solver/StandardGameSolver.h"
-#include "storm/solver/SymbolicGameSolver.h"
-
-#include "storm/settings/SettingsManager.h"
-#include "storm/settings/modules/CoreSettings.h"
-#include "storm/settings/modules/GeneralSettings.h"
-
 #include "storm/utility/macros.h"
 #include "storm/utility/prism.h"
-
 #include "storm/utility/vector.h"
-
-#include "storm/exceptions/InvalidModelException.h"
-#include "storm/exceptions/InvalidPropertyException.h"
-#include "storm/exceptions/NotSupportedException.h"
-
-#include "storm/modelchecker/results/CheckResult.h"
 
 namespace storm::gbar {
 namespace modelchecker {
@@ -989,9 +977,11 @@ class ExplicitGameExporter {
                       ExplicitQuantitativeResultMinMax<ValueType> const& quantitativeResult, storage::ExplicitGameStrategyPair const* minStrategyPair,
                       storage::ExplicitGameStrategyPair const* maxStrategyPair) {
         // Export game as json.
-        std::ofstream outfile(filename);
+        std::ofstream outfile;
+        storm::io::openFile(filename, outfile);
         exportGame(outfile, player1Groups, player2Groups, transitionMatrix, initialStates, constraintStates, targetStates, quantitativeResult, minStrategyPair,
                    maxStrategyPair);
+        storm::io::closeFile(outfile);
     }
 
     void setShowNonStrategyAlternatives(bool value) {

--- a/src/storm-gspn/api/storm-gspn.cpp
+++ b/src/storm-gspn/api/storm-gspn.cpp
@@ -22,30 +22,30 @@ void handleGSPNExportSettings(storm::gspn::GSPN const& gspn,
     storm::settings::modules::GSPNExportSettings const& exportSettings = storm::settings::getModule<storm::settings::modules::GSPNExportSettings>();
     if (exportSettings.isWriteToDotSet()) {
         std::ofstream fs;
-        storm::utility::openFile(exportSettings.getWriteToDotFilename(), fs);
+        storm::io::openFile(exportSettings.getWriteToDotFilename(), fs);
         gspn.writeDotToStream(fs);
-        storm::utility::closeFile(fs);
+        storm::io::closeFile(fs);
     }
 
     if (exportSettings.isWriteToPnproSet()) {
         std::ofstream fs;
-        storm::utility::openFile(exportSettings.getWriteToPnproFilename(), fs);
+        storm::io::openFile(exportSettings.getWriteToPnproFilename(), fs);
         gspn.toPnpro(fs);
-        storm::utility::closeFile(fs);
+        storm::io::closeFile(fs);
     }
 
     if (exportSettings.isWriteToPnmlSet()) {
         std::ofstream fs;
-        storm::utility::openFile(exportSettings.getWriteToPnmlFilename(), fs);
+        storm::io::openFile(exportSettings.getWriteToPnmlFilename(), fs);
         gspn.toPnml(fs);
-        storm::utility::closeFile(fs);
+        storm::io::closeFile(fs);
     }
 
     if (exportSettings.isWriteToJsonSet()) {
         std::ofstream fs;
-        storm::utility::openFile(exportSettings.getWriteToJsonFilename(), fs);
+        storm::io::openFile(exportSettings.getWriteToJsonFilename(), fs);
         gspn.toJson(fs);
-        storm::utility::closeFile(fs);
+        storm::io::closeFile(fs);
     }
 
     if (exportSettings.isDisplayStatsSet()) {
@@ -56,9 +56,9 @@ void handleGSPNExportSettings(storm::gspn::GSPN const& gspn,
 
     if (exportSettings.isWriteStatsToFileSet()) {
         std::ofstream fs;
-        storm::utility::openFile(exportSettings.getWriteStatsFilename(), fs);
+        storm::io::openFile(exportSettings.getWriteStatsFilename(), fs);
         gspn.writeStatsToStream(fs);
-        storm::utility::closeFile(fs);
+        storm::io::closeFile(fs);
     }
 
     if (exportSettings.isWriteToJaniSet()) {
@@ -93,10 +93,10 @@ std::unordered_map<std::string, uint64_t> parseCapacitiesList(std::string const&
     std::unordered_map<std::string, uint64_t> map;
 
     std::ifstream stream;
-    storm::utility::openFile(filename, stream);
+    storm::io::openFile(filename, stream);
 
     std::string line;
-    while (storm::utility::getline(stream, line)) {
+    while (storm::io::getline(stream, line)) {
         std::vector<std::string> strs;
         boost::split(strs, line, boost::is_any_of("\t "));
         STORM_LOG_THROW(strs.size() == 2, storm::exceptions::WrongFormatException, "Expect key value pairs");
@@ -108,7 +108,7 @@ std::unordered_map<std::string, uint64_t> parseCapacitiesList(std::string const&
                         "The capacity expression '" << strs[1] << "' still contains undefined constants.");
         map[strs[0]] = expr.evaluateAsInt();
     }
-    storm::utility::closeFile(stream);
+    storm::io::closeFile(stream);
     return map;
 }
 }  // namespace api

--- a/src/storm-pars-cli/monotonicity.cpp
+++ b/src/storm-pars-cli/monotonicity.cpp
@@ -37,7 +37,7 @@ void analyzeMonotonicity(std::shared_ptr<storm::models::sparse::Model<ValueType>
     auto monSettings = storm::settings::getModule<storm::settings::modules::MonotonicitySettings>();
 
     if (monSettings.isExportMonotonicitySet()) {
-        storm::utility::openFile(monSettings.getExportMonotonicityFilename(), outfile);
+        storm::io::openFile(monSettings.getExportMonotonicityFilename(), outfile);
     }
     std::vector<std::shared_ptr<storm::logic::Formula const>> formulas = storm::api::extractFormulasFromProperties(input.properties);
     storm::utility::Stopwatch monotonicityWatch(true);
@@ -99,7 +99,7 @@ void analyzeMonotonicity(std::shared_ptr<storm::models::sparse::Model<ValueType>
     }
 
     if (monSettings.isExportMonotonicitySet()) {
-        storm::utility::closeFile(outfile);
+        storm::io::closeFile(outfile);
     }
 
     monotonicityWatch.stop();

--- a/src/storm-pars/analysis/MonotonicityHelper.cpp
+++ b/src/storm-pars/analysis/MonotonicityHelper.cpp
@@ -136,7 +136,7 @@ MonotonicityHelper<ValueType, ConstantType>::checkMonotonicityInBuild(std::ostre
         while (i < 10 && orderItr != monResults.end()) {
             std::ofstream dotOutfile;
             std::string name = dotOutfileName + std::to_string(i);
-            utility::openFile(name, dotOutfile);
+            storm::io::openFile(name, dotOutfile);
             dotOutfile << "Assumptions:\n";
             auto assumptionItr = orderItr->second.second.begin();
             while (assumptionItr != orderItr->second.second.end()) {
@@ -146,7 +146,7 @@ MonotonicityHelper<ValueType, ConstantType>::checkMonotonicityInBuild(std::ostre
             }
             dotOutfile << '\n';
             orderItr->first->dotOutputToFile(dotOutfile);
-            utility::closeFile(dotOutfile);
+            storm::io::closeFile(dotOutfile);
             i++;
             orderItr++;
         }

--- a/src/storm-pars/api/export.h
+++ b/src/storm-pars/api/export.h
@@ -17,7 +17,7 @@ inline void exportParametricResultToFile(std::optional<storm::RationalFunction> 
                                          storm::OptionalRef<storm::analysis::ConstraintCollector<storm::RationalFunction> const> const& constraintCollector,
                                          std::string const& path) {
     std::ofstream filestream;
-    storm::utility::openFile(path, filestream);
+    storm::io::openFile(path, filestream);
     if (constraintCollector.has_value()) {
         filestream << "$Parameters: ";
         auto const& vars = constraintCollector->getVariables();
@@ -48,7 +48,7 @@ inline void exportParametricResultToFile(std::optional<storm::RationalFunction> 
                        [](carl::Formula<typename storm::Polynomial::PolyType> const& c) -> std::string { return c.toString(); });
         std::copy(stringConstraints.begin(), stringConstraints.end(), std::ostream_iterator<std::string>(filestream, "\n"));
     }
-    storm::utility::closeFile(filestream);
+    storm::io::closeFile(filestream);
 }
 }  // namespace api
 }  // namespace storm

--- a/src/storm-pars/api/region.h
+++ b/src/storm-pars/api/region.h
@@ -49,7 +49,7 @@ std::vector<storm::storage::ParameterRegion<ValueType>> parseRegions(
     std::string const& inputString, std::set<typename storm::storage::ParameterRegion<ValueType>::VariableType> const& consideredVariables) {
     // If the given input string looks like a file (containing a dot and there exists a file with that name),
     // we try to parse it as a file, otherwise we assume it's a region string.
-    if (inputString.find(".") != std::string::npos && storm::utility::fileExistsAndIsReadable(inputString)) {
+    if (inputString.find(".") != std::string::npos && storm::io::fileExistsAndIsReadable(inputString)) {
         return storm::parser::ParameterRegionParser<ValueType>().parseMultipleRegionsFromFile(inputString, consideredVariables);
     } else {
         return storm::parser::ParameterRegionParser<ValueType>().parseMultipleRegions(inputString, consideredVariables);
@@ -353,7 +353,7 @@ void exportRegionCheckResultToFile(std::unique_ptr<storm::modelchecker::CheckRes
                     "Can not export region check result: The given checkresult does not have the expected type.");
 
     std::ofstream filestream;
-    storm::utility::openFile(filename, filestream);
+    storm::io::openFile(filename, filestream);
     for (auto const& res : regionCheckResult->getRegionResults()) {
         if (!onlyConclusiveResults || res.second == storm::modelchecker::RegionResult::AllViolated || res.second == storm::modelchecker::RegionResult::AllSat) {
             filestream << res.second << ": " << res.first << '\n';

--- a/src/storm-pars/api/region.h
+++ b/src/storm-pars/api/region.h
@@ -49,7 +49,7 @@ std::vector<storm::storage::ParameterRegion<ValueType>> parseRegions(
     std::string const& inputString, std::set<typename storm::storage::ParameterRegion<ValueType>::VariableType> const& consideredVariables) {
     // If the given input string looks like a file (containing a dot and there exists a file with that name),
     // we try to parse it as a file, otherwise we assume it's a region string.
-    if (inputString.find(".") != std::string::npos && std::ifstream(inputString).good()) {
+    if (inputString.find(".") != std::string::npos && storm::utility::fileExistsAndIsReadable(inputString)) {
         return storm::parser::ParameterRegionParser<ValueType>().parseMultipleRegionsFromFile(inputString, consideredVariables);
     } else {
         return storm::parser::ParameterRegionParser<ValueType>().parseMultipleRegions(inputString, consideredVariables);

--- a/src/storm-pars/api/region.h
+++ b/src/storm-pars/api/region.h
@@ -359,6 +359,7 @@ void exportRegionCheckResultToFile(std::unique_ptr<storm::modelchecker::CheckRes
             filestream << res.second << ": " << res.first << '\n';
         }
     }
+    storm::io::closeFile(filestream);
 }
 
 }  // namespace api

--- a/src/storm-pars/parser/MonotonicityParser.cpp
+++ b/src/storm-pars/parser/MonotonicityParser.cpp
@@ -16,7 +16,7 @@ std::pair<std::set<VariableType>, std::set<VariableType>> MonotonicityParser<Var
     std::string const& fileName, std::set<VariableType> const& consideredVariables) {
     // Open file and initialize result.
     std::ifstream inputFileStream;
-    storm::utility::openFile(fileName, inputFileStream);
+    storm::io::openFile(fileName, inputFileStream);
 
     std::set<VariableType> monotoneIncrVars;
     std::set<VariableType> monotoneDecrVars;
@@ -60,12 +60,12 @@ std::pair<std::set<VariableType>, std::set<VariableType>> MonotonicityParser<Var
 
     } catch (std::exception& e) {
         // In case of an exception properly close the file before passing exception.
-        storm::utility::closeFile(inputFileStream);
+        storm::io::closeFile(inputFileStream);
         throw e;
     }
 
     // Close the stream in case everything went smoothly and return result.
-    storm::utility::closeFile(inputFileStream);
+    storm::io::closeFile(inputFileStream);
     return {std::move(monotoneIncrVars), std::move(monotoneDecrVars)};
 }
 

--- a/src/storm-pars/parser/ParameterRegionParser.cpp
+++ b/src/storm-pars/parser/ParameterRegionParser.cpp
@@ -107,7 +107,7 @@ std::vector<storm::storage::ParameterRegion<ParametricType>> ParameterRegionPars
     std::string const& fileName, std::set<VariableType> const& consideredVariables) {
     // Open file and initialize result.
     std::ifstream inputFileStream;
-    storm::utility::openFile(fileName, inputFileStream);
+    storm::io::openFile(fileName, inputFileStream);
 
     std::vector<storm::storage::ParameterRegion<ParametricType>> result;
 
@@ -117,12 +117,12 @@ std::vector<storm::storage::ParameterRegion<ParametricType>> ParameterRegionPars
         result = parseMultipleRegions(fileContent, consideredVariables);
     } catch (std::exception& e) {
         // In case of an exception properly close the file before passing exception.
-        storm::utility::closeFile(inputFileStream);
+        storm::io::closeFile(inputFileStream);
         throw e;
     }
 
     // Close the stream in case everything went smoothly and return result.
-    storm::utility::closeFile(inputFileStream);
+    storm::io::closeFile(inputFileStream);
     return result;
 }
 

--- a/src/storm-pars/transformer/TimeTravelling.cpp
+++ b/src/storm-pars/transformer/TimeTravelling.cpp
@@ -151,9 +151,9 @@ models::sparse::Dtmc<RationalFunction> TimeTravelling::timeTravel(models::sparse
             newnewDTMC.addRewardModel(*stateRewardName, newRewardModel);
         }
         std::ofstream file;
-        file.open("dots/jipconvert_" + std::to_string(flexibleMatrix.getRowCount()) + ".dot");
+        storm::io::openFile("dots/jipconvert_" + std::to_string(flexibleMatrix.getRowCount()) + ".dot", file);
         newnewDTMC.writeDotToStream(file);
-        file.close();
+        storm::io::closeFile(file);
         // newnewDTMC.writeDotToStream(std::cout);
         newnewDTMC.getTransitionMatrix().isProbabilistic();
 #endif
@@ -328,9 +328,9 @@ models::sparse::Dtmc<RationalFunction> TimeTravelling::timeTravel(models::sparse
         newnewnewDTMC.addRewardModel(*stateRewardName, newRewardModel);
     }
     std::ofstream file2;
-    file2.open("dots/travel_" + std::to_string(flexibleMatrix.getRowCount()) + ".dot");
+    storm::io::openFile("dots/travel_" + std::to_string(flexibleMatrix.getRowCount()) + ".dot", file2);
     newnewnewDTMC.writeDotToStream(file2);
-    file2.close();
+    storm::io::closeFile(file2);
     newnewnewDTMC.getTransitionMatrix().isProbabilistic();
 #endif
 

--- a/src/storm-parsers/api/properties.cpp
+++ b/src/storm-parsers/api/properties.cpp
@@ -32,6 +32,12 @@ std::vector<storm::jani::Property> parseProperties(storm::parser::FormulaParser&
         STORM_LOG_INFO("Loading properties from file: " << inputString << '\n');
         properties = formulaParser.parseFromFile(inputString);
     } else {
+        // File does not exists -> parse as property string
+        // Provide warning if string could potentially be a property file
+        if (inputString.find(".prop") != std::string::npos || inputString.find(".pctl") != std::string::npos ||
+            inputString.find(".prctl") != std::string::npos || inputString.find(".csl") != std::string::npos) {
+            STORM_LOG_WARN("File with name '" << inputString << "' does not exist. Trying to parse as property string.");
+        }
         properties = formulaParser.parseFromString(inputString);
     }
 
@@ -46,8 +52,7 @@ std::vector<storm::jani::Property> parseProperties(std::string const& inputStrin
     } catch (storm::exceptions::WrongFormatException const& e) {
         STORM_LOG_THROW(false, storm::exceptions::WrongFormatException,
                         e.what() << "Note that the used API function does not have access to model variables. If the property you tried to parse contains "
-                                    "model variables, it will not "
-                                    "be parsed correctly.");
+                                    "model variables, it will not be parsed correctly.");
     }
 }
 

--- a/src/storm-parsers/api/properties.cpp
+++ b/src/storm-parsers/api/properties.cpp
@@ -28,7 +28,7 @@ std::vector<storm::jani::Property> parseProperties(storm::parser::FormulaParser&
                                                    boost::optional<std::set<std::string>> const& propertyFilter) {
     // If the given property is a file, we parse it as a file, otherwise we assume it's a property.
     std::vector<storm::jani::Property> properties;
-    if (storm::utility::fileExistsAndIsReadable(inputString)) {
+    if (storm::io::fileExistsAndIsReadable(inputString)) {
         STORM_LOG_INFO("Loading properties from file: " << inputString << '\n');
         properties = formulaParser.parseFromFile(inputString);
     } else {

--- a/src/storm-parsers/api/properties.cpp
+++ b/src/storm-parsers/api/properties.cpp
@@ -2,18 +2,14 @@
 
 #include "storm-parsers/parser/FormulaParser.h"
 #include "storm/api/properties.h"
-
+#include "storm/exceptions/WrongFormatException.h"
+#include "storm/io/file.h"
+#include "storm/logic/Formula.h"
 #include "storm/logic/RewardAccumulationEliminationVisitor.h"
 #include "storm/storage/SymbolicModelDescription.h"
-
 #include "storm/storage/jani/Model.h"
 #include "storm/storage/jani/Property.h"
 #include "storm/storage/prism/Program.h"
-
-#include "storm/exceptions/WrongFormatException.h"
-
-#include "storm/logic/Formula.h"
-
 #include "storm/utility/cli.h"
 
 namespace storm {
@@ -32,7 +28,7 @@ std::vector<storm::jani::Property> parseProperties(storm::parser::FormulaParser&
                                                    boost::optional<std::set<std::string>> const& propertyFilter) {
     // If the given property is a file, we parse it as a file, otherwise we assume it's a property.
     std::vector<storm::jani::Property> properties;
-    if (std::ifstream(inputString).good()) {
+    if (storm::utility::fileExistsAndIsReadable(inputString)) {
         STORM_LOG_INFO("Loading properties from file: " << inputString << '\n');
         properties = formulaParser.parseFromFile(inputString);
     } else {

--- a/src/storm-parsers/parser/DirectEncodingParser.cpp
+++ b/src/storm-parsers/parser/DirectEncodingParser.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<storm::models::sparse::Model<ValueType, RewardModelType>> Direct
     // Load file
     STORM_LOG_INFO("Reading from file " << filename);
     std::ifstream file;
-    storm::utility::openFile(filename, file);
+    storm::io::openFile(filename, file);
     std::string line;
 
     // Initialize
@@ -51,7 +51,7 @@ std::shared_ptr<storm::models::sparse::Model<ValueType, RewardModelType>> Direct
     std::shared_ptr<storm::storage::sparse::ModelComponents<ValueType, RewardModelType>> modelComponents;
 
     // Parse header
-    while (storm::utility::getline(file, line)) {
+    while (storm::io::getline(file, line)) {
         if (line.empty() || boost::starts_with(line, "//")) {
             continue;
         }
@@ -68,7 +68,7 @@ std::shared_ptr<storm::models::sparse::Model<ValueType, RewardModelType>> Direct
         } else if (line == "@parameters") {
             // Parse parameters
             STORM_LOG_THROW(!sawParameters, storm::exceptions::WrongFormatException, "Parameters declared twice");
-            storm::utility::getline(file, line);
+            storm::io::getline(file, line);
             if (line != "") {
                 std::vector<std::string> parameters;
                 boost::split(parameters, line, boost::is_any_of(" "));
@@ -81,7 +81,7 @@ std::shared_ptr<storm::models::sparse::Model<ValueType, RewardModelType>> Direct
 
         } else if (line == "@placeholders") {
             // Parse placeholders
-            while (storm::utility::getline(file, line)) {
+            while (storm::io::getline(file, line)) {
                 size_t posColon = line.find(':');
                 STORM_LOG_THROW(posColon != std::string::npos, storm::exceptions::WrongFormatException, "':' not found.");
                 std::string placeName = line.substr(0, posColon - 1);
@@ -99,16 +99,16 @@ std::shared_ptr<storm::models::sparse::Model<ValueType, RewardModelType>> Direct
         } else if (line == "@reward_models") {
             // Parse reward models
             STORM_LOG_THROW(rewardModelNames.empty(), storm::exceptions::WrongFormatException, "Reward model names declared twice");
-            storm::utility::getline(file, line);
+            storm::io::getline(file, line);
             boost::split(rewardModelNames, line, boost::is_any_of("\t "));
         } else if (line == "@nr_states") {
             // Parse no. of states
             STORM_LOG_THROW(nrStates == 0, storm::exceptions::WrongFormatException, "Number states declared twice");
-            storm::utility::getline(file, line);
+            storm::io::getline(file, line);
             nrStates = parseNumber<size_t>(line);
         } else if (line == "@nr_choices") {
             STORM_LOG_THROW(nrChoices == 0, storm::exceptions::WrongFormatException, "Number of actions declared twice");
-            storm::utility::getline(file, line);
+            storm::io::getline(file, line);
             nrChoices = parseNumber<size_t>(line);
         } else if (line == "@model") {
             // Parse rest of the model
@@ -125,7 +125,7 @@ std::shared_ptr<storm::models::sparse::Model<ValueType, RewardModelType>> Direct
         }
     }
     // Done parsing
-    storm::utility::closeFile(file);
+    storm::io::closeFile(file);
 
     // Build model
     return storm::utility::builder::buildModelFromComponents(type, std::move(*modelComponents));
@@ -167,7 +167,7 @@ std::shared_ptr<storm::storage::sparse::ModelComponents<ValueType, RewardModelTy
     uint64_t lineNumber = 0;
     bool firstState = true;
     bool firstActionForState = true;
-    while (storm::utility::getline(file, line)) {
+    while (storm::io::getline(file, line)) {
         lineNumber++;
         if (boost::starts_with(line, "//")) {
             continue;

--- a/src/storm-parsers/parser/FormulaParser.cpp
+++ b/src/storm-parsers/parser/FormulaParser.cpp
@@ -62,7 +62,7 @@ std::shared_ptr<storm::logic::Formula const> FormulaParser::parseSingleFormulaFr
 std::vector<storm::jani::Property> FormulaParser::parseFromFile(std::string const& filename) const {
     // Open file and initialize result.
     std::ifstream inputFileStream;
-    storm::utility::openFile(filename, inputFileStream);
+    storm::io::openFile(filename, inputFileStream);
 
     std::vector<storm::jani::Property> properties;
 
@@ -72,12 +72,12 @@ std::vector<storm::jani::Property> FormulaParser::parseFromFile(std::string cons
         properties = parseFromString(fileContent);
     } catch (std::exception& e) {
         // In case of an exception properly close the file before passing exception.
-        storm::utility::closeFile(inputFileStream);
+        storm::io::closeFile(inputFileStream);
         throw e;
     }
 
     // Close the stream in case everything went smoothly and return result.
-    storm::utility::closeFile(inputFileStream);
+    storm::io::closeFile(inputFileStream);
     return properties;
 }
 

--- a/src/storm-parsers/parser/ImcaMarkovAutomatonParser.cpp
+++ b/src/storm-parsers/parser/ImcaMarkovAutomatonParser.cpp
@@ -16,7 +16,7 @@ template<typename ValueType>
 std::shared_ptr<storm::models::sparse::MarkovAutomaton<ValueType>> ImcaMarkovAutomatonParser<ValueType>::parseImcaFile(std::string const& filename) {
     // Open file and initialize result.
     std::ifstream inputFileStream;
-    storm::utility::openFile(filename, inputFileStream);
+    storm::io::openFile(filename, inputFileStream);
 
     storm::storage::sparse::ModelComponents<ValueType> components;
 
@@ -35,15 +35,15 @@ std::shared_ptr<storm::models::sparse::MarkovAutomaton<ValueType>> ImcaMarkovAut
         STORM_LOG_DEBUG("Parsed imca file successfully.");
     } catch (qi::expectation_failure<PositionIteratorType> const& e) {
         STORM_LOG_THROW(false, storm::exceptions::WrongFormatException, e.what_);
-        storm::utility::closeFile(inputFileStream);
+        storm::io::closeFile(inputFileStream);
     } catch (std::exception& e) {
         // In case of an exception properly close the file before passing exception.
-        storm::utility::closeFile(inputFileStream);
+        storm::io::closeFile(inputFileStream);
         throw e;
     }
 
     // Close the stream in case everything went smoothly
-    storm::utility::closeFile(inputFileStream);
+    storm::io::closeFile(inputFileStream);
 
     // Build the model from the obtained model components
     return storm::utility::builder::buildModelFromComponents(storm::models::ModelType::MarkovAutomaton, std::move(components))

--- a/src/storm-parsers/parser/JaniParser.cpp
+++ b/src/storm-parsers/parser/JaniParser.cpp
@@ -103,9 +103,9 @@ JaniParser<ValueType>::JaniParser(std::string const& jsonstring) : expressionMan
 template<typename ValueType>
 void JaniParser<ValueType>::readFile(std::string const& path) {
     std::ifstream file;
-    storm::utility::openFile(path, file);
+    storm::io::openFile(path, file);
     file >> parsedStructure;
-    storm::utility::closeFile(file);
+    storm::io::closeFile(file);
 }
 
 template<typename ValueType>

--- a/src/storm-parsers/parser/MappedFile.cpp
+++ b/src/storm-parsers/parser/MappedFile.cpp
@@ -21,7 +21,7 @@ namespace storm {
 namespace parser {
 
 MappedFile::MappedFile(const char* filename) {
-    STORM_LOG_THROW(storm::utility::fileExistsAndIsReadable(filename), storm::exceptions::FileIoException,
+    STORM_LOG_THROW(storm::io::fileExistsAndIsReadable(filename), storm::exceptions::FileIoException,
                     "Error while reading " << filename << ": The file does not exist or is not readable.");
 
 #if defined LINUX || defined MACOSX

--- a/src/storm-parsers/parser/PrismParserGrammar.cpp
+++ b/src/storm-parsers/parser/PrismParserGrammar.cpp
@@ -21,7 +21,7 @@ namespace parser {
 storm::prism::Program PrismParserGrammar::parse(std::string const& filename, bool prismCompatibility) {
     // Open file and initialize result.
     std::ifstream inputFileStream;
-    storm::utility::openFile(filename, inputFileStream);
+    storm::io::openFile(filename, inputFileStream);
     storm::prism::Program result;
 
     // Now try to parse the contents of the file.
@@ -30,16 +30,16 @@ storm::prism::Program PrismParserGrammar::parse(std::string const& filename, boo
         result = parseFromString(fileContent, filename, prismCompatibility);
     } catch (storm::exceptions::WrongFormatException& e) {
         // In case of an exception properly close the file before passing exception.
-        storm::utility::closeFile(inputFileStream);
+        storm::io::closeFile(inputFileStream);
         throw e;
     } catch (std::exception& e) {
         // In case of an exception properly close the file before passing exception.
-        storm::utility::closeFile(inputFileStream);
+        storm::io::closeFile(inputFileStream);
         throw e;
     }
 
     // Close the stream in case everything went smoothly and return result.
-    storm::utility::closeFile(inputFileStream);
+    storm::io::closeFile(inputFileStream);
     return result;
 }
 

--- a/src/storm-permissive/analysis/MILPPermissiveSchedulers.h
+++ b/src/storm-permissive/analysis/MILPPermissiveSchedulers.h
@@ -6,6 +6,7 @@
 
 #include "storm-permissive/analysis/PermissiveSchedulerComputation.h"
 #include "storm-permissive/analysis/PermissiveSchedulers.h"
+#include "storm/io/file.h"
 #include "storm/models/sparse/StandardRewardModel.h"
 #include "storm/solver/LpSolver.h"
 #include "storm/storage/BitVector.h"
@@ -59,8 +60,8 @@ class MilpPermissiveSchedulerComputation : public PermissiveSchedulerComputation
     }
 
     void dumpLpSolutionToFile(std::string const& filename) {
-        std::fstream filestream;
-        filestream.open(filename, std::fstream::out);
+        std::ofstream filestream;
+        storm::io::openFile(filename, filestream);
         for (auto const& pVar : mProbVariables) {
             filestream << pVar.second.getName() << "->" << solver.getContinuousValue(pVar.second) << '\n';
         }
@@ -76,7 +77,7 @@ class MilpPermissiveSchedulerComputation : public PermissiveSchedulerComputation
         for (auto const& gammaVar : mGammaVariables) {
             filestream << gammaVar.second.getName() << "->" << solver.getContinuousValue(gammaVar.second) << '\n';
         }
-        filestream.close();
+        storm::io::closeFile(filestream);
     }
 
     void dumpLpToFile(std::string const& filename) {

--- a/src/storm-pomdp/analysis/IterativePolicySearch.cpp
+++ b/src/storm-pomdp/analysis/IterativePolicySearch.cpp
@@ -887,9 +887,9 @@ bool IterativePolicySearch<ValueType>::smtCheck(uint64_t iteration, std::set<sto
         STORM_LOG_DEBUG("Export SMT Solver Call (" << iteration << ")");
         std::string filepath = options.getExportSATCallsPath() + "call_" + std::to_string(iteration) + ".smt2";
         std::ofstream filestream;
-        storm::utility::openFile(filepath, filestream);
+        storm::io::openFile(filepath, filestream);
         filestream << smtSolver->getSmtLibString() << '\n';
-        storm::utility::closeFile(filestream);
+        storm::io::closeFile(filestream);
     }
 
     STORM_LOG_DEBUG("Call to SMT Solver (" << iteration << ")");

--- a/src/storm-pomdp/analysis/WinningRegion.cpp
+++ b/src/storm-pomdp/analysis/WinningRegion.cpp
@@ -310,7 +310,7 @@ uint64_t WinningRegion::getStorageSize() const {
 
 void WinningRegion::storeToFile(std::string const& path, std::string const& preamble, bool append) const {
     std::ofstream file;
-    storm::utility::openFile(path, file, append);
+    storm::io::openFile(path, file, append);
     file << ":preamble\n";
     file << preamble << '\n';
     file << ":winningregion\n";
@@ -331,19 +331,19 @@ void WinningRegion::storeToFile(std::string const& path, std::string const& prea
         }
         file << '\n';
     }
-    storm::utility::closeFile(file);
+    storm::io::closeFile(file);
 }
 
 std::pair<WinningRegion, std::string> WinningRegion::loadFromFile(std::string const& path) {
     std::ifstream file;
     std::vector<uint64_t> observationSizes;
-    storm::utility::openFile(path, file);
+    storm::io::openFile(path, file);
     std::string line;
     uint64_t state = 0;  // 0 = expect preamble
     uint64_t observation = 0;
     WinningRegion wr({1});
     std::stringstream preamblestream;
-    while (std::getline(file, line)) {
+    while (storm::io::getline(file, line)) {
         if (boost::starts_with(line, "#")) {
             continue;
         }
@@ -375,7 +375,7 @@ std::pair<WinningRegion, std::string> WinningRegion::loadFromFile(std::string co
             ++observation;
         }
     }
-    storm::utility::closeFile(file);
+    storm::io::closeFile(file);
     return {wr, preamblestream.str()};
 }
 

--- a/src/storm/api/export.cpp
+++ b/src/storm/api/export.cpp
@@ -6,9 +6,9 @@ namespace api {
 
 void exportJaniModelAsDot(storm::jani::Model const& model, std::string const& filename) {
     std::ofstream out;
-    storm::utility::openFile(filename, out);
+    storm::io::openFile(filename, out);
     model.writeDotToStream(out);
-    storm::utility::closeFile(out);
+    storm::io::closeFile(out);
 }
 
 }  // namespace api

--- a/src/storm/api/export.h
+++ b/src/storm/api/export.h
@@ -25,32 +25,32 @@ template<typename ValueType>
 void exportSparseModelAsDrn(std::shared_ptr<storm::models::sparse::Model<ValueType>> const& model, std::string const& filename,
                             std::vector<std::string> const& parameterNames = {}, bool allowPlaceholders = true) {
     std::ofstream stream;
-    storm::utility::openFile(filename, stream);
-    storm::exporter::DirectEncodingOptions options;
+    storm::io::openFile(filename, stream);
+    storm::io::DirectEncodingOptions options;
     options.allowPlaceholders = allowPlaceholders;
-    storm::exporter::explicitExportSparseModel(stream, model, parameterNames, options);
-    storm::utility::closeFile(stream);
+    storm::io::explicitExportSparseModel(stream, model, parameterNames, options);
+    storm::io::closeFile(stream);
 }
 
 template<storm::dd::DdType Type, typename ValueType>
 void exportSymbolicModelAsDrdd(std::shared_ptr<storm::models::symbolic::Model<Type, ValueType>> const& model, std::string const& filename) {
-    storm::exporter::explicitExportSymbolicModel(filename, model);
+    storm::io::explicitExportSymbolicModel(filename, model);
 }
 
 template<typename ValueType>
 void exportSparseModelAsDot(std::shared_ptr<storm::models::sparse::Model<ValueType>> const& model, std::string const& filename, size_t maxWidth = 30) {
     std::ofstream stream;
-    storm::utility::openFile(filename, stream);
+    storm::io::openFile(filename, stream);
     model->writeDotToStream(stream, maxWidth);
-    storm::utility::closeFile(stream);
+    storm::io::closeFile(stream);
 }
 
 template<typename ValueType>
 void exportSparseModelAsJson(std::shared_ptr<storm::models::sparse::Model<ValueType>> const& model, std::string const& filename) {
     std::ofstream stream;
-    storm::utility::openFile(filename, stream);
+    storm::io::openFile(filename, stream);
     model->writeJsonToStream(stream);
-    storm::utility::closeFile(stream);
+    storm::io::closeFile(stream);
 }
 
 template<storm::dd::DdType Type, typename ValueType>
@@ -62,21 +62,21 @@ template<typename ValueType>
 void exportScheduler(std::shared_ptr<storm::models::sparse::Model<ValueType>> const& model, storm::storage::Scheduler<ValueType> const& scheduler,
                      std::string const& filename) {
     std::ofstream stream;
-    storm::utility::openFile(filename, stream);
+    storm::io::openFile(filename, stream);
     std::string jsonFileExtension = ".json";
     if (filename.size() > 4 && std::equal(jsonFileExtension.rbegin(), jsonFileExtension.rend(), filename.rbegin())) {
         scheduler.printJsonToStream(stream, model, false, true);
     } else {
         scheduler.printToStream(stream, model, false, true);
     }
-    storm::utility::closeFile(stream);
+    storm::io::closeFile(stream);
 }
 
 template<typename ValueType>
 inline void exportCheckResultToJson(std::shared_ptr<storm::models::sparse::Model<ValueType>> const& model,
                                     std::unique_ptr<storm::modelchecker::CheckResult> const& checkResult, std::string const& filename) {
     std::ofstream stream;
-    storm::utility::openFile(filename, stream);
+    storm::io::openFile(filename, stream);
     if (checkResult->isExplicitQualitativeCheckResult()) {
         auto j = checkResult->asExplicitQualitativeCheckResult().toJson<storm::RationalNumber>(model->getOptionalStateValuations(), model->getStateLabeling());
         stream << storm::dumpJson(j);
@@ -86,7 +86,7 @@ inline void exportCheckResultToJson(std::shared_ptr<storm::models::sparse::Model
         auto j = checkResult->template asExplicitQuantitativeCheckResult<ValueType>().toJson(model->getOptionalStateValuations(), model->getStateLabeling());
         stream << storm::dumpJson(j);
     }
-    storm::utility::closeFile(stream);
+    storm::io::closeFile(stream);
 }
 
 template<>

--- a/src/storm/automata/DeterministicAutomaton.cpp
+++ b/src/storm/automata/DeterministicAutomaton.cpp
@@ -6,9 +6,9 @@
 
 #include "storm/automata/AcceptanceCondition.h"
 #include "storm/automata/HOAConsumerDA.h"
-#include "storm/utility/macros.h"
-
 #include "storm/exceptions/FileIoException.h"
+#include "storm/io/file.h"
+#include "storm/utility/macros.h"
 
 namespace storm {
 namespace automata {
@@ -95,9 +95,10 @@ DeterministicAutomaton::ptr DeterministicAutomaton::parse(std::istream& in) {
 }
 
 DeterministicAutomaton::ptr DeterministicAutomaton::parseFromFile(const std::string& filename) {
-    std::ifstream in(filename);
-    STORM_LOG_THROW(in.good(), storm::exceptions::FileIoException, "Can not open '" << filename << "' for reading.");
+    std::ifstream in;
+    storm::utility::openFile(filename, in);
     auto da = parse(in);
+    storm::utility::closeFile(in);
 
     STORM_LOG_INFO("Deterministic automaton from HOA file '" << filename << "' has " << da->getNumberOfStates() << " states, " << da->getAPSet().size()
                                                              << " atomic propositions and " << *da->getAcceptance()->getAcceptanceExpression()

--- a/src/storm/automata/DeterministicAutomaton.cpp
+++ b/src/storm/automata/DeterministicAutomaton.cpp
@@ -96,9 +96,9 @@ DeterministicAutomaton::ptr DeterministicAutomaton::parse(std::istream& in) {
 
 DeterministicAutomaton::ptr DeterministicAutomaton::parseFromFile(const std::string& filename) {
     std::ifstream in;
-    storm::utility::openFile(filename, in);
+    storm::io::openFile(filename, in);
     auto da = parse(in);
-    storm::utility::closeFile(in);
+    storm::io::closeFile(in);
 
     STORM_LOG_INFO("Deterministic automaton from HOA file '" << filename << "' has " << da->getNumberOfStates() << " states, " << da->getAPSet().size()
                                                              << " atomic propositions and " << *da->getAcceptance()->getAcceptanceExpression()

--- a/src/storm/io/DDEncodingExporter.cpp
+++ b/src/storm/io/DDEncodingExporter.cpp
@@ -1,26 +1,27 @@
 #include "storm/io/DDEncodingExporter.h"
+
 #include "storm/io/file.h"
 #include "storm/models/symbolic/StandardRewardModel.h"
 
 namespace storm {
-namespace exporter {
+namespace io {
 
 template<storm::dd::DdType Type, typename ValueType>
 void explicitExportSymbolicModel(std::string const& filename, std::shared_ptr<storm::models::symbolic::Model<Type, ValueType>> symbolicModel) {
     std::ofstream filestream;
-    storm::utility::openFile(filename, filestream);
+    storm::io::openFile(filename, filestream);
     filestream << "// storm exported dd\n";
     filestream << "%transitions\n";
-    storm::utility::closeFile(filestream);
+    storm::io::closeFile(filestream);
     symbolicModel->getTransitionMatrix().exportToText(filename);
-    storm::utility::openFile(filename, filestream, true, true);
+    storm::io::openFile(filename, filestream, true, true);
     filestream << "%initial\n";
-    storm::utility::closeFile(filestream);
+    storm::io::closeFile(filestream);
     symbolicModel->getInitialStates().template toAdd<ValueType>().exportToText(filename);
     for (auto const& label : symbolicModel->getLabels()) {
-        storm::utility::openFile(filename, filestream, true, true);
+        storm::io::openFile(filename, filestream, true, true);
         filestream << "\n%label " << label << '\n';
-        storm::utility::closeFile(filestream);
+        storm::io::closeFile(filestream);
         symbolicModel->getStates(label).template toAdd<ValueType>().exportToText(filename);
     }
 }
@@ -34,5 +35,5 @@ template void explicitExportSymbolicModel<storm::dd::DdType::Sylvan, storm::Rati
     std::string const&, std::shared_ptr<storm::models::symbolic::Model<storm::dd::DdType::Sylvan, storm::RationalNumber>> sparseModel);
 template void explicitExportSymbolicModel<storm::dd::DdType::Sylvan, storm::RationalFunction>(
     std::string const&, std::shared_ptr<storm::models::symbolic::Model<storm::dd::DdType::Sylvan, storm::RationalFunction>> sparseModel);
-}  // namespace exporter
+}  // namespace io
 }  // namespace storm

--- a/src/storm/io/DDEncodingExporter.h
+++ b/src/storm/io/DDEncodingExporter.h
@@ -3,7 +3,7 @@
 #include "storm/models/symbolic/Model.h"
 
 namespace storm {
-namespace exporter {
+namespace io {
 
 /*!
  * Exports a sparse model into the explicit drdd format.
@@ -14,5 +14,5 @@ namespace exporter {
 template<storm::dd::DdType Type, typename ValueType>
 void explicitExportSymbolicModel(std::string const& filename, std::shared_ptr<storm::models::symbolic::Model<Type, ValueType>> symbolicModel);
 
-}  // namespace exporter
+}  // namespace io
 }  // namespace storm

--- a/src/storm/io/DirectEncodingExporter.cpp
+++ b/src/storm/io/DirectEncodingExporter.cpp
@@ -1,20 +1,19 @@
 #include "storm/io/DirectEncodingExporter.h"
-#include <storm/exceptions/NotSupportedException.h>
 
 #include "storm/adapters/RationalFunctionAdapter.h"
 #include "storm/exceptions/NotImplementedException.h"
+#include "storm/exceptions/NotSupportedException.h"
 #include "storm/models/sparse/Ctmc.h"
 #include "storm/models/sparse/Dtmc.h"
 #include "storm/models/sparse/MarkovAutomaton.h"
 #include "storm/models/sparse/Mdp.h"
 #include "storm/models/sparse/Pomdp.h"
+#include "storm/models/sparse/StandardRewardModel.h"
 #include "storm/utility/constants.h"
 #include "storm/utility/macros.h"
 
-#include "storm/models/sparse/StandardRewardModel.h"
-
 namespace storm {
-namespace exporter {
+namespace io {
 
 template<typename ValueType>
 void explicitExportSparseModel(std::ostream& os, std::shared_ptr<storm::models::sparse::Model<ValueType>> sparseModel,
@@ -281,5 +280,5 @@ template void explicitExportSparseModel<storm::RationalFunction>(std::ostream& o
                                                                  std::vector<std::string> const& parameters, DirectEncodingOptions const& options);
 template void explicitExportSparseModel<storm::Interval>(std::ostream& os, std::shared_ptr<storm::models::sparse::Model<storm::Interval>> sparseModel,
                                                          std::vector<std::string> const& parameters, DirectEncodingOptions const& options);
-}  // namespace exporter
+}  // namespace io
 }  // namespace storm

--- a/src/storm/io/DirectEncodingExporter.h
+++ b/src/storm/io/DirectEncodingExporter.h
@@ -6,7 +6,7 @@
 #include "storm/models/sparse/Model.h"
 
 namespace storm {
-namespace exporter {
+namespace io {
 
 struct DirectEncodingOptions {
     bool allowPlaceholders = true;
@@ -50,5 +50,5 @@ std::unordered_map<ValueType, std::string> generatePlaceholders(std::shared_ptr<
  */
 template<typename ValueType>
 void writeValue(std::ostream& os, ValueType value, std::unordered_map<ValueType, std::string> const& placeholders);
-}  // namespace exporter
+}  // namespace io
 }  // namespace storm

--- a/src/storm/io/ModelExportFormat.cpp
+++ b/src/storm/io/ModelExportFormat.cpp
@@ -4,7 +4,7 @@
 #include "storm/utility/macros.h"
 
 namespace storm {
-namespace exporter {
+namespace io {
 
 ModelExportFormat getModelExportFormatFromString(std::string const& input) {
     if (input == "dot") {
@@ -41,5 +41,5 @@ ModelExportFormat getModelExportFormatFromFileExtension(std::string const& filen
     return getModelExportFormatFromString(filename.substr(pos));
 }
 
-}  // namespace exporter
+}  // namespace io
 }  // namespace storm

--- a/src/storm/io/ModelExportFormat.h
+++ b/src/storm/io/ModelExportFormat.h
@@ -3,7 +3,7 @@
 #include <string>
 
 namespace storm {
-namespace exporter {
+namespace io {
 
 enum class ModelExportFormat { Dot, Drdd, Drn, Json };
 
@@ -23,5 +23,5 @@ std::string toString(ModelExportFormat const& input);
  * @throws InvalidArgumentException if there is no file extension or if it doesn't match any known format.
  */
 ModelExportFormat getModelExportFormatFromFileExtension(std::string const& filename);
-}  // namespace exporter
+}  // namespace io
 }  // namespace storm

--- a/src/storm/io/export.h
+++ b/src/storm/io/export.h
@@ -1,5 +1,4 @@
-#ifndef STORM_UTILITY_EXPORT_H_
-#define STORM_UTILITY_EXPORT_H_
+#pragma once
 
 #include <boost/optional.hpp>
 #include <iostream>
@@ -8,14 +7,14 @@
 #include "storm/utility/macros.h"
 
 namespace storm {
-namespace utility {
+namespace io {
 
 template<typename DataType, typename Header1Type = DataType, typename Header2Type = DataType>
 inline void exportDataToCSVFile(std::string filepath, std::vector<std::vector<DataType>> const& data,
                                 boost::optional<std::vector<Header1Type>> const& header1 = boost::none,
                                 boost::optional<std::vector<Header2Type>> const& header2 = boost::none) {
     std::ofstream filestream;
-    storm::utility::openFile(filepath, filestream);
+    storm::io::openFile(filepath, filestream);
 
     if (header1) {
         for (auto columnIt = header1->begin(); columnIt != header1->end(); ++columnIt) {
@@ -46,7 +45,7 @@ inline void exportDataToCSVFile(std::string filepath, std::vector<std::vector<Da
         }
         filestream << '\n';
     }
-    storm::utility::closeFile(filestream);
+    storm::io::closeFile(filestream);
 }
 
 /*!
@@ -73,7 +72,5 @@ inline void outputFixedWidth(std::ostream& stream, Container const& output, size
         }
     }
 }
-}  // namespace utility
+}  // namespace io
 }  // namespace storm
-
-#endif

--- a/src/storm/io/file.h
+++ b/src/storm/io/file.h
@@ -6,7 +6,7 @@
 #include "storm/utility/macros.h"
 
 namespace storm {
-namespace utility {
+namespace io {
 
 /*!
  * Open the given file for writing.
@@ -92,5 +92,5 @@ inline std::basic_istream<CharT, Traits>& getline(std::basic_istream<CharT, Trai
     return res;
 }
 
-}  // namespace utility
+}  // namespace io
 }  // namespace storm

--- a/src/storm/logic/HOAPathFormula.cpp
+++ b/src/storm/logic/HOAPathFormula.cpp
@@ -75,9 +75,9 @@ void HOAPathFormula::gatherReferencedRewardModels(std::set<std::string>& referen
 
 storm::automata::DeterministicAutomaton::ptr HOAPathFormula::readAutomaton() const {
     std::ifstream in;
-    storm::utility::openFile(automatonFile, in);
+    storm::io::openFile(automatonFile, in);
     storm::automata::DeterministicAutomaton::ptr automaton = storm::automata::DeterministicAutomaton::parse(in);
-    storm::utility::closeFile(in);
+    storm::io::closeFile(in);
     for (auto& ap : automaton->getAPSet().getAPs()) {
         STORM_LOG_THROW(apToFormulaMap.find(ap) != apToFormulaMap.end(), storm::exceptions::ExpressionEvaluationException,
                         "For '" << automatonFile << "' HOA automaton, expression for atomic proposition '" << ap << "' is missing.");

--- a/src/storm/logic/HOAPathFormula.cpp
+++ b/src/storm/logic/HOAPathFormula.cpp
@@ -1,12 +1,14 @@
 #include "storm/logic/HOAPathFormula.h"
+
 #include <boost/any.hpp>
 #include <ostream>
-#include "storm/logic/FormulaVisitor.h"
 
 #include "storm/automata/DeterministicAutomaton.h"
 #include "storm/exceptions/ExpressionEvaluationException.h"
 #include "storm/exceptions/IllegalArgumentException.h"
 #include "storm/exceptions/InvalidPropertyException.h"
+#include "storm/io/file.h"
+#include "storm/logic/FormulaVisitor.h"
 #include "storm/utility/macros.h"
 
 namespace storm {
@@ -72,8 +74,10 @@ void HOAPathFormula::gatherReferencedRewardModels(std::set<std::string>& referen
 }
 
 storm::automata::DeterministicAutomaton::ptr HOAPathFormula::readAutomaton() const {
-    std::ifstream in(automatonFile);
+    std::ifstream in;
+    storm::utility::openFile(automatonFile, in);
     storm::automata::DeterministicAutomaton::ptr automaton = storm::automata::DeterministicAutomaton::parse(in);
+    storm::utility::closeFile(in);
     for (auto& ap : automaton->getAPSet().getAPs()) {
         STORM_LOG_THROW(apToFormulaMap.find(ap) != apToFormulaMap.end(), storm::exceptions::ExpressionEvaluationException,
                         "For '" << automatonFile << "' HOA automaton, expression for atomic proposition '" << ap << "' is missing.");

--- a/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsParetoExplorer.cpp
+++ b/src/storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsParetoExplorer.cpp
@@ -680,7 +680,7 @@ storm::utility::zero<GeometryValueType>()), std::vector<GeometryValueType>(objec
         for(auto const& v : underApproxVertices) {
             pointsForPlotting.push_back(storm::utility::vector::convertNumericVector<double>(v));
         }
-        storm::utility::exportDataToCSVFile<double, std::string>(env.modelchecker().multi().getPlotPathUnderApproximation().get(), pointsForPlotting,
+        storm::io::exportDataToCSVFile<double, std::string>(env.modelchecker().multi().getPlotPathUnderApproximation().get(), pointsForPlotting,
 columnHeaders);
     }
 
@@ -691,7 +691,7 @@ columnHeaders);
         for(auto const& v : overApproxVertices) {
             pointsForPlotting.push_back(storm::utility::vector::convertNumericVector<double>(v));
         }
-        storm::utility::exportDataToCSVFile<double, std::string>(env.modelchecker().multi().getPlotPathOverApproximation().get(), pointsForPlotting,
+        storm::io::exportDataToCSVFile<double, std::string>(env.modelchecker().multi().getPlotPathOverApproximation().get(), pointsForPlotting,
 columnHeaders);
     }
 
@@ -701,7 +701,7 @@ columnHeaders);
         for(auto const& v : paretoPoints) {
             pointsForPlotting.push_back(storm::utility::vector::convertNumericVector<double>(v));
         }
-        storm::utility::exportDataToCSVFile<double, std::string>(env.modelchecker().multi().getPlotPathParetoPoints().get(), pointsForPlotting, columnHeaders);
+        storm::io::exportDataToCSVFile<double, std::string>(env.modelchecker().multi().getPlotPathParetoPoints().get(), pointsForPlotting, columnHeaders);
     }
 };
      */

--- a/src/storm/modelchecker/multiobjective/pcaa/RewardBoundedMdpPcaaWeightVectorChecker.cpp
+++ b/src/storm/modelchecker/multiobjective/pcaa/RewardBoundedMdpPcaaWeightVectorChecker.cpp
@@ -119,7 +119,7 @@ void RewardBoundedMdpPcaaWeightVectorChecker<SparseMdpModelType>::check(Environm
         for (uint64_t i = 0; i < this->objectives.size(); ++i) {
             headers.push_back("obj" + std::to_string(i));
         }
-        storm::utility::exportDataToCSVFile<ValueType, ValueType, std::string>(
+        storm::io::exportDataToCSVFile<ValueType, ValueType, std::string>(
             storm::settings::getModule<storm::settings::modules::IOSettings>().getExportCdfDirectory() + "cdf" + std::to_string(numChecks) + ".csv", cdfData,
             weightVector, headers);
     }

--- a/src/storm/modelchecker/multiobjective/pcaa/SparsePcaaQuery.cpp
+++ b/src/storm/modelchecker/multiobjective/pcaa/SparsePcaaQuery.cpp
@@ -189,8 +189,7 @@ void SparsePcaaQuery<SparseModelType, GeometryValueType>::exportPlotOfCurrentApp
         for (auto const& v : underApproxVertices) {
             pointsForPlotting.push_back(storm::utility::vector::convertNumericVector<double>(v));
         }
-        storm::utility::exportDataToCSVFile<double, std::string>(env.modelchecker().multi().getPlotPathUnderApproximation().get(), pointsForPlotting,
-                                                                 columnHeaders);
+        storm::io::exportDataToCSVFile<double, std::string>(env.modelchecker().multi().getPlotPathUnderApproximation().get(), pointsForPlotting, columnHeaders);
     }
 
     if (env.modelchecker().multi().getPlotPathOverApproximation()) {
@@ -200,8 +199,7 @@ void SparsePcaaQuery<SparseModelType, GeometryValueType>::exportPlotOfCurrentApp
         for (auto const& v : overApproxVertices) {
             pointsForPlotting.push_back(storm::utility::vector::convertNumericVector<double>(v));
         }
-        storm::utility::exportDataToCSVFile<double, std::string>(env.modelchecker().multi().getPlotPathOverApproximation().get(), pointsForPlotting,
-                                                                 columnHeaders);
+        storm::io::exportDataToCSVFile<double, std::string>(env.modelchecker().multi().getPlotPathOverApproximation().get(), pointsForPlotting, columnHeaders);
     }
 
     if (env.modelchecker().multi().getPlotPathParetoPoints()) {
@@ -210,7 +208,7 @@ void SparsePcaaQuery<SparseModelType, GeometryValueType>::exportPlotOfCurrentApp
         for (auto const& v : paretoPoints) {
             pointsForPlotting.push_back(storm::utility::vector::convertNumericVector<double>(v));
         }
-        storm::utility::exportDataToCSVFile<double, std::string>(env.modelchecker().multi().getPlotPathParetoPoints().get(), pointsForPlotting, columnHeaders);
+        storm::io::exportDataToCSVFile<double, std::string>(env.modelchecker().multi().getPlotPathParetoPoints().get(), pointsForPlotting, columnHeaders);
     }
 }
 

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -126,7 +126,7 @@ std::map<storm::storage::sparse::state_type, ValueType> SparseDtmcPrctlHelper<Va
             headers.push_back(rewardUnfolding.getDimension(i).formula->toString());
         }
         headers.push_back("Result");
-        storm::utility::exportDataToCSVFile<ValueType, std::string, std::string>(
+        storm::io::exportDataToCSVFile<ValueType, std::string, std::string>(
             storm::settings::getModule<storm::settings::modules::IOSettings>().getExportCdfDirectory() + "cdf.csv", cdfData, headers);
     }
 

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -125,7 +125,7 @@ std::map<storm::storage::sparse::state_type, SolutionType> SparseMdpPrctlHelper<
                 headers.push_back(rewardUnfolding.getDimension(i).formula->toString());
             }
             headers.push_back("Result");
-            storm::utility::exportDataToCSVFile<ValueType, std::string, std::string>(
+            storm::io::exportDataToCSVFile<ValueType, std::string, std::string>(
                 storm::settings::getModule<storm::settings::modules::IOSettings>().getExportCdfDirectory() + "cdf.csv", cdfData, headers);
         }
 

--- a/src/storm/models/sparse/DeterministicModel.cpp
+++ b/src/storm/models/sparse/DeterministicModel.cpp
@@ -41,7 +41,7 @@ void DeterministicModel<ValueType, RewardModelType>::writeDotToStream(std::ostre
             arrowOrigin = "\"" + arrowOrigin + "c\"";
             outStream << "\t" << arrowOrigin << " [shape = \"point\"]\n";
             outStream << "\t" << i << " -> " << arrowOrigin << " [label= \"{";
-            storm::utility::outputFixedWidth(outStream, this->getChoiceLabeling().getLabelsOfChoice(i), maxWidthLabel);
+            storm::io::outputFixedWidth(outStream, this->getChoiceLabeling().getLabelsOfChoice(i), maxWidthLabel);
             outStream << "}\"];\n";
         }
 

--- a/src/storm/models/sparse/Model.cpp
+++ b/src/storm/models/sparse/Model.cpp
@@ -472,14 +472,14 @@ void Model<ValueType, RewardModelType>::writeDotToStream(std::ostream& outStream
                         std::string stateInfo = getStateValuations().getStateInfo(state);
                         std::vector<std::string> results;
                         boost::split(results, stateInfo, [](char c) { return c == ','; });
-                        storm::utility::outputFixedWidth(outStream, results, maxWidthLabel);
+                        storm::io::outputFixedWidth(outStream, results, maxWidthLabel);
                     }
                     outStream << ": ";
 
                     // Now print the state labeling to the stream if requested.
                     if (includeLabeling) {
                         outStream << "{";
-                        storm::utility::outputFixedWidth(outStream, this->getLabelsOfState(state), maxWidthLabel);
+                        storm::io::outputFixedWidth(outStream, this->getLabelsOfState(state), maxWidthLabel);
                         outStream << "}";
                     }
 

--- a/src/storm/models/sparse/NondeterministicModel.cpp
+++ b/src/storm/models/sparse/NondeterministicModel.cpp
@@ -133,7 +133,7 @@ void NondeterministicModel<ValueType, RewardModelType>::writeDotToStream(std::os
                     outStream << " [ label = \"{";
                 }
                 arrowHasLabel = true;
-                storm::utility::outputFixedWidth(outStream, this->getChoiceLabeling().getLabelsOfChoice(rowIndex), maxWidthLabel);
+                storm::io::outputFixedWidth(outStream, this->getChoiceLabeling().getLabelsOfChoice(rowIndex), maxWidthLabel);
                 outStream << "}";
             }
             if (arrowHasLabel) {

--- a/src/storm/settings/ArgumentValidators.cpp
+++ b/src/storm/settings/ArgumentValidators.cpp
@@ -84,7 +84,7 @@ bool FileValidator::isValid(std::string const& filename) {
                         "Unable to read from non-existing file '" << filename << "'.");
 
         // Now that we know it's a file, we can check its readability.
-        STORM_LOG_THROW(storm::utility::fileExistsAndIsReadable(filename), storm::exceptions::IllegalArgumentValueException,
+        STORM_LOG_THROW(storm::io::fileExistsAndIsReadable(filename), storm::exceptions::IllegalArgumentValueException,
                         "Unable to read from file '" << filename << "'.");
 
         return true;

--- a/src/storm/settings/ArgumentValidators.cpp
+++ b/src/storm/settings/ArgumentValidators.cpp
@@ -8,6 +8,7 @@
 #include "storm/exceptions/IllegalArgumentValueException.h"
 #include "storm/exceptions/IllegalFunctionCallException.h"
 #include "storm/exceptions/InvalidArgumentException.h"
+#include "storm/io/file.h"
 #include "storm/settings/Argument.h"
 #include "storm/utility/macros.h"
 
@@ -83,8 +84,8 @@ bool FileValidator::isValid(std::string const& filename) {
                         "Unable to read from non-existing file '" << filename << "'.");
 
         // Now that we know it's a file, we can check its readability.
-        std::ifstream istream(filename);
-        STORM_LOG_THROW(istream.good(), storm::exceptions::IllegalArgumentValueException, "Unable to read from file '" << filename << "'.");
+        STORM_LOG_THROW(storm::utility::fileExistsAndIsReadable(filename), storm::exceptions::IllegalArgumentValueException,
+                        "Unable to read from file '" << filename << "'.");
 
         return true;
     } else if (mode == Mode::Writable) {

--- a/src/storm/settings/ArgumentValidators.cpp
+++ b/src/storm/settings/ArgumentValidators.cpp
@@ -89,11 +89,11 @@ bool FileValidator::isValid(std::string const& filename) {
 
         return true;
     } else if (mode == Mode::Writable) {
-        std::ofstream filestream(filename);
+        std::ofstream filestream;
+        storm::io::openFile(filename, filestream, false, true);
         STORM_LOG_THROW(filestream.is_open(), storm::exceptions::IllegalArgumentValueException, "Could not open file '" << filename << "' for writing.");
-        filestream.close();
+        storm::io::closeFile(filestream);
         std::remove(filename.c_str());
-
         return true;
     }
     return false;

--- a/src/storm/settings/SettingsManager.cpp
+++ b/src/storm/settings/SettingsManager.cpp
@@ -555,12 +555,12 @@ std::map<std::string, std::vector<std::string>> SettingsManager::parseConfigFile
     std::map<std::string, std::vector<std::string>> result;
 
     std::ifstream input;
-    storm::utility::openFile(filename, input);
+    storm::io::openFile(filename, input);
 
     bool globalScope = true;
     std::string activeModule = "";
     uint_fast64_t lineNumber = 1;
-    for (std::string line; storm::utility::getline(input, line); ++lineNumber) {
+    for (std::string line; storm::io::getline(input, line); ++lineNumber) {
         // If the first character of the line is a "[", we expect the settings of a new module to start and
         // the line to be of the shape [<module>].
         if (line.at(0) == '[') {
@@ -655,7 +655,7 @@ std::map<std::string, std::vector<std::string>> SettingsManager::parseConfigFile
         }
     }
 
-    storm::utility::closeFile(input);
+    storm::io::closeFile(input);
     return result;
 }
 

--- a/src/storm/settings/modules/IOSettings.cpp
+++ b/src/storm/settings/modules/IOSettings.cpp
@@ -286,12 +286,12 @@ std::string IOSettings::getExportBuildFilename() const {
     return this->getOption(exportBuildOptionName).getArgumentByName("file").getValueAsString();
 }
 
-storm::exporter::ModelExportFormat IOSettings::getExportBuildFormat() const {
+storm::io::ModelExportFormat IOSettings::getExportBuildFormat() const {
     auto format = this->getOption(exportBuildOptionName).getArgumentByName("format").getValueAsString();
     if (format == "auto") {
-        return storm::exporter::getModelExportFormatFromFileExtension(getExportBuildFilename());
+        return storm::io::getModelExportFormatFromFileExtension(getExportBuildFilename());
     } else {
-        return storm::exporter::getModelExportFormatFromString(format);
+        return storm::io::getModelExportFormatFromString(format);
     }
 }
 

--- a/src/storm/settings/modules/IOSettings.h
+++ b/src/storm/settings/modules/IOSettings.h
@@ -57,7 +57,7 @@ class IOSettings : public ModuleSettings {
     /*!
      * Retrieves the specified export format for the exportbuild option
      */
-    storm::exporter::ModelExportFormat getExportBuildFormat() const;
+    storm::io::ModelExportFormat getExportBuildFormat() const;
 
     /*!
      * Retrieves whether the export-to-dot option for jani was set.

--- a/src/storm/solver/SmtlibSmtSolver.cpp
+++ b/src/storm/solver/SmtlibSmtSolver.cpp
@@ -230,7 +230,7 @@ void SmtlibSmtSolver::init() {
 
     if (storm::settings::getModule<storm::settings::modules::Smt2SmtSolverSettings>().isExportSmtLibScriptSet()) {
         STORM_LOG_DEBUG("The SMT-LIBv2 commands are exportet to the given file");
-        storm::utility::openFile(storm::settings::getModule<storm::settings::modules::Smt2SmtSolverSettings>().getExportSmtLibScriptPath(), commandFile);
+        storm::io::openFile(storm::settings::getModule<storm::settings::modules::Smt2SmtSolverSettings>().getExportSmtLibScriptPath(), commandFile);
         isCommandFileOpen = true;
         // TODO also close file
     }

--- a/src/storm/solver/Z3LpSolver.cpp
+++ b/src/storm/solver/Z3LpSolver.cpp
@@ -276,9 +276,9 @@ ValueType Z3LpSolver<ValueType, RawMode>::getObjectiveValue() const {
 template<typename ValueType, bool RawMode>
 void Z3LpSolver<ValueType, RawMode>::writeModelToFile(std::string const& filename) const {
     std::ofstream stream;
-    storm::utility::openFile(filename, stream);
+    storm::io::openFile(filename, stream);
     stream << Z3_optimize_to_string(*context, *solver);
-    storm::utility::closeFile(stream);
+    storm::io::closeFile(stream);
 }
 
 template<typename ValueType, bool RawMode>

--- a/src/storm/storage/Qvbs.cpp
+++ b/src/storm/storage/Qvbs.cpp
@@ -15,13 +15,12 @@ namespace storm {
 namespace storage {
 
 storm::json<storm::RationalNumber> readQvbsJsonFile(std::string const& filePath) {
-    STORM_LOG_THROW(storm::utility::fileExistsAndIsReadable(filePath), storm::exceptions::WrongFormatException,
-                    "QVBS json file " << filePath << " was not found.");
+    STORM_LOG_THROW(storm::io::fileExistsAndIsReadable(filePath), storm::exceptions::WrongFormatException, "QVBS json file " << filePath << " was not found.");
     storm::json<storm::RationalNumber> result;
     std::ifstream file;
-    storm::utility::openFile(filePath, file);
+    storm::io::openFile(filePath, file);
     file >> result;
-    storm::utility::closeFile(file);
+    storm::io::closeFile(file);
     return result;
 }
 

--- a/src/storm/storage/dd/Odd.cpp
+++ b/src/storm/storage/dd/Odd.cpp
@@ -126,7 +126,7 @@ void Odd::oldToNewIndexRec(uint_fast64_t oldOffset, storm::dd::Odd const& oldOdd
 
 void Odd::exportToDot(std::string const& filename) const {
     std::ofstream dotFile;
-    storm::utility::openFile(filename, dotFile);
+    storm::io::openFile(filename, dotFile);
 
     // Print header.
     dotFile << "digraph \"ODD\" {\n"
@@ -166,7 +166,7 @@ void Odd::exportToDot(std::string const& filename) const {
     }
 
     dotFile << "}\n";
-    storm::utility::closeFile(dotFile);
+    storm::io::closeFile(dotFile);
 }
 
 void Odd::exportToText(std::string const& filename) const {

--- a/src/storm/storage/jani/visitor/JSONExporter.cpp
+++ b/src/storm/storage/jani/visitor/JSONExporter.cpp
@@ -806,9 +806,9 @@ boost::any ExpressionToJson::visit(storm::expressions::TranscendentalNumberLiter
 void JsonExporter::toFile(storm::jani::Model const& janiModel, std::vector<storm::jani::Property> const& formulas, std::string const& filepath, bool checkValid,
                           bool compact) {
     std::ofstream stream;
-    storm::utility::openFile(filepath, stream, false, true);
+    storm::io::openFile(filepath, stream, false, true);
     toStream(janiModel, formulas, stream, checkValid, compact);
-    storm::utility::closeFile(stream);
+    storm::io::closeFile(stream);
 }
 
 void JsonExporter::toStream(storm::jani::Model const& janiModel, std::vector<storm::jani::Property> const& formulas, std::ostream& os, bool checkValid,

--- a/src/storm/utility/threads.cpp
+++ b/src/storm/utility/threads.cpp
@@ -25,12 +25,12 @@ uint tryReadFromSlurm() {
 
 uint tryReadFromCgroups() {
     std::string const filename = "/sys/fs/cgroup/cpu.max";
-    if (storm::utility::fileExistsAndIsReadable(filename)) {
+    if (storm::io::fileExistsAndIsReadable(filename)) {
         std::ifstream inputFileStream;
-        storm::utility::openFile(filename, inputFileStream);
+        storm::io::openFile(filename, inputFileStream);
         std::string contents;
-        storm::utility::getline(inputFileStream, contents);
-        storm::utility::closeFile(inputFileStream);
+        storm::io::getline(inputFileStream, contents);
+        storm::io::closeFile(inputFileStream);
 
         auto pos1 = contents.data();
         char* pos2;

--- a/src/test/storm/parser/MappedFileTest.cpp
+++ b/src/test/storm/parser/MappedFileTest.cpp
@@ -39,12 +39,12 @@ TEST(MappedFileTest, ExistsAndReadble) {
     // Test the fileExistsAndIsReadable() method under various circumstances.
 
     // File exists and is readable.
-    ASSERT_TRUE(storm::utility::fileExistsAndIsReadable(STORM_TEST_RESOURCES_DIR "/txt/testStringFile.txt"));
+    ASSERT_TRUE(storm::io::fileExistsAndIsReadable(STORM_TEST_RESOURCES_DIR "/txt/testStringFile.txt"));
 
     // File does not exist.
-    ASSERT_FALSE(storm::utility::fileExistsAndIsReadable(STORM_TEST_RESOURCES_DIR "/nonExistingFile.not"));
+    ASSERT_FALSE(storm::io::fileExistsAndIsReadable(STORM_TEST_RESOURCES_DIR "/nonExistingFile.not"));
 
     // File exists but is not readable.
     // TODO: Find portable solution to providing a situation in which a file exists but is not readable.
-    // ASSERT_FALSE(storm::utility::fileExistsAndIsReadable(STORM_TEST_RESOURCES_DIR "/parser/unreadableFile.txt"));
+    // ASSERT_FALSE(storm::io::fileExistsAndIsReadable(STORM_TEST_RESOURCES_DIR "/parser/unreadableFile.txt"));
 }

--- a/src/test/storm/transformer/DAProductBuilderTest.cpp
+++ b/src/test/storm/transformer/DAProductBuilderTest.cpp
@@ -63,13 +63,15 @@ TEST(DAProductBuilderTest_aUb, Dtmc) {
     storm::transformer::DAProductBuilder productBuilder(*da, apLabels);
     auto product = productBuilder.build(*dtmc, dtmc->getInitialStates());
 
-    // std::ofstream modelDot("model.dot");
+    // std::ofstream modelDot;
+    // storm::io::openFile("model.dot", modelDot);
     // dtmc->writeDotToStream(modelDot);
-    // modelDot.close();
+    // storm::io::closeFile(modelDot);
 
-    // std::ofstream productDot("product.dot");
+    // std::ofstream productDot;
+    // storm::io::openFile("product.dot", modelDot);
     // product->getProductModel().writeDotToStream(productDot);
-    // productDot.close();
+    // storm::io::closeFile(productDot);
 
     // product->printMapping(std::cout);
 

--- a/src/test/storm/utility/FileTest.cpp
+++ b/src/test/storm/utility/FileTest.cpp
@@ -10,7 +10,7 @@ TEST(FileTest, GetLine) {
     std::string str;
     int i = 0;
     std::string expected[] = {"Hello world", "This is a test with n", "This is a test with rn", "", "More tests"};
-    while (storm::utility::getline(stream, str)) {
+    while (storm::io::getline(stream, str)) {
         EXPECT_EQ(str, expected[i]);
         ++i;
     }
@@ -19,5 +19,5 @@ TEST(FileTest, GetLine) {
 TEST(FileTest, GetLineEmpty) {
     std::stringstream stream;
     std::string str;
-    EXPECT_FALSE(storm::utility::getline(stream, str));
+    EXPECT_FALSE(storm::io::getline(stream, str));
 }


### PR DESCRIPTION
- Consistently use `openFile` / `closeFile` helper functions
- Introduce namespace `storm::io` for all files in `storm/io`
- Warn if a property string looks like a link to a property file but the file does not exist (Resolves #643). The check warns if the property strings contains any of `.prop`, `.prctl`, `.pctl` or `.csl` (following the [Prism documentation](https://www.prismmodelchecker.org/manual/PropertySpecification/PropertiesFiles))