### PR TITLE
Warning on potential modeling issues in DFT

### DIFF
--- a/resources/examples/testfiles/dft/fdep7.dft
+++ b/resources/examples/testfiles/dft/fdep7.dft
@@ -1,0 +1,13 @@
+toplevel "T";
+"T" or "dummy" "A";
+"dummy" prob=0 dorm=1.0;
+"A" lambda=1 dorm=0.0;
+"F1" fdep "G" "dummy";
+"G" or "PAND" "SPARE";
+"PAND" pand "C" "dummy2";
+"dummy2" prob=0 dorm=1.0;
+"F2" fdep "D" "dummy2";
+"SPARE" wsp "D" "E";
+"C" lambda=1 dorm=0.0;
+"D" lambda=2 dorm=0.0;
+"E" lambda=5 dorm=0.0;

--- a/resources/examples/testfiles/dft/spare_contains_spare.dft
+++ b/resources/examples/testfiles/dft/spare_contains_spare.dft
@@ -1,0 +1,13 @@
+// Spare module of D contains its parent gate.
+// SPARE is not properly activated
+toplevel "T";
+"T" or "dummy" "A";
+"dummy" prob=0 dorm=1.0;
+"A" lambda=1 dorm=0.0;
+"F1" fdep "G" "dummy";
+"G" or "PAND" "SPARE";
+"PAND" pand "C" "D";
+"SPARE" wsp "D" "E";
+"C" lambda=1 dorm=0.0;
+"D" lambda=2 dorm=0.0;
+"E" lambda=5 dorm=0.0;

