### PR TITLE
Added two functions for more convenient access to state valuations

### DIFF
--- a/src/storm/storage/prism/Program.cpp
+++ b/src/storm/storage/prism/Program.cpp
@@ -487,11 +487,13 @@ std::vector<IntegerVariable> const& Program::getGlobalIntegerVariables() const {
     return this->globalIntegerVariables;
 }
 
-std::set<storm::expressions::Variable> Program::getAllExpressionVariables() const {
+std::set<storm::expressions::Variable> Program::getAllExpressionVariables(bool includeConstants) const {
     std::set<storm::expressions::Variable> result;
 
-    for (auto const& constant : constants) {
-        result.insert(constant.getExpressionVariable());
+    if (includeConstants) {
+        for (auto const& constant : constants) {
+            result.insert(constant.getExpressionVariable());
+        }
     }
     for (auto const& variable : globalBooleanVariables) {
         result.insert(variable.getExpressionVariable());

--- a/src/storm/storage/prism/Program.h
+++ b/src/storm/storage/prism/Program.h
@@ -258,9 +258,10 @@ class Program : public LocatedInformation {
     /*!
      * Retrieves all expression variables used by this program.
      *
+     * @param includeConstants Whether to include constants in the set of expression variables.
      * @return The set of expression variables used by this program.
      */
-    std::set<storm::expressions::Variable> getAllExpressionVariables() const;
+    std::set<storm::expressions::Variable> getAllExpressionVariables(bool includeConstants = true) const;
 
     /*!
      * Retrieves a list of expressions that characterize the legal ranges of all variables.

--- a/src/storm/storage/sparse/StateValuations.cpp
+++ b/src/storm/storage/sparse/StateValuations.cpp
@@ -164,6 +164,34 @@ storm::RationalNumber const& StateValuations::getRationalValue(storm::storage::s
     return valuation.rationalValues[variableToIndexMap.at(rationalVariable)];
 }
 
+storm::storage::BitVector StateValuations::getBooleanValues(storm::expressions::Variable const& booleanVariable) const {
+    storm::storage::BitVector result(getNumberOfStates(), false);
+    for (uint64_t stateIndex = 0; stateIndex < getNumberOfStates(); ++stateIndex) {
+        if (getBooleanValue(stateIndex, booleanVariable)) {
+            result.set(stateIndex);
+        }
+    }
+    return result;
+}
+
+std::vector<int64_t> StateValuations::getIntegerValues(storm::expressions::Variable const& integerVariable) const {
+    std::vector<int64_t> result;
+    result.reserve(getNumberOfStates());
+    for (uint64_t stateIndex = 0; stateIndex < getNumberOfStates(); ++stateIndex) {
+        result.push_back(getIntegerValue(stateIndex, integerVariable));
+    }
+    return result;
+}
+
+std::vector<storm::RationalNumber> StateValuations::getRationalValues(storm::expressions::Variable const& rationalVariable) const {
+    std::vector<storm::RationalNumber> result;
+    result.reserve(getNumberOfStates());
+    for (uint64_t stateIndex = 0; stateIndex < getNumberOfStates(); ++stateIndex) {
+        result.push_back(getRationalValue(stateIndex, rationalVariable));
+    }
+    return result;
+}
+
 bool StateValuations::isEmpty(storm::storage::sparse::state_type const& stateIndex) const {
     auto const& valuation = valuations[stateIndex];  // Do not use getValuations, as that is only valid after adding stuff.
     return valuation.booleanValues.empty() && valuation.integerValues.empty() && valuation.rationalValues.empty() && valuation.observationLabelValues.empty();

--- a/src/storm/storage/sparse/StateValuations.cpp
+++ b/src/storm/storage/sparse/StateValuations.cpp
@@ -165,9 +165,11 @@ storm::RationalNumber const& StateValuations::getRationalValue(storm::storage::s
 }
 
 storm::storage::BitVector StateValuations::getBooleanValues(storm::expressions::Variable const& booleanVariable) const {
+    STORM_LOG_ASSERT(variableToIndexMap.count(booleanVariable) > 0, "Variable " << booleanVariable.getName() << " is not part of this valuation.");
+    auto const varIndex = variableToIndexMap.at(booleanVariable);
     storm::storage::BitVector result(getNumberOfStates(), false);
     for (uint64_t stateIndex = 0; stateIndex < getNumberOfStates(); ++stateIndex) {
-        if (getBooleanValue(stateIndex, booleanVariable)) {
+        if (getValuation(stateIndex).booleanValues[varIndex]) {
             result.set(stateIndex);
         }
     }
@@ -175,19 +177,23 @@ storm::storage::BitVector StateValuations::getBooleanValues(storm::expressions::
 }
 
 std::vector<int64_t> StateValuations::getIntegerValues(storm::expressions::Variable const& integerVariable) const {
+    STORM_LOG_ASSERT(variableToIndexMap.count(integerVariable) > 0, "Variable " << integerVariable.getName() << " is not part of this valuation.");
+    auto const varIndex = variableToIndexMap.at(integerVariable);
     std::vector<int64_t> result;
     result.reserve(getNumberOfStates());
     for (uint64_t stateIndex = 0; stateIndex < getNumberOfStates(); ++stateIndex) {
-        result.push_back(getIntegerValue(stateIndex, integerVariable));
+        result.push_back(getValuation(stateIndex).integerValues[varIndex]);
     }
     return result;
 }
 
 std::vector<storm::RationalNumber> StateValuations::getRationalValues(storm::expressions::Variable const& rationalVariable) const {
+    STORM_LOG_ASSERT(variableToIndexMap.count(rationalVariable) > 0, "Variable " << rationalVariable.getName() << " is not part of this valuation.");
+    auto const varIndex = variableToIndexMap.at(rationalVariable);
     std::vector<storm::RationalNumber> result;
     result.reserve(getNumberOfStates());
     for (uint64_t stateIndex = 0; stateIndex < getNumberOfStates(); ++stateIndex) {
-        result.push_back(getRationalValue(stateIndex, rationalVariable));
+        result.push_back(getValuation(stateIndex).rationalValues[varIndex]);
     }
     return result;
 }

--- a/src/storm/storage/sparse/StateValuations.h
+++ b/src/storm/storage/sparse/StateValuations.h
@@ -102,6 +102,21 @@ class StateValuations : public storm::models::sparse::StateAnnotation {
     bool isEmpty(storm::storage::sparse::state_type const& stateIndex) const;
 
     /*!
+     * Returns a vector of size getNumberOfStates() such that the i'th entry is the value of the given variable of state i.
+     */
+    storm::storage::BitVector getBooleanValues(storm::expressions::Variable const& booleanVariable) const;
+
+    /*!
+     * Returns a vector of size getNumberOfStates() such that the i'th entry is the value of the given variable of state i.
+     */
+    std::vector<int64_t> getIntegerValues(storm::expressions::Variable const& integerVariable) const;
+
+    /*!
+     * Returns a vector of size getNumberOfStates() such that the i'th entry is the value of the given variable of state i.
+     */
+    std::vector<storm::RationalNumber> getRationalValues(storm::expressions::Variable const& rationalVariable) const;
+
+    /*!
      * Returns a string representation of the valuation.
      *
      * @param selectedVariables If given, only the informations for the variables in this set are processed.


### PR DESCRIPTION
* `prism::Program::getAllExpressionVariables` now has the possibility to not include constants
* added `storage::sparse::StateValuations::getIntegerValues()` and similar for other types, to provide access to all state values of a given variable