### PR TITLE
Speed up of MEC decomposition by adjusting loops

### DIFF
--- a/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
+++ b/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
@@ -108,7 +108,7 @@ storm::storage::BitVector SparseLTLHelper<ValueType, Nondeterministic>::computeA
 
         for (uint64_t i = 0; i < transitionMatrix.getRowGroupCount(); i++) {
             uint64_t mec_index = state_to_mec[i];
-            if (mec_index != MAX && is_amec[mec_index]) {
+            if (mec_index == MAX || is_amec[mec_index]) {
                 allowed.set(i, false);
             }
         }

--- a/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
+++ b/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
@@ -108,7 +108,7 @@ storm::storage::BitVector SparseLTLHelper<ValueType, Nondeterministic>::computeA
 
         for (uint64_t i = 0; i < transitionMatrix.getRowGroupCount(); i++) {
             uint64_t mec_index = state_to_mec[i];
-            if (mec_index == MAX || is_amec[mec_index]) {
+            if (mec_index != MAX && is_amec[mec_index]) {
                 allowed.set(i, false);
             }
         }

--- a/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
+++ b/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
@@ -86,31 +86,27 @@ storm::storage::BitVector SparseLTLHelper<ValueType, Nondeterministic>::computeA
     std::size_t accMECs = 0;
     std::size_t allMECs = 0;
 
+    // All accepting states will be on a MEC. For efficiency, we compute the MECs of the MDP first to restrict the possible candidates.
     // Compute MECs for the entire MDP
     storm::storage::MaximalEndComponentDecomposition<ValueType> mecs(transitionMatrix, backwardTransitions);
-    // Is true if a MEC contains an accepting end component
-    storm::storage::BitVector is_amec(mecs.size());
-    uint64_t MAX = std::numeric_limits<uint64_t>::max();
-    // Maps every state to the MEC it is in, or to MAX
-    std::vector<uint64_t> state_to_mec(transitionMatrix.getRowGroupCount(), MAX);
-    uint64_t mec_counter = 0;
-
-    for (auto const& mec : mecs) {
-        for (auto const& stateChoicePair : mec) {
-            state_to_mec[stateChoicePair.first] = mec_counter;
+    // Maps every state to the MEC it is in, or to InvalidMecIndex if it does not belong to any MEC.
+    std::vector<uint64_t> stateToMec(transitionMatrix.getRowGroupCount(), std::numeric_limits<uint64_t>::max());
+    // Contains states that are on a mec
+    storm::storage::BitVector mecStates(transitionMatrix.getRowGroupCount(), false);
+    for (uint64_t mec_counter = 0; auto const& mec : mecs) {
+        for (auto const& [state, _] : mec) {
+            stateToMec[state] = mec_counter;
+            mecStates.set(state, true);
         }
-        mec_counter++;
+        ++mec_counter;
     }
 
     for (auto const& conjunction : dnf) {
-        // Determine the set of states of the subMDP that can satisfy the condition, remove all states that would violate Fins in the conjunction.
-        storm::storage::BitVector allowed(transitionMatrix.getRowGroupCount(), true);
+        // get the states of the mdp that (a) are on a MEC, (b) are not already known to be accepting, and (c) don't violate Fins of the conjunction
+        storm::storage::BitVector allowed = mecStates & ~acceptingStates;
 
-        for (uint64_t i = 0; i < transitionMatrix.getRowGroupCount(); i++) {
-            uint64_t mec_index = state_to_mec[i];
-            if (mec_index == MAX || is_amec[mec_index]) {
-                allowed.set(i, false);
-            }
+        if (allowed.empty()) {
+            break;  // no more candidates
         }
 
         for (auto const& literal : conjunction) {
@@ -141,9 +137,15 @@ storm::storage::BitVector SparseLTLHelper<ValueType, Nondeterministic>::computeA
         }
 
         // Compute MECs in the allowed fragment
-        storm::storage::MaximalEndComponentDecomposition<ValueType> mecs(transitionMatrix, backwardTransitions, allowed);
-        allMECs += mecs.size();
-        for (const auto& mec : mecs) {
+        storm::storage::MaximalEndComponentDecomposition<ValueType> allowedECs(transitionMatrix, backwardTransitions, allowed);
+        allMECs += allowedECs.size();
+        for (const auto& ec : allowedECs) {
+            auto const representativeEcState = ec.begin()->first;
+            if (acceptingStates.get(representativeEcState)) {
+                // The ec is part of a mec that is already known to be accepting
+                continue;
+            }
+
             bool accepting = true;
             for (auto const& literal : conjunction) {
                 if (literal->isTRUE()) {
@@ -157,12 +159,12 @@ storm::storage::BitVector SparseLTLHelper<ValueType, Nondeterministic>::computeA
                     const storm::storage::BitVector& accSet = acceptance.getAcceptanceSet(atom.getAcceptanceSet());
                     if (atom.getType() == cpphoafparser::AtomAcceptance::TEMPORAL_INF) {
                         if (atom.isNegated()) {
-                            if (!mec.containsAnyState(~accSet)) {
+                            if (!ec.containsAnyState(~accSet)) {
                                 accepting = false;
                                 break;
                             }
                         } else {
-                            if (!mec.containsAnyState(accSet)) {
+                            if (!ec.containsAnyState(accSet)) {
                                 accepting = false;
                                 break;
                             }
@@ -170,8 +172,8 @@ storm::storage::BitVector SparseLTLHelper<ValueType, Nondeterministic>::computeA
 
                     } else if (atom.getType() == cpphoafparser::AtomAcceptance::TEMPORAL_FIN) {
                         // Do only sanity checks here.
-                        STORM_LOG_ASSERT(atom.isNegated() ? !mec.containsAnyState(~accSet) : !mec.containsAnyState(accSet),
-                                         "MEC contains Fin-states, which should have been removed");
+                        STORM_LOG_ASSERT(atom.isNegated() ? !ec.containsAnyState(~accSet) : !ec.containsAnyState(accSet),
+                                         "EC contains Fin-states, which should have been removed");
                     }
                 }
             }
@@ -179,16 +181,19 @@ storm::storage::BitVector SparseLTLHelper<ValueType, Nondeterministic>::computeA
             if (accepting) {
                 accMECs++;
 
-                uint64_t mec_index = state_to_mec[(*mec.begin()).first];
-                is_amec.set(mec_index);
+                // get the MEC containing the current EC
+                auto const mec_index = stateToMec[representativeEcState];
+                STORM_LOG_ASSERT(mec_index < mecs.size(), "MEC index out of range.");
+                auto const& mec = mecs[mec_index];
 
-                for (auto const& stateChoicePair : mec) {
-                    acceptingStates.set(stateChoicePair.first);
+                // All states of the (global) mec are accepting since we can almost surely reach the inner ec
+                for (auto const& [state, _] : mec) {
+                    acceptingStates.set(state);
                 }
 
                 if (this->isProduceSchedulerSet()) {
                     // save choices for states that weren't assigned to any other MEC yet.
-                    this->_schedulerHelper.get().saveProductEcChoices(acceptance, mec, conjunction, product);
+                    this->_schedulerHelper.get().saveProductEcChoices(acceptance, ec, mec, conjunction, product);
                 }
             }
         }

--- a/src/storm/modelchecker/helper/ltl/internal/SparseLTLSchedulerHelper.h
+++ b/src/storm/modelchecker/helper/ltl/internal/SparseLTLSchedulerHelper.h
@@ -35,20 +35,20 @@ class SparseLTLSchedulerHelper {
     void setRandom();
 
     /*!
-     * Save choices for states in the accepting end component of the DA-Model product.
-     * We know the EC satisfies the given conjunction of the acceptance condition. Therefore, we want to reach each infinity set in the conjunction infinitely
-     * often. Choices are of the Form <s, q, InfSetID> -> choice.
+     * Save choices for states in the accepting end component of the DA-Model product and for the states in the maximal end component that contains the
+     * accepting EC. We know the acceptingEC satisfies the given conjunction of the acceptance condition. Therefore, we want to reach each infinity set in the
+     * conjunction infinitely often. Choices are of the Form <s, q, InfSetID> -> choice. For states in the containingMEC that are not in the accepting EC, this
+     * method will set a scheduler under which the states of the contained acceptingEC are reached almost surely.
      *
-     * @note The given end component might overlap with another accepting EC (that potentially satisfies another conjunction of the DNF-acceptance condition).
-     * If this is the case, this method will set a scheduler under which the states of the overlapping EC are reached almost surely.
-     * This method only sets new choices for states that are not in any other accepting EC (yet).
+     * @note This method only sets new choices for states that do not have a choice set yet.
      *
      * @param acceptance the acceptance condition (in DNF)
      * @param mec the accepting end component which shall only contain states that can be visited infinitely often (without violating the acc cond.)
      * @param conjunction the conjunction satisfied by the end component
      * @param product the product model
      */
-    void saveProductEcChoices(automata::AcceptanceCondition const& acceptance, storm::storage::MaximalEndComponent const& mec,
+    void saveProductEcChoices(automata::AcceptanceCondition const& acceptance, storm::storage::MaximalEndComponent const& acceptingEC,
+                              storm::storage::MaximalEndComponent const& containingMEC,
                               std::vector<automata::AcceptanceCondition::acceptance_expr::ptr> const& conjunction,
                               typename transformer::DAProduct<productModelType>::ptr product);
 

--- a/src/storm/storage/MaximalEndComponentDecomposition.cpp
+++ b/src/storm/storage/MaximalEndComponentDecomposition.cpp
@@ -138,12 +138,12 @@ void MaximalEndComponentDecomposition<ValueType>::performMaximalEndComponentDeco
         // flattened vector that contains all potential states of end components
         std::vector<uint64_t> ecSccStates(sccDecRes.nonTrivialStates.getNumberOfSetBits());
 
-        for (auto state: sccDecRes.nonTrivialStates) {
+        for (auto state : sccDecRes.nonTrivialStates) {
             ecSccSize[sccDecRes.stateToSccMapping[state]]++;
         }
 
-        for (uint64_t i = 0; i < sccDecRes.sccCount-1; i++) {
-            ecSccIndexToStateIndex[i+1] = ecSccIndexToStateIndex[i] + ecSccSize[i];
+        for (uint64_t i = 0; i < sccDecRes.sccCount - 1; i++) {
+            ecSccIndexToStateIndex[i + 1] = ecSccIndexToStateIndex[i] + ecSccSize[i];
         }
         std::vector<uint64_t> offset(sccDecRes.sccCount);
 

--- a/src/storm/storage/MaximalEndComponentDecomposition.cpp
+++ b/src/storm/storage/MaximalEndComponentDecomposition.cpp
@@ -6,12 +6,8 @@
 #include "storm/adapters/RationalFunctionAdapter.h"
 #include "storm/storage/MaximalEndComponentDecomposition.h"
 
-#include <boost/spirit/home/support/char_class.hpp>
-#include <boost/spirit/home/support/common_terminals.hpp>
-
 #include "storm/storage/StronglyConnectedComponentDecomposition.h"
 #include "storm/utility/graph.h"
-#include "utility/Stopwatch.h"
 
 namespace storm {
 namespace storage {

--- a/src/storm/storage/MaximalEndComponentDecomposition.cpp
+++ b/src/storm/storage/MaximalEndComponentDecomposition.cpp
@@ -147,11 +147,6 @@ void MaximalEndComponentDecomposition<ValueType>::performMaximalEndComponentDeco
         }
         std::vector<uint64_t> offset(sccDecRes.sccCount);
 
-        for (auto state: remainingEcCandidates) {
-            auto const sccIndex = sccDecRes.stateToSccMapping[state];
-            ecSccStates[ecSccIndexToStateIndex[sccIndex] + offset[sccIndex]++] = state;
-        }
-
         remainingEcCandidates = sccDecRes.nonTrivialStates;
         storm::storage::BitVector ecSccIndices(sccDecRes.sccCount, true);
         storm::storage::BitVector nonTrivSccIndices(sccDecRes.sccCount, false);
@@ -159,6 +154,7 @@ void MaximalEndComponentDecomposition<ValueType>::performMaximalEndComponentDeco
         for (auto state : remainingEcCandidates) {
             auto const sccIndex = sccDecRes.stateToSccMapping[state];
             nonTrivSccIndices.set(sccIndex, true);
+            ecSccStates[ecSccIndexToStateIndex[sccIndex] + offset[sccIndex]++] = state;
             bool stateCanStayInScc = false;
             for (auto const choice : transitionMatrix.getRowGroupIndices(state)) {
                 if (!ecChoices.get(choice)) {


### PR DESCRIPTION
I streamlined the decomposition into MECs by preventing to iterate over all remaining candidates for every end component and by keeping track of MECs that contain an accepting end component 