--- a/src/storm-dft-cli/storm-dft.cpp
+++ b/src/storm-dft-cli/storm-dft.cpp
@@ -49,6 +49,9 @@ void processOptions() {
     // Check well-formedness of DFT
     auto wellFormedResult = storm::dft::api::isWellFormed(*dft, false);
     STORM_LOG_THROW(wellFormedResult.first, storm::exceptions::UnmetRequirementException, "DFT is not well-formed: " << wellFormedResult.second);
+    // Warn about potential modeling issues
+    auto modelingIssues = storm::dft::api::hasPotentialModelingIssues(*dft);
+    STORM_LOG_WARN_COND(!modelingIssues.first, modelingIssues.second);
 
     // Transformation to GSPN
     if (dftGspnSettings.isTransformToGspn()) {

--- a/src/storm-dft/api/storm-dft.h
+++ b/src/storm-dft/api/storm-dft.h
@@ -73,6 +73,19 @@ std::pair<bool, std::string> isWellFormed(storm::dft::storage::DFT<ValueType> co
 }
 
 /*!
+ * Check whether the DFT has potential modeling issues.
+ *
+ * @param dft DFT.
+ * @return Pair where the first entry is true iff the DFT has potential modeling issues. The second entry contains the warning messages for the issues.
+ */
+template<typename ValueType>
+std::pair<bool, std::string> hasPotentialModelingIssues(storm::dft::storage::DFT<ValueType> const& dft) {
+    std::stringstream stream;
+    bool modelingIssues = storm::dft::utility::DftValidator<ValueType>::hasPotentialModelingIssues(dft, stream);
+    return std::pair<bool, std::string>(modelingIssues, stream.str());
+}
+
+/*!
  * Apply transformations for DFT.
  *
  * @param dft DFT.

--- a/src/storm-dft/parser/DFTGalileoParser.cpp
+++ b/src/storm-dft/parser/DFTGalileoParser.cpp
@@ -150,10 +150,7 @@ storm::dft::storage::DFT<ValueType> DFTGalileoParser<ValueType>::parseDFT(const 
     storm::io::closeFile(file);
 
     // Build DFT
-    storm::dft::storage::DFT<ValueType> dft = builder.build();
-    STORM_LOG_DEBUG("DFT elements:\n" << dft.getElementsString());
-    STORM_LOG_DEBUG("Spare modules:\n" << dft.getModulesString());
-    return dft;
+    return builder.build();
 }
 
 template<typename ValueType>

--- a/src/storm-dft/parser/DFTJsonParser.cpp
+++ b/src/storm-dft/parser/DFTJsonParser.cpp
@@ -157,8 +157,6 @@ storm::dft::storage::DFT<ValueType> DFTJsonParser<ValueType>::parseJson(Json con
 
     // Build DFT
     storm::dft::storage::DFT<ValueType> dft = builder.build();
-    STORM_LOG_DEBUG("DFT elements:\n" << dft.getElementsString());
-    STORM_LOG_DEBUG("Spare modules:\n" << dft.getModulesString());
     // Set relevant events
     dft.setRelevantEvents(relevantEvents, false);
     STORM_LOG_DEBUG("Relevant events: " << dft.getRelevantEventsString());

--- a/src/storm-dft/storage/DFT.cpp
+++ b/src/storm-dft/storage/DFT.cpp
@@ -41,6 +41,11 @@ DFT<ValueType>::DFT(DFTElementVector const& elements, DFTElementPointer const& t
                         sparesAndBes.insert(modelem);
                     }
                 }
+                if (std::find(sparesAndBes.begin(), sparesAndBes.end(), elem->id()) != sparesAndBes.end()) {
+                    STORM_LOG_WARN("Spare module '" << spareReprs->name() << "' also contains the parent SPARE-gate '" << elem->name()
+                                                    << "'. This can prevent proper activation of the spare module. Consider introducing dependencies to "
+                                                       "properly separate the spare module from the SPARE-gate.");
+                }
                 mModules.insert(std::make_pair(spareReprs->id(), storm::dft::storage::DftModule(spareReprs->id(), sparesAndBes)));
             }
         } else if (elem->isDependency()) {
@@ -99,6 +104,9 @@ DFT<ValueType>::DFT(DFTElementVector const& elements, DFTElementPointer const& t
 
     // Set relevant events: empty list corresponds to only setting the top-level event as relevant
     setRelevantEvents({}, false);
+
+    STORM_LOG_DEBUG("DFT elements:\n" << getElementsString());
+    STORM_LOG_DEBUG("DFT modules:\n" << getModulesString());
 }
 
 template<typename ValueType>

--- a/src/storm-dft/storage/DFT.cpp
+++ b/src/storm-dft/storage/DFT.cpp
@@ -41,11 +41,6 @@ DFT<ValueType>::DFT(DFTElementVector const& elements, DFTElementPointer const& t
                         sparesAndBes.insert(modelem);
                     }
                 }
-                if (std::find(sparesAndBes.begin(), sparesAndBes.end(), elem->id()) != sparesAndBes.end()) {
-                    STORM_LOG_WARN("Spare module '" << spareReprs->name() << "' also contains the parent SPARE-gate '" << elem->name()
-                                                    << "'. This can prevent proper activation of the spare module. Consider introducing dependencies to "
-                                                       "properly separate the spare module from the SPARE-gate.");
-                }
                 mModules.insert(std::make_pair(spareReprs->id(), storm::dft::storage::DftModule(spareReprs->id(), sparesAndBes)));
             }
         } else if (elem->isDependency()) {
@@ -80,9 +75,6 @@ DFT<ValueType>::DFT(DFTElementVector const& elements, DFTElementPointer const& t
             auto& spareModule = module.second;
             auto const& spareModuleElements = spareModule.getElements();
             if (std::find(spareModuleElements.begin(), spareModuleElements.end(), topModuleId) != spareModuleElements.end()) {
-                STORM_LOG_WARN("Elements of spare module '"
-                               << getElement(spareModule.getRepresentative())->name()
-                               << "' also contained in top module. All elements of this spare module will be activated from the beginning on.");
                 spareModule.clear();
             }
         }

--- a/src/storm-dft/storage/DFTState.cpp
+++ b/src/storm-dft/storage/DFTState.cpp
@@ -25,7 +25,7 @@ DFTState<ValueType>::DFTState(DFT<ValueType> const& dft, DFTStateGenerationInfo 
         this->setUses(spareId, elem->children()[0]->id());
     }
 
-    // Initialize activation
+    // Initialize activation and set failable BEs
     propagateActivation(mDft.getTopLevelIndex());
 
     // Initialize currently failable BEs

--- a/src/storm-dft/utility/DftValidator.h
+++ b/src/storm-dft/utility/DftValidator.h
@@ -12,10 +12,12 @@ class DftValidator {
    public:
     /*!
      * Check whether the DFT is well-formed.
+     * The check follows the constraints of a well-formed DFT (Def. 2.15 in [Volk, 2022])
+     * @see https://doi.org/10.18154/RWTH-2023-04092
      * A DFT is well-formed if it satisfies several constraints such as
      * - graph is acyclic
      * - valid threshold for VOT
-     * - SEQ and PDEP are at least binary and hove no parents
+     * - SEQ and PDEP are at least binary and have no parents
      * - etc.
      * @param dft DFT
      * @param stream Output stream which contains additional information if the DFT is well-formed.
@@ -24,8 +26,9 @@ class DftValidator {
     static bool isDftWellFormed(storm::dft::storage::DFT<ValueType> const& dft, std::ostream& stream);
 
     /*!
-     * Check whether the DFT can be analysed by translation to a Markov model.
-     * Such as DFT is sometimes called conventional.
+     * Check whether the DFT can be analysed by translation to a Markov model, i.e. the DFT is conventional.
+     * The check follows the constraints of a conventional DFT (Def. 2.19 in [Volk, 2022])
+     * @see https://doi.org/10.18154/RWTH-2023-04092
      * A DFT can be analysed if it satisfies several constraints:
      * - it is well-formed
      * - all BE failure distributions are exponential distributions
@@ -35,6 +38,15 @@ class DftValidator {
      * @return True iff the DFT is valid for Markovian analysis.
      */
     static bool isDftValidForMarkovianAnalysis(storm::dft::storage::DFT<ValueType> const& dft, std::ostream& stream);
+
+    /*!
+     * Check whether the DFT has potential modeling issues.
+     * While these issue do not prevent analysis, they could lead to unexpected analysis results and warnings should be issued.
+     * A DFT has modeling issues if:
+     * - spare modules overlap with the top module and are therefore already initially activated
+     * - spare modules contains the parent SPARE gate and therefore might never be activated.
+     */
+    static bool hasPotentialModelingIssues(storm::dft::storage::DFT<ValueType> const& dft, std::ostream& stream);
 };
 
 }  // namespace utility

