### PR TITLE
Support for macOS builds in CI

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -180,8 +180,8 @@ jobs:
       - name: Run tests
         run: docker exec ci bash -c "cd /opt/storm/build; ctest test --output-on-failure"
 
-  distroTests:
-    name: Distro Tests (${{ matrix.distro }}, ${{ matrix.buildType }})
+  linuxTests:
+    name: Linux Tests (${{ matrix.distro }}, ${{ matrix.buildType }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -218,6 +218,68 @@ jobs:
         run: docker exec ci bash -c "cd /opt/storm/build; make -j ${NR_JOBS}"
       - name: Run tests
         run: docker exec ci bash -c "cd /opt/storm/build; ctest test --output-on-failure"
+
+  macTests:
+    name: macOS Tests (${{ matrix.config.name }})
+    strategy:
+      matrix:
+        config:
+          - {name: "XCode 14.3, Intel, Release",
+             distro: "macos-13",
+             xcode: "14.3",
+             buildType: "Release"
+            }
+          - {name: "XCode 15.4, ARM, Release",
+             distro: "macos-14",
+             xcode: "15.4",
+             buildType: "Release"
+            }
+          - {name: "XCode 16.2, ARM, Release",
+             distro: "macos-15",
+             xcode: "16.2",
+             buildType: "Release"
+            }
+        buildType: ["Release"]
+    runs-on: ${{ matrix.config.distro }}
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.config.xcode }}
+      - name: Git clone
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        # cmake and gmp are already installed
+        run: |
+          brew update
+          brew install automake boost cln ginac glpk hwloc z3 xerces-c
+      - name: Configure storm
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_BUILD_TYPE="${{ matrix.config.buildType }}"
+      - name: Build storm
+        working-directory: ./build
+        run: make binaries -j ${NR_JOBS}
+
+      # A bit hacky... but its usefulness has been proven in production
+      - name: Check release makeflags
+        working-directory: ./build
+        if: matrix.config.buildType == 'Release'
+        run: |
+          ./bin/storm --version | grep 'with flags .* -O3' || (echo \"Error: Missing flag \'-O3\' for release build.\" && false)
+          ./bin/storm --version | grep 'with flags .* -DNDEBUG' || (echo \"Error: Missing flag \'-DNDEBUG\' for release build.\" && false)
+      - name: Check debug makeflags
+        working-directory: ./build
+        if: matrix.config.buildType == 'Debug'
+        run: |
+          ./bin/storm --version | grep 'with flags .* -g' || (echo \"Error: Missing flag \'-g\' for debug build.\" && false)
+
+      - name: Build tests
+        working-directory: ./build
+        run: make -j ${NR_JOBS}
+      - name: Run tests
+        working-directory: ./build
+        run: ctest test--output-on-failure
 
   deploy:
     name: Test and Deploy (${{ matrix.buildType.name }})
@@ -285,7 +347,7 @@ jobs:
   notify:
     name: Email notification
     runs-on: ubuntu-latest
-    needs: [indepthTests, compilerTests, distroTests, deploy]
+    needs: [indepthTests, compilerTests, linuxTests, macTests, deploy]
     # Only run in main repo and even if previous step failed
     if: github.repository_owner == 'moves-rwth' && always()
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,8 +227,8 @@ endif()
 #############################################################
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 	# using Clang
-	if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.2)
-		message(FATAL_ERROR "Clang version must be at least 3.2.")
+	if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)
+		message(FATAL_ERROR "Clang version must be at least 10.0")
 	endif()
 
 	set(STORM_COMPILER_CLANG ON)
@@ -236,8 +236,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 	set(STORM_COMPILER_ID "clang")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
 	# using AppleClang
-	if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.3)
-		message(FATAL_ERROR "AppleClang version must be at least 7.3.")
+	if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.0.3)
+		message(FATAL_ERROR "AppleClang version must be at least 14.0.3 (Xcode version 14.3).")
 	elseif ((CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 11.0.0) OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0.0))
 		message(WARNING "Disabling stack checks for AppleClang version 11.0.0 or higher.")
 		# Stack checks are known to produce errors with the following Clang versions:
@@ -253,8 +253,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	set(GCC ON)
 	# using GCC
-	if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
-		message(FATAL_ERROR "gcc version must be at least 5.0.")
+	if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)
+		message(FATAL_ERROR "gcc version must be at least 10.0.")
 	endif()
 
 	set(STORM_COMPILER_GCC ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,8 +238,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
 	# using AppleClang
 	if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.0.3)
 		message(FATAL_ERROR "AppleClang version must be at least 14.0.3 (Xcode version 14.3).")
-	elseif ((CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 11.0.0) OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0.0))
-		message(WARNING "Disabling stack checks for AppleClang version 11.0.0 or higher.")
+	elseif (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15.0.0)
+		message(WARNING "Disabling stack checks for AppleClang version < 15.0")
 		# Stack checks are known to produce errors with the following Clang versions:
 		# 11.0.0: Runtime errors (stack_not_16_byte_aligned_error) when invoking storm in release mode
 		# 11.0.3 and  12.0.0: Catching exceptions thrown within PRISM parser does not work (The exception just falls through)


### PR DESCRIPTION
#### Added CI builds on macOS:
- Xcode 14.3 on macOS 13 (Intel)
- Xcode 15.4 on macOS 14 (ARM)
- Xcode 16.2 on macOS 15 (ARM)

(The CI also shows that the ARM processors nearly halve the compilation times.)

#### Bumped the minimal required compiler versions.
- AppleClang needs at least Xcode version 14.3. XCode version 14.2 fails, see [this test](https://github.com/volkm/storm/actions/runs/13721879189/job/38378974632). Fixes #684
- Bumped Clang and GCC versions to the first versions supporting the flag ` -std=c++20`. The required compiler versions are probably still too low. But I did not want to run extensive tests as the CMake version is most likely the main restriction at the moment anyway.

#### Enabled the stack checks again on AppleClang >= 15.
- AppleClang 14 [still failed with the checks](https://github.com/volkm/storm/actions/runs/13724840840/job/38388686191).