### PR TITLE
Fixes for (negative) expected rewards

### DIFF
--- a/resources/examples/testfiles/mdp/tiny_rewards_negative.nm
+++ b/resources/examples/testfiles/mdp/tiny_rewards_negative.nm
@@ -1,0 +1,19 @@
+mdp
+
+module model
+    state : [0..2];
+
+    [] state=0 -> (state'=1);
+    [a] state=0 -> true;
+    [b] state=1 -> true;
+	[] state=1 -> (state'=2);
+	[] state=2 -> true;
+endmodule
+
+rewards "a"
+    [a] true : -1;
+endrewards
+
+rewards "b"
+    [b] true : 1;
+endrewards

--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -1080,7 +1080,8 @@ void computeStateValues(std::string const& description, std::function<std::uniqu
             auto const& property = properties[propertyIndex];
             // As the property serves as filter, it should (a) be qualitative and should (b) not consider a filter itself.
             if (!property.getRawFormula()->hasQualitativeResult()) {
-                STORM_LOG_ERROR("Property " << property.getRawFormula() << " can not be used for filtering states as it does not have a qualitative result.");
+                STORM_LOG_ERROR("Property '" << *property.getRawFormula()
+                                             << "' can not be used for filtering states as it does not have a qualitative result.");
                 continue;
             }
 

--- a/src/storm/modelchecker/multiobjective/pcaa/StandardPcaaWeightVectorChecker.cpp
+++ b/src/storm/modelchecker/multiobjective/pcaa/StandardPcaaWeightVectorChecker.cpp
@@ -42,6 +42,9 @@ void StandardPcaaWeightVectorChecker<SparseModelType>::initialize(
     auto rewardAnalysis = preprocessing::SparseMultiObjectiveRewardAnalysis<SparseModelType>::analyze(preprocessorResult);
     STORM_LOG_THROW(rewardAnalysis.rewardFinitenessType != preprocessing::RewardFinitenessType::Infinite, storm::exceptions::NotSupportedException,
                     "There is no Pareto optimal scheduler that yields finite reward for all objectives. This is not supported.");
+    STORM_LOG_WARN_COND(rewardAnalysis.rewardFinitenessType == preprocessing::RewardFinitenessType::AllFinite,
+                        "There might be infinite reward for some scheduler. Multi-objective model checking restricts to schedulers that yield finite reward "
+                        "for all objectives. Be aware that solutions yielding infinite reward are discarded.");
     STORM_LOG_THROW(rewardAnalysis.totalRewardLessInfinityEStates, storm::exceptions::UnexpectedException,
                     "The set of states with reward < infinity for some scheduler has not been computed during preprocessing.");
     STORM_LOG_THROW(preprocessorResult.containsOnlyTrivialObjectives(), storm::exceptions::NotSupportedException,

--- a/src/storm/modelchecker/prctl/helper/BaierUpperRewardBoundsComputer.cpp
+++ b/src/storm/modelchecker/prctl/helper/BaierUpperRewardBoundsComputer.cpp
@@ -218,7 +218,7 @@ ValueType BaierUpperRewardBoundsComputer<ValueType>::computeUpperBound() {
         for (auto rowIndex : transitionMatrix.getRowGroupIndices(state)) {
             auto const row = transitionMatrix.getRow(rowIndex);
             bool const exitingChoice =
-                std::all_of(row.begin(), row.begin(), [&stateToSccFct, &currScc](auto const& entry) { return currScc != stateToSccFct(entry.getColumn()); });
+                std::all_of(row.begin(), row.end(), [&stateToSccFct, &currScc](auto const& entry) { return currScc != stateToSccFct(entry.getColumn()); });
             if (exitingChoice) {
                 maxRewardExit = std::max(maxRewardExit, rewards[rowIndex]);
             } else {

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -887,6 +887,8 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, RewardModelType const& rewardModel, bool qualitative, bool produceScheduler,
     ModelCheckerHint const& hint) {
+    STORM_LOG_THROW(!rewardModel.hasNegativeRewards(), storm::exceptions::NotImplementedException,
+                    "The reward model contains negative rewards. This is not implemented by the total rewards computation.");
     // Reduce to reachability rewards
     if (goal.minimize()) {
         // Identify the states from which no reward can be collected under some scheduler

--- a/src/storm/models/sparse/StandardRewardModel.h
+++ b/src/storm/models/sparse/StandardRewardModel.h
@@ -333,6 +333,13 @@ class StandardRewardModel {
     bool isAllZero() const;
 
     /*!
+     * Checks whether the reward model has negative rewards.
+     *
+     * @return True iff the reward model has at least one negative reward value
+     */
+    bool hasNegativeRewards() const;
+
+    /*!
      * Checks whether the reward model is compatible with key model characteristics.
      *
      * In detail, the method checks

--- a/src/storm/models/sparse/StandardRewardModel.h
+++ b/src/storm/models/sparse/StandardRewardModel.h
@@ -333,11 +333,14 @@ class StandardRewardModel {
     bool isAllZero() const;
 
     /*!
-     * Checks whether the reward model has negative rewards.
-     *
-     * @return True iff the reward model has at least one negative reward value
+     * @return Whether the reward model has at least one negative reward value
      */
     bool hasNegativeRewards() const;
+
+    /*!
+     * @return Whether the reward model has at least one positive reward value
+     */
+    bool hasPositiveRewards() const;
 
     /*!
      * Checks whether the reward model is compatible with key model characteristics.


### PR DESCRIPTION
This PR fixes a few bugs and improves behaviour based on feedback by @Chickenpowerrr (Thanks a lot!)

- Throw an error for currently unsupported (single-objective) total reward computation with negative rewards
- Warn users about potentially discarded "infinitely bad" solutions
- Properly handle multi-objective queries involving negative and mixed-sign rewards
- Mildly improve upper reward bound computation: Rewards on transitions that can only be triggered once can also only be collected once.