--- a/src/test/storm-dft/api/DftModelCheckerTest.cpp
+++ b/src/test/storm-dft/api/DftModelCheckerTest.cpp
@@ -179,11 +179,14 @@ TYPED_TEST(DftModelCheckerTest, FdepMTTF) {
     EXPECT_NEAR(result, 2, this->precision());
     result = this->analyzeMTTF(STORM_TEST_RESOURCES_DIR "/dft/fdep3.dft");
     EXPECT_NEAR(result, 5 / 2.0, this->precision());
+    result = this->analyzeMTTF(STORM_TEST_RESOURCES_DIR "/dft/fdep7.dft");
+    EXPECT_NEAR(result, 5 / 12.0, this->precision());
 
     if (this->getConfig().useMod) {
         STORM_SILENT_EXPECT_THROW(this->analyzeMTTF(STORM_TEST_RESOURCES_DIR "/dft/fdep.dft"), storm::exceptions::NotSupportedException);
         STORM_SILENT_EXPECT_THROW(this->analyzeMTTF(STORM_TEST_RESOURCES_DIR "/dft/fdep4.dft"), storm::exceptions::NotSupportedException);
         STORM_SILENT_EXPECT_THROW(this->analyzeMTTF(STORM_TEST_RESOURCES_DIR "/dft/fdep5.dft"), storm::exceptions::NotSupportedException);
+        STORM_SILENT_EXPECT_THROW(this->analyzeMTTF(STORM_TEST_RESOURCES_DIR "/dft/fdep6.dft"), storm::exceptions::NotSupportedException);
     } else {
         double result = this->analyzeMTTF(STORM_TEST_RESOURCES_DIR "/dft/fdep.dft");
         EXPECT_NEAR(result, 2 / 3.0, this->precision());
@@ -191,6 +194,8 @@ TYPED_TEST(DftModelCheckerTest, FdepMTTF) {
         EXPECT_NEAR(result, 1, this->precision());
         result = this->analyzeMTTF(STORM_TEST_RESOURCES_DIR "/dft/fdep5.dft");
         EXPECT_NEAR(result, 3, this->precision());
+        result = this->analyzeMTTF(STORM_TEST_RESOURCES_DIR "/dft/fdep6.dft");
+        EXPECT_NEAR(result, 9 / 56.0, this->precision());
     }
 }
 
@@ -235,6 +240,9 @@ TYPED_TEST(DftModelCheckerTest, SpareMTTF) {
     EXPECT_NEAR(result, 78311 / 182700.0, this->precision());
     result = this->analyzeMTTF(STORM_TEST_RESOURCES_DIR "/dft/modules3.dft");
     EXPECT_NEAR(result, 7 / 6.0, this->precision());
+    // Spare gate is part of spare module. As a result it is not activated.
+    result = this->analyzeMTTF(STORM_TEST_RESOURCES_DIR "/dft/spare_contains_spare.dft");
+    EXPECT_NEAR(result, 1, this->precision());
 }
 
 TYPED_TEST(DftModelCheckerTest, SeqMTTF) {

--- a/src/test/storm-dft/api/DftValidatorTest.cpp
+++ b/src/test/storm-dft/api/DftValidatorTest.cpp
@@ -66,4 +66,57 @@ TEST(DftValidatorTest, NonExponential) {
     EXPECT_THAT(result.second, ::testing::HasSubstr("DFT has BE distributions which are neither exponential nor constant failed/failsafe."));
 }
 
+TEST(DftValidatorTest, OverlappingWithTopModule) {
+    std::string file = STORM_TEST_RESOURCES_DIR "/dft/modules3.dft";
+    std::shared_ptr<storm::dft::storage::DFT<double>> dft = storm::dft::api::loadDFTGalileoFile<double>(file);
+    EXPECT_TRUE(storm::dft::api::isWellFormed(*dft, true).first);
+    auto result = storm::dft::api::hasPotentialModelingIssues(*dft);
+    EXPECT_TRUE(result.first);
+    EXPECT_THAT(result.second, ::testing::HasSubstr(" All elements of this spare module will be activated from the beginning on."));
+}
+
+TEST(DftValidatorTest, SpareModuleContainsParent) {
+    std::string file = STORM_TEST_RESOURCES_DIR "/dft/spare_contains_spare.dft";
+    std::shared_ptr<storm::dft::storage::DFT<double>> dft = storm::dft::api::loadDFTGalileoFile<double>(file);
+    EXPECT_TRUE(storm::dft::api::isWellFormed(*dft, true).first);
+    auto result = storm::dft::api::hasPotentialModelingIssues(*dft);
+    EXPECT_TRUE(result.first);
+    EXPECT_THAT(result.second, ::testing::HasSubstr("also contains the parent SPARE-gate"));
+    EXPECT_THAT(result.second, ::testing::HasSubstr("This can prevent proper activation of the spare module."));
+}
+
+TEST(DftValidatorTest, NoModelingIssues) {
+    std::shared_ptr<storm::dft::storage::DFT<double>> dft = storm::dft::api::loadDFTGalileoFile<double>(STORM_TEST_RESOURCES_DIR "/dft/spare.dft");
+    EXPECT_TRUE(storm::dft::api::isWellFormed(*dft, true).first);
+    EXPECT_FALSE(storm::dft::api::hasPotentialModelingIssues(*dft).first);
+
+    dft = storm::dft::api::loadDFTGalileoFile<double>(STORM_TEST_RESOURCES_DIR "/dft/spare2.dft");
+    EXPECT_TRUE(storm::dft::api::isWellFormed(*dft, true).first);
+    EXPECT_FALSE(storm::dft::api::hasPotentialModelingIssues(*dft).first);
+
+    dft = storm::dft::api::loadDFTGalileoFile<double>(STORM_TEST_RESOURCES_DIR "/dft/spare3.dft");
+    EXPECT_TRUE(storm::dft::api::isWellFormed(*dft, true).first);
+    EXPECT_FALSE(storm::dft::api::hasPotentialModelingIssues(*dft).first);
+
+    dft = storm::dft::api::loadDFTGalileoFile<double>(STORM_TEST_RESOURCES_DIR "/dft/spare4.dft");
+    EXPECT_TRUE(storm::dft::api::isWellFormed(*dft, true).first);
+    EXPECT_FALSE(storm::dft::api::hasPotentialModelingIssues(*dft).first);
+
+    dft = storm::dft::api::loadDFTGalileoFile<double>(STORM_TEST_RESOURCES_DIR "/dft/spare5.dft");
+    EXPECT_TRUE(storm::dft::api::isWellFormed(*dft, true).first);
+    EXPECT_FALSE(storm::dft::api::hasPotentialModelingIssues(*dft).first);
+
+    dft = storm::dft::api::loadDFTGalileoFile<double>(STORM_TEST_RESOURCES_DIR "/dft/spare6.dft");
+    EXPECT_TRUE(storm::dft::api::isWellFormed(*dft, true).first);
+    EXPECT_FALSE(storm::dft::api::hasPotentialModelingIssues(*dft).first);
+
+    dft = storm::dft::api::loadDFTGalileoFile<double>(STORM_TEST_RESOURCES_DIR "/dft/spare7.dft");
+    EXPECT_TRUE(storm::dft::api::isWellFormed(*dft, true).first);
+    EXPECT_FALSE(storm::dft::api::hasPotentialModelingIssues(*dft).first);
+
+    dft = storm::dft::api::loadDFTGalileoFile<double>(STORM_TEST_RESOURCES_DIR "/dft/spare8.dft");
+    EXPECT_TRUE(storm::dft::api::isWellFormed(*dft, true).first);
+    EXPECT_FALSE(storm::dft::api::hasPotentialModelingIssues(*dft).first);
+}
+
 }  // namespace

--- a/src/test/storm-dft/simulator/DftSimulatorTest.cpp
+++ b/src/test/storm-dft/simulator/DftSimulatorTest.cpp
@@ -100,6 +100,8 @@ TEST(DftSimulatorTest, FdepUnreliability) {
     EXPECT_NEAR(result, 0.1548181217, 0.01);
     result = simulateDftProb(STORM_TEST_RESOURCES_DIR "/dft/fdep6.dft", 1, 10000);
     EXPECT_NEAR(result, 0.9985116987, 0.01);
+    result = simulateDftProb(STORM_TEST_RESOURCES_DIR "/dft/fdep7.dft", 1, 10000);
+    EXPECT_NEAR(result, 0.9343760449, 0.01);
 }
 
 TEST(DftSimulatorTest, PdepUnreliability) {

--- a/src/test/storm-dft/storage/SymmetryTest.cpp
+++ b/src/test/storm-dft/storage/SymmetryTest.cpp
@@ -80,6 +80,10 @@ TEST(SymmetryTest, SymmetriesDynamicFT) {
     EXPECT_EQ(symmetries.nrSymmetries(), 1ul);
     EXPECT_EQ(symmetries.getSymmetryGroup(1).size(), 1ul);
     EXPECT_EQ(symmetries.getSymmetryGroup(1)[0].size(), 2ul);
+    symmetries = findSymmetries(STORM_TEST_RESOURCES_DIR "/dft/fdep6.dft");
+    EXPECT_EQ(symmetries.nrSymmetries(), 0ul);
+    symmetries = findSymmetries(STORM_TEST_RESOURCES_DIR "/dft/fdep7.dft");
+    EXPECT_EQ(symmetries.nrSymmetries(), 0ul);
 
     symmetries = findSymmetries(STORM_TEST_RESOURCES_DIR "/dft/pdep.dft");
     EXPECT_EQ(symmetries.nrSymmetries(), 0ul);


### PR DESCRIPTION
Added a separate function to check for potential modeling issues in DFT. These issues do not prevent analysis but might lead to unexpected results.
We consider two potential issues for now:
- spare modules which are initially activated because they overlap with the top module
- We allow that elements in the primary module of a SPARE gate are also connected to other parts of the fault tree. In an edge case, this can lead to unexpected behavior though, if the SPARE parent is also part of the spare module but not directly connected to the top module. In this instance, the SPARE is never activated.