### PR TITLE
Fix DRN POMDP parsing

### DIFF
--- a/resources/examples/testfiles/pomdp/maze2_sl0.drn
+++ b/resources/examples/testfiles/pomdp/maze2_sl0.drn
@@ -1,0 +1,148 @@
+
+// Exported by storm
+// Original model type: POMDP
+@type: POMDP
+@parameters
+
+@reward_models
+rew
+@nr_states
+15
+@nr_choices
+54
+@model
+state 0 {6} [0] init
+	action init [0]
+		1 : 0.07692307692
+		2 : 0.07692307692
+		3 : 0.07692307692
+		4 : 0.07692307692
+		5 : 0.07692307692
+		6 : 0.07692307692
+		7 : 0.07692307692
+		8 : 0.07692307692
+		9 : 0.07692307692
+		10 : 0.07692307692
+		11 : 0.07692307692
+		12 : 0.07692307692
+		13 : 0.07692307692
+state 1 {1} [0]
+	action east [0.1428571429]
+		2 : 1
+	action west [0.1428571429]
+		1 : 1
+	action north [0.1428571429]
+		1 : 1
+	action south [0.1428571429]
+		6 : 1
+state 2 {4} [0]
+	action east [0.1428571429]
+		3 : 1
+	action west [0.1428571429]
+		1 : 1
+	action north [0.1428571429]
+		2 : 1
+	action south [0.1428571429]
+		2 : 1
+state 3 {7} [0]
+	action east [0.1428571429]
+		4 : 1
+	action west [0.1428571429]
+		2 : 1
+	action north [0.1428571429]
+		3 : 1
+	action south [0.1428571429]
+		7 : 1
+state 4 {4} [0]
+	action east [0.1428571429]
+		5 : 1
+	action west [0.1428571429]
+		3 : 1
+	action north [0.1428571429]
+		4 : 1
+	action south [0.1428571429]
+		4 : 1
+state 5 {3} [0]
+	action east [0.1428571429]
+		5 : 1
+	action west [0.1428571429]
+		4 : 1
+	action north [0.1428571429]
+		5 : 1
+	action south [0.1428571429]
+		8 : 1
+state 6 {0} [0]
+	action east [0.1428571429]
+		6 : 1
+	action west [0.1428571429]
+		6 : 1
+	action north [0.1428571429]
+		1 : 1
+	action south [0.1428571429]
+		9 : 1
+state 7 {0} [0]
+	action east [0.1428571429]
+		7 : 1
+	action west [0.1428571429]
+		7 : 1
+	action north [0.1428571429]
+		3 : 1
+	action south [0.1428571429]
+		10 : 1
+state 8 {0} [0]
+	action east [0.1428571429]
+		8 : 1
+	action west [0.1428571429]
+		8 : 1
+	action north [0.1428571429]
+		5 : 1
+	action south [0.1428571429]
+		11 : 1
+state 9 {0} [0]
+	action east [0.1428571429]
+		9 : 1
+	action west [0.1428571429]
+		9 : 1
+	action north [0.1428571429]
+		6 : 1
+	action south [0.1428571429]
+		12 : 1
+state 10 {0} [0]
+	action east [0.1428571429]
+		10 : 1
+	action west [0.1428571429]
+		10 : 1
+	action north [0.1428571429]
+		7 : 1
+	action south [0.1428571429]
+		14 : 1
+state 11 {0} [0]
+	action east [0.1428571429]
+		11 : 1
+	action west [0.1428571429]
+		11 : 1
+	action north [0.1428571429]
+		8 : 1
+	action south [0.1428571429]
+		13 : 1
+state 12 {2} [0] bad
+	action east [0.1428571429]
+		12 : 1
+	action west [0.1428571429]
+		12 : 1
+	action north [0.1428571429]
+		9 : 1
+	action south [0.1428571429]
+		12 : 1
+state 13 {2} [0] bad
+	action east [0.1428571429]
+		13 : 1
+	action west [0.1428571429]
+		13 : 1
+	action north [0.1428571429]
+		11 : 1
+	action south [0.1428571429]
+		13 : 1
+state 14 {5} [0] goal
+	action done [0]
+		14 : 1

--- a/src/storm-parsers/parser/DirectEncodingParser.cpp
+++ b/src/storm-parsers/parser/DirectEncodingParser.cpp
@@ -229,6 +229,21 @@ std::shared_ptr<storm::storage::sparse::ModelComponents<ValueType, RewardModelTy
                 modelComponents->exitRates.get()[state] = exitRate;
             }
 
