### PR TITLE
Fixing formula parser

### DIFF
--- a/src/storm-parsers/parser/FormulaParserGrammar.cpp
+++ b/src/storm-parsers/parser/FormulaParserGrammar.cpp
@@ -43,7 +43,7 @@ void FormulaParserGrammar::initialize() {
     noAmbiguousNonAssociativeOperator.name("no ambiguous non-associative operator");
     identifier %= qi::as_string[qi::raw[qi::lexeme[((qi::alpha | qi::char_('_') | qi::char_('.')) >> *(qi::alnum | qi::char_('_')))]]];
     identifier.name("identifier");
-    label %= qi::as_string[qi::raw[qi::lexeme[((qi::alpha | qi::char_('_')) >> *(qi::alnum | qi::char_('_')))]]];
+    label %= qi::as_string[qi::raw[qi::lexeme[+(qi::char_ - qi::char_('"') - qi::eol)]]];
     label.name("label");
     quotedString %= qi::as_string[qi::lexeme[qi::omit[qi::char_('"')] > qi::raw[*(!qi::char_('"') >> qi::char_)] > qi::omit[qi::lit('"')]]];
     quotedString.name("quoted string");


### PR DESCRIPTION
Trying to fix https://github.com/moves-rwth/storm/issues/705. Not sure if there are some edge cases where this would fail. I also did not test this properly but for the example of PRISM formula-like label it works.