### PR TITLE
Cut-off memory information for interactive unfolder

### DIFF
--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -652,7 +652,10 @@ void BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
                                     auto candidateIndex = (chosenRow.end() - 1)->getColumn();
                                     transMatrix.makeRowDirac(transMatrix.getRowGroupIndices()[i], candidateIndex);
                                 } else if (label.rfind("mem_node", 0) == 0) {
-                                    newLabeling.addLabelToState("finite_mem", i);
+                                    if (!newLabeling.containsLabel("finite_mem_" + label.substr(9, 1))) {
+                                        newLabeling.addLabel("finite_mem_" + label.substr(9, 1));
+                                    }
+                                    newLabeling.addLabelToState("finite_mem_" + label.substr(9, 1), i);
                                     newLabeling.addLabelToState("cutoff", i);
                                 } else {
                                     newLabeling.addLabelToState(label, i);


### PR DESCRIPTION
Extending the PR https://github.com/moves-rwth/storm/pull/691 to the interactive unfolder that is used in SAYNT. The previous PR works fine, but only when you call Storm without the interactive unfolding.

See https://github.com/moves-rwth/storm/issues/688 for more information.
