### PR TITLE
Fix computing schedulers for max reach. reward properties (fixes #683)

### DIFF
--- a/resources/examples/testfiles/mdp/tiny_rewards2.nm
+++ b/resources/examples/testfiles/mdp/tiny_rewards2.nm
@@ -1,0 +1,24 @@
+// Adapted from https://github.com/moves-rwth/storm/issues/297
+mdp
+
+module main
+    s : [0..3];
+
+[a0] s=0 -> 0.1: (s'=0) + 0.9: (s'=2);
+[a1] s=0 -> 0.1: (s'=1) + 0.9: (s'=2);
+
+[a0] s=1 -> 0.1: (s'=0) + 0.9: (s'=2);
+[a1] s=1 -> (s'=2);
+
+[a0] s=2 -> 0.1: (s'=2) + 0.9: (s'=3);
+[a1] s=2 -> 0.1: (s'=0) + 0.9: (s'=2);
+
+[a0] s=3 -> (s'=3);
+
+endmodule
+
+label "goal" = s=3;
+
+rewards "rew"
+    s<3 : 1;
+endrewards

--- a/resources/examples/testfiles/mdp/tiny_rewards3.nm
+++ b/resources/examples/testfiles/mdp/tiny_rewards3.nm
@@ -1,0 +1,24 @@
+// Taken from https://github.com/moves-rwth/storm/issues/683
+mdp
+
+module state_space
+    s : [0..3];
+
+    [a1] s=0 -> (s'=1);
+
+    [a2] s=1 -> 0.5 : (s'=2) + 0.5 : (s'=3);
+
+    [a3] s=2 -> (s'=1);
+    [a4] s=2 -> (s'=2);
+
+    [] s=3 -> true;
+endmodule
+
+label "goal" = s=3;
+
+rewards "rew"
+    [a1] true : 1;
+    [a2] true : 1;
+    [a3] true : 1;
+    [a4] true : 1;
+endrewards

--- a/src/test/storm/modelchecker/prctl/mdp/SchedulerGenerationMdpPrctlModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/prctl/mdp/SchedulerGenerationMdpPrctlModelCheckerTest.cpp
@@ -193,6 +193,76 @@ TYPED_TEST(SchedulerGenerationMdpPrctlModelCheckerTest, total_reward) {
     }
 }
 
+TYPED_TEST(SchedulerGenerationMdpPrctlModelCheckerTest, reach_reward) {
+    // Test case taken from https://github.com/moves-rwth/storm/issues/297
+    typedef typename TestFixture::ValueType ValueType;
+
+    std::string formulasString = "Rmax=? [ F \"goal\" ];";
+
+    auto [mdp, formulas] = this->buildModelFormulas(STORM_TEST_RESOURCES_DIR "/mdp/tiny_rewards2.nm", formulasString);
+    auto tasks = this->getTasks(formulas);
+    EXPECT_EQ(4ul, mdp->getNumberOfStates());
+    EXPECT_EQ(7ul, mdp->getNumberOfChoices());
+    EXPECT_EQ(12ul, mdp->getNumberOfTransitions());
+    ASSERT_EQ(mdp->getType(), storm::models::ModelType::Mdp);
+    storm::modelchecker::SparseMdpPrctlModelChecker<storm::models::sparse::Mdp<ValueType>> checker(*mdp);
+
+    {
+        auto result = checker.check(this->env(), tasks[0]);
+        ASSERT_TRUE(result->isExplicitQuantitativeCheckResult());
+        ASSERT_TRUE(storm::utility::isInfinity(result->template asExplicitQuantitativeCheckResult<ValueType>()[*mdp->getInitialStates().begin()]));
+        ASSERT_TRUE(result->template asExplicitQuantitativeCheckResult<ValueType>().hasScheduler());
+        storm::storage::Scheduler<ValueType> const& scheduler = result->template asExplicitQuantitativeCheckResult<ValueType>().getScheduler();
+        EXPECT_TRUE(scheduler.isDeterministicScheduler());
+        EXPECT_TRUE(scheduler.isMemorylessScheduler());
+        EXPECT_TRUE(!scheduler.isPartialScheduler());
+
+        auto inducedModel = mdp->applyScheduler(scheduler);
+        ASSERT_EQ(inducedModel->getType(), storm::models::ModelType::Dtmc);
+        auto const& inducedDtmc = inducedModel->template as<storm::models::sparse::Dtmc<ValueType>>();
+        EXPECT_EQ(inducedDtmc->getNumberOfChoices(), inducedDtmc->getNumberOfStates());
+        storm::modelchecker::SparseDtmcPrctlModelChecker<storm::models::sparse::Dtmc<ValueType>> inducedChecker(*inducedDtmc);
+        auto inducedResult = inducedChecker.check(this->env(), tasks[0]);
+        ASSERT_TRUE(inducedResult->isExplicitQuantitativeCheckResult());
+        EXPECT_TRUE(storm::utility::isInfinity(inducedResult->template asExplicitQuantitativeCheckResult<ValueType>()[*mdp->getInitialStates().begin()]));
+    }
+}
+
+TYPED_TEST(SchedulerGenerationMdpPrctlModelCheckerTest, reach_reward2) {
+    // Test case taken from https://github.com/moves-rwth/storm/issues/683
+    typedef typename TestFixture::ValueType ValueType;
+
+    std::string formulasString = "Rmax=? [ F \"goal\" ];";
+
+    auto [mdp, formulas] = this->buildModelFormulas(STORM_TEST_RESOURCES_DIR "/mdp/tiny_rewards3.nm", formulasString);
+    auto tasks = this->getTasks(formulas);
+    EXPECT_EQ(4ul, mdp->getNumberOfStates());
+    EXPECT_EQ(5ul, mdp->getNumberOfChoices());
+    EXPECT_EQ(6ul, mdp->getNumberOfTransitions());
+    ASSERT_EQ(mdp->getType(), storm::models::ModelType::Mdp);
+    storm::modelchecker::SparseMdpPrctlModelChecker<storm::models::sparse::Mdp<ValueType>> checker(*mdp);
+
+    {
+        auto result = checker.check(this->env(), tasks[0]);
+        ASSERT_TRUE(result->isExplicitQuantitativeCheckResult());
+        ASSERT_TRUE(storm::utility::isInfinity(result->template asExplicitQuantitativeCheckResult<ValueType>()[*mdp->getInitialStates().begin()]));
+        ASSERT_TRUE(result->template asExplicitQuantitativeCheckResult<ValueType>().hasScheduler());
+        storm::storage::Scheduler<ValueType> const& scheduler = result->template asExplicitQuantitativeCheckResult<ValueType>().getScheduler();
+        EXPECT_TRUE(scheduler.isDeterministicScheduler());
+        EXPECT_TRUE(scheduler.isMemorylessScheduler());
+        EXPECT_TRUE(!scheduler.isPartialScheduler());
+
+        auto inducedModel = mdp->applyScheduler(scheduler);
+        ASSERT_EQ(inducedModel->getType(), storm::models::ModelType::Dtmc);
+        auto const& inducedDtmc = inducedModel->template as<storm::models::sparse::Dtmc<ValueType>>();
+        EXPECT_EQ(inducedDtmc->getNumberOfChoices(), inducedDtmc->getNumberOfStates());
+        storm::modelchecker::SparseDtmcPrctlModelChecker<storm::models::sparse::Dtmc<ValueType>> inducedChecker(*inducedDtmc);
+        auto inducedResult = inducedChecker.check(this->env(), tasks[0]);
+        ASSERT_TRUE(inducedResult->isExplicitQuantitativeCheckResult());
+        EXPECT_TRUE(storm::utility::isInfinity(inducedResult->template asExplicitQuantitativeCheckResult<ValueType>()[*mdp->getInitialStates().begin()]));
+    }
+}
+
 TYPED_TEST(SchedulerGenerationMdpPrctlModelCheckerTest, lra) {
     typedef typename TestFixture::ValueType ValueType;
 


### PR DESCRIPTION
I also added the examples from #297 and #683 as test cases.