### PR TITLE
Add cut-off memory node information

### DIFF
--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -2,7 +2,6 @@
 
 #include <tuple>
 
-#include "../../storm/api/export.h"
 #include "storm-pomdp/analysis/FiniteBeliefMdpDetection.h"
 #include "storm-pomdp/analysis/FormulaInformation.h"
 #include "storm-pomdp/transformer/MakeStateSetObservationClosed.h"
@@ -13,7 +12,6 @@
 
 #include "storm-pomdp/builder/BeliefMdpExplorer.h"
 #include "storm-pomdp/modelchecker/PreprocessingPomdpValueBoundsModelChecker.h"
-#include "storm/models/sparse/Dtmc.h"
 #include "storm/utility/vector.h"
 
 #include "storm/environment/Environment.h"

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -2,6 +2,7 @@
 
 #include <tuple>
 
+#include "../../storm/api/export.h"
 #include "storm-pomdp/analysis/FiniteBeliefMdpDetection.h"
 #include "storm-pomdp/analysis/FormulaInformation.h"
 #include "storm-pomdp/transformer/MakeStateSetObservationClosed.h"
@@ -539,7 +540,10 @@ void BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
                             auto candidateIndex = (chosenRow.end() - 1)->getColumn();
                             transMatrix.makeRowDirac(transMatrix.getRowGroupIndices()[i], candidateIndex);
                         } else if (label.rfind("mem_node", 0) == 0) {
-                            newLabeling.addLabelToState("finite_mem", i);
+                            if (!newLabeling.containsLabel("finite_mem_" + label.substr(9, 1))) {
+                                newLabeling.addLabel("finite_mem_" + label.substr(9, 1));
+                            }
+                            newLabeling.addLabelToState("finite_mem_" + label.substr(9, 1), i);
                             newLabeling.addLabelToState("cutoff", i);
                         } else {
                             newLabeling.addLabelToState(label, i);


### PR DESCRIPTION
This PR extends the labeling for induced Markov chains of belief MDPs with an indication which node of an FSC is used for cut-offs when external cut-off values are provided.
This is in particular important for obtaining the scheduler from the belief exploration, e.g. in the context of SAYNT.

Resolves #688 