+            if (type == storm::models::ModelType::Pomdp) {
+                if (boost::starts_with(line, "{")) {
+                    size_t posEndObservation = line.find("}");
+                    std::string observation = line.substr(1, posEndObservation - 1);
+                    STORM_LOG_TRACE("State observation " << observation);
+                    modelComponents->observabilityClasses.value()[state] = std::stoi(observation);
+                    line = line.substr(posEndObservation + 1);
+                    STORM_LOG_THROW(line.starts_with(" "), storm::exceptions::WrongFormatException,
+                                    "Expected whitespace after observation in line " << lineNumber);
+                    line = line.substr(1);
+                } else {
+                    STORM_LOG_THROW(false, storm::exceptions::WrongFormatException, "Expected an observation for state " << state << " in line " << lineNumber);
+                }
+            }
+
             if (boost::starts_with(line, "[")) {
                 // Parse rewards
                 size_t posEndReward = line.find(']');
@@ -252,18 +267,6 @@ std::shared_ptr<storm::storage::sparse::ModelComponents<ValueType, RewardModelTy
                     ++stateRewardsIt;
                 }
                 line = line.substr(posEndReward + 1);
-            }
-
-            if (type == storm::models::ModelType::Pomdp) {
-                if (boost::starts_with(line, "{")) {
-                    size_t posEndObservation = line.find("}");
-                    std::string observation = line.substr(1, posEndObservation - 1);
-                    STORM_LOG_TRACE("State observation " << observation);
-                    modelComponents->observabilityClasses.value()[state] = std::stoi(observation);
-                    line = line.substr(posEndObservation + 1);
-                } else {
-                    STORM_LOG_THROW(false, storm::exceptions::WrongFormatException, "Expected an observation for state " << state << " in line " << lineNumber);
-                }
             }
 
             // Parse labels

--- a/src/test/storm/parser/DirectEncodingParserTest.cpp
+++ b/src/test/storm/parser/DirectEncodingParserTest.cpp
@@ -97,3 +97,25 @@ TEST(DirectEncodingParserTest, IntervalDtmcTest) {
     ASSERT_EQ(613ul, dtmc->getNumberOfStates());
     EXPECT_TRUE(modelPtr->hasUncertainty());
 }
+
+TEST(DirectEncodingParserTest, PomdpParsing) {
+    std::shared_ptr<storm::models::sparse::Model<double>> modelPtr =
+        storm::parser::DirectEncodingParser<double>::parseModel(STORM_TEST_RESOURCES_DIR "/pomdp/maze2_sl0.drn");
+
+    // Test if parsed correctly.
+    ASSERT_EQ(storm::models::ModelType::Pomdp, modelPtr->getType());
+    ASSERT_EQ(15ul, modelPtr->getNumberOfStates());
+    ASSERT_EQ(66ul, modelPtr->getNumberOfTransitions());
+    ASSERT_EQ(54ul, modelPtr->as<storm::models::sparse::Mdp<double>>()->getNumberOfChoices());
+    ASSERT_TRUE(modelPtr->hasLabel("init"));
+    ASSERT_EQ(1ul, modelPtr->getInitialStates().getNumberOfSetBits());
+    ASSERT_TRUE(modelPtr->hasLabel("bad"));
+    ASSERT_EQ(2ul, modelPtr->getStates("bad").getNumberOfSetBits());
+    ASSERT_TRUE(modelPtr->hasLabel("goal"));
+    ASSERT_EQ(1ul, modelPtr->getStates("goal").getNumberOfSetBits());
+    ASSERT_EQ(1ul, modelPtr->getNumberOfRewardModels());
+    ASSERT_TRUE(modelPtr->hasRewardModel("rew"));
+    ASSERT_TRUE(!modelPtr->getRewardModel("rew").hasStateRewards());
+    ASSERT_TRUE(modelPtr->getRewardModel("rew").hasStateActionRewards());
+    ASSERT_TRUE(!modelPtr->getRewardModel("rew").isAllZero());
+}


### PR DESCRIPTION
The DRN parser had the order of observations and state rewards switched up compared to the exporter.
Furthermore, whitespaces were not properly handled in the observation parsing part.

Also added a test case for the explicit parsing of POMDPs.

Fixes #689 