### PR TITLE
Retrieving sub-optimal values from Gurobi LP solver

### DIFF
--- a/src/storm/solver/GurobiLpSolver.cpp
+++ b/src/storm/solver/GurobiLpSolver.cpp
@@ -590,7 +590,7 @@ uint64_t GurobiLpSolver<ValueType, RawMode>::getSolutionCount() const {
 
 template<typename ValueType, bool RawMode>
 ValueType GurobiLpSolver<ValueType, RawMode>::getContinuousValue(Variable const& variable, uint64_t const& solutionIndex) const {
-    if (!this->isOptimal()) {
+    if (!this->currentModelHasBeenOptimized) {
         STORM_LOG_THROW(!this->isInfeasible(), storm::exceptions::InvalidAccessException,
                         "Unable to get Gurobi solution from infeasible model (" << GRBgeterrormsg(**environment) << ").");
         STORM_LOG_THROW(!this->isUnbounded(), storm::exceptions::InvalidAccessException,
@@ -622,7 +622,7 @@ ValueType GurobiLpSolver<ValueType, RawMode>::getContinuousValue(Variable const&
 
 template<typename ValueType, bool RawMode>
 int_fast64_t GurobiLpSolver<ValueType, RawMode>::getIntegerValue(Variable const& variable, uint64_t const& solutionIndex) const {
-    if (!this->isOptimal()) {
+    if (!this->currentModelHasBeenOptimized) {
         STORM_LOG_THROW(!this->isInfeasible(), storm::exceptions::InvalidAccessException,
                         "Unable to get Gurobi solution from infeasible model (" << GRBgeterrormsg(**environment) << ").");
         STORM_LOG_THROW(!this->isUnbounded(), storm::exceptions::InvalidAccessException,
@@ -657,7 +657,7 @@ int_fast64_t GurobiLpSolver<ValueType, RawMode>::getIntegerValue(Variable const&
 
 template<typename ValueType, bool RawMode>
 bool GurobiLpSolver<ValueType, RawMode>::getBinaryValue(Variable const& variable, uint64_t const& solutionIndex) const {
-    if (!this->isOptimal()) {
+    if (!this->currentModelHasBeenOptimized) {
         STORM_LOG_THROW(!this->isInfeasible(), storm::exceptions::InvalidAccessException,
                         "Unable to get Gurobi solution from infeasible model (" << GRBgeterrormsg(**environment) << ").");
         STORM_LOG_THROW(!this->isUnbounded(), storm::exceptions::InvalidAccessException,
@@ -697,7 +697,7 @@ bool GurobiLpSolver<ValueType, RawMode>::getBinaryValue(Variable const& variable
 
 template<typename ValueType, bool RawMode>
 ValueType GurobiLpSolver<ValueType, RawMode>::getObjectiveValue(uint64_t solutionIndex) const {
-    if (!this->isOptimal()) {
+    if (!this->currentModelHasBeenOptimized) {
         STORM_LOG_THROW(!this->isInfeasible(), storm::exceptions::InvalidAccessException,
                         "Unable to get Gurobi solution from infeasible model (" << GRBgeterrormsg(**environment) << ").");
         STORM_LOG_THROW(!this->isUnbounded(), storm::exceptions::InvalidAccessException,

--- a/src/storm/solver/GurobiLpSolver.cpp
+++ b/src/storm/solver/GurobiLpSolver.cpp
@@ -591,10 +591,6 @@ uint64_t GurobiLpSolver<ValueType, RawMode>::getSolutionCount() const {
 template<typename ValueType, bool RawMode>
 ValueType GurobiLpSolver<ValueType, RawMode>::getContinuousValue(Variable const& variable, uint64_t const& solutionIndex) const {
     if (!this->currentModelHasBeenOptimized) {
-        STORM_LOG_THROW(!this->isInfeasible(), storm::exceptions::InvalidAccessException,
-                        "Unable to get Gurobi solution from infeasible model (" << GRBgeterrormsg(**environment) << ").");
-        STORM_LOG_THROW(!this->isUnbounded(), storm::exceptions::InvalidAccessException,
-                        "Unable to get Gurobi solution from unbounded model (" << GRBgeterrormsg(**environment) << ").");
         STORM_LOG_THROW(false, storm::exceptions::InvalidAccessException,
                         "Unable to get Gurobi solution from unoptimized model (" << GRBgeterrormsg(**environment) << ").");
     }
@@ -623,10 +619,6 @@ ValueType GurobiLpSolver<ValueType, RawMode>::getContinuousValue(Variable const&
 template<typename ValueType, bool RawMode>
 int_fast64_t GurobiLpSolver<ValueType, RawMode>::getIntegerValue(Variable const& variable, uint64_t const& solutionIndex) const {
     if (!this->currentModelHasBeenOptimized) {
-        STORM_LOG_THROW(!this->isInfeasible(), storm::exceptions::InvalidAccessException,
-                        "Unable to get Gurobi solution from infeasible model (" << GRBgeterrormsg(**environment) << ").");
-        STORM_LOG_THROW(!this->isUnbounded(), storm::exceptions::InvalidAccessException,
-                        "Unable to get Gurobi solution from unbounded model (" << GRBgeterrormsg(**environment) << ").");
         STORM_LOG_THROW(false, storm::exceptions::InvalidAccessException,
                         "Unable to get Gurobi solution from unoptimized model (" << GRBgeterrormsg(**environment) << ").");
     }
@@ -658,10 +650,6 @@ int_fast64_t GurobiLpSolver<ValueType, RawMode>::getIntegerValue(Variable const&
 template<typename ValueType, bool RawMode>
 bool GurobiLpSolver<ValueType, RawMode>::getBinaryValue(Variable const& variable, uint64_t const& solutionIndex) const {
     if (!this->currentModelHasBeenOptimized) {
-        STORM_LOG_THROW(!this->isInfeasible(), storm::exceptions::InvalidAccessException,
-                        "Unable to get Gurobi solution from infeasible model (" << GRBgeterrormsg(**environment) << ").");
-        STORM_LOG_THROW(!this->isUnbounded(), storm::exceptions::InvalidAccessException,
-                        "Unable to get Gurobi solution from unbounded model (" << GRBgeterrormsg(**environment) << ").");
         STORM_LOG_THROW(false, storm::exceptions::InvalidAccessException,
                         "Unable to get Gurobi solution from unoptimized model (" << GRBgeterrormsg(**environment) << ").");
     }
@@ -698,10 +686,6 @@ bool GurobiLpSolver<ValueType, RawMode>::getBinaryValue(Variable const& variable
 template<typename ValueType, bool RawMode>
 ValueType GurobiLpSolver<ValueType, RawMode>::getObjectiveValue(uint64_t solutionIndex) const {
     if (!this->currentModelHasBeenOptimized) {
-        STORM_LOG_THROW(!this->isInfeasible(), storm::exceptions::InvalidAccessException,
-                        "Unable to get Gurobi solution from infeasible model (" << GRBgeterrormsg(**environment) << ").");
-        STORM_LOG_THROW(!this->isUnbounded(), storm::exceptions::InvalidAccessException,
-                        "Unable to get Gurobi solution from unbounded model (" << GRBgeterrormsg(**environment) << ").");
         STORM_LOG_THROW(false, storm::exceptions::InvalidAccessException,
                         "Unable to get Gurobi solution from unoptimized model (" << GRBgeterrormsg(**environment) << ").");
     }


### PR DESCRIPTION
The `GurobiLpSolver` only allows retrieving values of sub-optimal solutions when an optimal solution is found. Is this behaviour intended? If so, then this PR can be ignored. Since Gurobi still stores sub-optimal solutions when no optimal solution is found (within a given timelimit), I have changed the corresponding methods. Thank you!