### PR TITLE
Expression parsing: detect and handle integer overflows

### DIFF
--- a/src/storm-parsers/parser/ExpressionCreator.cpp
+++ b/src/storm-parsers/parser/ExpressionCreator.cpp
@@ -243,9 +243,18 @@ storm::expressions::Expression ExpressionCreator::createRationalLiteralExpressio
     }
 }
 
-storm::expressions::Expression ExpressionCreator::createIntegerLiteralExpression(int64_t value, bool&) const {
-    if (this->createExpressions) {
-        return manager.integer(value);
+storm::expressions::Expression ExpressionCreator::createIntegerLiteralExpression(storm::RationalNumber const& value, bool&, bool& overflow) const {
+    STORM_LOG_ASSERT(storm::utility::isInteger(value), "Expected integer value.");
+    auto const min = storm::utility::convertNumber<storm::RationalNumber>(std::numeric_limits<int64_t>::min());
+    auto const max = storm::utility::convertNumber<storm::RationalNumber>(std::numeric_limits<int64_t>::max());
+    overflow = value < min || value > max;
+    if (overflow) {
+        STORM_LOG_ERROR("Overflow when parsing integer literal '"
+                        << value << "' as a 64 bit integer. Consider appending '.0' to the number to parse it as an (arbitrary precision) float.");
+        // parsing failure is triggered by the calling parser
+        return manager.boolean(false);
+    } else if (this->createExpressions) {
+        { return manager.integer(storm::utility::convertNumber<int64_t>(value)); }
     } else {
         return manager.boolean(false);
     }

--- a/src/storm-parsers/parser/ExpressionCreator.h
+++ b/src/storm-parsers/parser/ExpressionCreator.h
@@ -74,7 +74,7 @@ class ExpressionCreator {
     storm::expressions::Expression createUnaryExpression(std::vector<storm::expressions::OperatorType> const& operatorType,
                                                          storm::expressions::Expression const& e1, bool& pass) const;
     storm::expressions::Expression createRationalLiteralExpression(storm::RationalNumber const& value, bool& pass) const;
-    storm::expressions::Expression createIntegerLiteralExpression(int64_t value, bool& pass) const;
+    storm::expressions::Expression createIntegerLiteralExpression(storm::RationalNumber const& value, bool& pass, bool& overflow) const;
     storm::expressions::Expression createBooleanLiteralExpression(bool value, bool& pass) const;
     storm::expressions::Expression createMinimumMaximumExpression(storm::expressions::Expression const& e1,
                                                                   storm::expressions::OperatorType const& operatorType,

--- a/src/storm-parsers/parser/ExpressionParser.h
+++ b/src/storm-parsers/parser/ExpressionParser.h
@@ -225,6 +225,8 @@ class ExpressionParser : public qi::grammar<Iterator, storm::expressions::Expres
     qi::rule<Iterator, storm::expressions::Expression(), Skipper> unaryExpression;
     qi::rule<Iterator, storm::expressions::Expression(), Skipper> atomicExpression;
     qi::rule<Iterator, storm::expressions::Expression(), Skipper> literalExpression;
+    qi::rule<Iterator, storm::expressions::Expression(), qi::locals<bool>, Skipper> integerLiteralExpression;
+    qi::rule<Iterator, qi::unused_type(bool), Skipper> integerOverflowHelperRule;
     qi::rule<Iterator, storm::expressions::Expression(), Skipper> identifierExpression;
     qi::rule<Iterator, storm::expressions::Expression(), qi::locals<storm::expressions::OperatorType, storm::expressions::Expression>, Skipper>
         minMaxExpression;
@@ -234,7 +236,8 @@ class ExpressionParser : public qi::grammar<Iterator, storm::expressions::Expres
     qi::rule<Iterator, std::string(), Skipper> identifier;
 
     // Parser that is used to recognize doubles only (as opposed to Spirit's double_ parser).
-    boost::spirit::qi::real_parser<storm::RationalNumber, RationalPolicies<storm::RationalNumber>> rationalLiteral_;
+    boost::spirit::qi::real_parser<storm::RationalNumber, RationalPolicies<storm::RationalNumber>> floatLiteral_;
+    boost::spirit::qi::int_parser<storm::RationalNumber> integerLiteral_;
 
     bool isValidIdentifier(std::string const& identifier);
 


### PR DESCRIPTION
When parsing large integers, the changes in this PR yield a more informative error message like this:

```
ERROR (ExpressionCreator.cpp:253): Overflow when parsing integer literal '92348905723462223372036854775807' as a 64 bit integer. Consider appending '.0' to the number to parse it as an (arbitrary precision) float.
ERROR (SpiritErrorHandler.h:26): Parsing error at 1:33:  expecting <no 64-bit integer overflow>, here:
        92348905723462223372036854775807/309779851562500000000000000000000000000000000000000000 [F (observe0 > 1)];
 ```

Fixes #652 

Notes:
- We might get rid of having 64-bit integer literals and just use arbitrary precision numbers in IntegerLiteralExpressions. However, this might affect performance (I'm not sure if that would be noticeable) and requires some more changes at different places.
- Parsing rationals like the one above as RationalLiteralExpressions would be an option. However, I'm a bit unsure if e.g. "4/2" should become an IntegerLiteral or a RationalLiteral, i.e., is it equivalent to "2" or "2.0". I'm also not sure if (in some contexts) integer division has to be considered. 

