### PR TITLE
Added fallback URL for Spot

### DIFF
--- a/doc/update_resources.md
+++ b/doc/update_resources.md
@@ -60,7 +60,7 @@ Remove directories that are not needed, e.g, `rm -r doc examples html css benchm
 
 ## Spot
 
-To update (shipped version of Spot), just change the url in `$STORM_DIR/resources/3rdparty/include_spot.cmake`.
+To update (shipped version of Spot), just change the `SPOT_SHIPPED_VERSION` in `$STORM_DIR/resources/3rdparty/include_spot.cmake`.
 
 
 ## Sylvan & Lace

--- a/resources/3rdparty/include_spot.cmake
+++ b/resources/3rdparty/include_spot.cmake
@@ -27,10 +27,11 @@ endif()
 
 set(STORM_SHIPPED_SPOT OFF)
 if(STORM_USE_SPOT_SHIPPED AND NOT STORM_HAVE_SPOT)
-
-    # download and install shipped Spot
+    # Set Spot version
+    set(SPOT_SHIPPED_VERSION 2.13)
+    # Download and install shipped Spot
     ExternalProject_Add(spot
-        URL https://www.lrde.epita.fr/dload/spot/spot-2.13.tar.gz # When updating, also change version output below
+        URL https://www.lre.epita.fr/dload/spot/spot-${SPOT_SHIPPED_VERSION}.tar.gz https://www.lrde.epita.fr/dload/spot/spot-${SPOT_SHIPPED_VERSION}.tar.gz
         DOWNLOAD_NO_PROGRESS TRUE
         DOWNLOAD_DIR ${STORM_3RDPARTY_BINARY_DIR}/spot_src
         SOURCE_DIR ${STORM_3RDPARTY_BINARY_DIR}/spot_src
@@ -51,7 +52,7 @@ if(STORM_USE_SPOT_SHIPPED AND NOT STORM_HAVE_SPOT)
     set(STORM_HAVE_SPOT ON)
     set(STORM_SHIPPED_SPOT ON)
 
-    message(STATUS "Storm - Using shipped version of Spot 2.13 (include: ${SPOT_INCLUDE_DIR}, library ${SPOT_LIBRARIES}).")
+    message(STATUS "Storm - Using shipped version of Spot ${SPOT_SHIPPED_VERSION} (include: ${SPOT_INCLUDE_DIR}, library ${SPOT_LIBRARIES}).")
 
 endif()
 


### PR DESCRIPTION
As suggested by the Spot developer [here](https://lists.lre.epita.fr/hyperkitty/list/spot@lrde.epita.fr/message/2FTD6F5XWXD2JSWRMPNZSTOBNCE6KK7R/), we can use both lre.epita.fr and lrde.epita.fr as download options for Spot.
Another possibility would be to add a [Webarchive link](https://web.archive.org/web/*/https://www.lre.epita.fr/dload/spot*), if really needed.