### PR TITLE
testGurobiLicense: Check whether the Gurobi settings module is known

### DIFF
--- a/src/test/storm_gtest.cpp
+++ b/src/test/storm_gtest.cpp
@@ -1,6 +1,8 @@
 #include "test/storm_gtest.h"
 
 #include "storm/exceptions/GurobiLicenseException.h"
+#include "storm/settings/SettingsManager.h"
+#include "storm/settings/modules/GurobiSettings.h"
 #include "storm/solver/GurobiLpSolver.h"
 #include "storm/utility/solver.h"
 
@@ -9,6 +11,9 @@ bool noGurobi = false;
 
 bool testGurobiLicense() {
 #ifdef STORM_HAVE_GUROBI
+    if (!storm::settings::hasModule<storm::settings::modules::GurobiSettings>()) {
+        return true;  // Gurobi not relevant for this test suite
+    }
     try {
         auto lpSolver = storm::utility::solver::getLpSolver<double>("test", storm::solver::LpSolverTypeSelection::Gurobi);
     } catch (storm::exceptions::GurobiLicenseException) {


### PR DESCRIPTION
When running tests for `storm-pars` and `storm-dft` with Gurobi installed, some errors where thrown:
```console
./test-pars-analysis        
Set parameter Username
Academic license - for non-commercial use only - expires xxxxx
ERROR (SettingsManager.cpp:470): Cannot retrieve unknown module 'gurobi'.
libc++abi: terminating due to uncaught exception of type storm::exceptions::IllegalFunctionCallException: IllegalFunctionCallException: Cannot retrieve unknown module 'gurobi'.
```

The reason was that, e.g. in storm-pars we never use gurobi, so the module is not loaded [here](https://github.com/moves-rwth/storm/blob/82eea9b64519d61c58127e9d4ac4fb40134742ad/src/storm-pars/settings/ParsSettings.cpp#L39).

This PR checks whether the gurobi settings module is known and skip the Gurobi License Test if necessary.