### PR TITLE
Time limit for Gurobi LP Solver

### DIFF
--- a/src/storm/solver/GurobiLpSolver.cpp
+++ b/src/storm/solver/GurobiLpSolver.cpp
@@ -731,8 +731,35 @@ ValueType GurobiLpSolver<ValueType, RawMode>::getMILPGap(bool relative) const {
 template<typename ValueType, bool RawMode>
 void GurobiLpSolver<ValueType, RawMode>::setTimeLimit(uint64_t seconds) {
     int error = GRBsetdblparam(GRBgetenv(model), GRB_DBL_PAR_TIMELIMIT, seconds);
+    timeLimit.emplace(seconds);
     STORM_LOG_THROW(error == 0, storm::exceptions::InvalidStateException,
                     "Unable to set Gurobi time limit (" << GRBgeterrormsg(**environment) << ", error code " << error << ").");
+}
+
+template<typename ValueType, bool RawMode>
+uint64_t GurobiLpSolver<ValueType, RawMode>::getTimeLimit() {
+    STORM_LOG_THROW(timeLimit.has_value(), storm::exceptions::InvalidAccessException,
+                    "Unable to get Gurobi time limit because none was specified.");
+    return timeLimit.value();
+}
+
+template<typename ValueType, bool RawMode>
+bool GurobiLpSolver<ValueType, RawMode>::hasTimeLimit() {
+    return timeLimit.has_value();
+}
+
+template<typename ValueType, bool RawMode>
+bool GurobiLpSolver<ValueType, RawMode>::hasTimedOut() {
+    if (!this->currentModelHasBeenOptimized) {
+        return false;
+    }
+    int status = 0;
+
+    int error = GRBgetintattr(model, GRB_INT_ATTR_STATUS, &status);
+    STORM_LOG_THROW(error == 0, storm::exceptions::InvalidStateException,
+                    "Unable to retrieve optimization status of Gurobi model (" << GRBgeterrormsg(**environment) << ", error code " << error << ").");
+
+    return status == GRB_TIME_LIMIT;
 }
 
 #else
@@ -905,6 +932,24 @@ ValueType GurobiLpSolver<ValueType, RawMode>::getMILPGap(bool) const {
 
 template<typename ValueType, bool RawMode>
 void GurobiLpSolver<ValueType, RawMode>::setTimeLimit(uint64_t) {
+    throw storm::exceptions::NotImplementedException() << "This version of storm was compiled without support for Gurobi. Yet, a method was called that "
+                                                          "requires this support. Please choose a version of storm with Gurobi support.";
+}
+
+template<typename ValueType, bool RawMode>
+uint64_t GurobiLpSolver<ValueType, RawMode>::getTimeLimit() {
+    throw storm::exceptions::NotImplementedException() << "This version of storm was compiled without support for Gurobi. Yet, a method was called that "
+                                                          "requires this support. Please choose a version of storm with Gurobi support.";
+}
+
+template<typename ValueType, bool RawMode>
+bool GurobiLpSolver<ValueType, RawMode>::hasTimeLimit() {
+    throw storm::exceptions::NotImplementedException() << "This version of storm was compiled without support for Gurobi. Yet, a method was called that "
+                                                          "requires this support. Please choose a version of storm with Gurobi support.";
+}
+
+template<typename ValueType, bool RawMode>
+bool GurobiLpSolver<ValueType, RawMode>::hasTimedOut() {
     throw storm::exceptions::NotImplementedException() << "This version of storm was compiled without support for Gurobi. Yet, a method was called that "
                                                           "requires this support. Please choose a version of storm with Gurobi support.";
 }

--- a/src/storm/solver/GurobiLpSolver.cpp
+++ b/src/storm/solver/GurobiLpSolver.cpp
@@ -738,8 +738,7 @@ void GurobiLpSolver<ValueType, RawMode>::setTimeLimit(uint64_t seconds) {
 
 template<typename ValueType, bool RawMode>
 uint64_t GurobiLpSolver<ValueType, RawMode>::getTimeLimit() {
-    STORM_LOG_THROW(timeLimit.has_value(), storm::exceptions::InvalidAccessException,
-                    "Unable to get Gurobi time limit because none was specified.");
+    STORM_LOG_THROW(timeLimit.has_value(), storm::exceptions::InvalidAccessException, "Unable to get Gurobi time limit because none was specified.");
     return timeLimit.value();
 }
 

--- a/src/storm/solver/GurobiLpSolver.cpp
+++ b/src/storm/solver/GurobiLpSolver.cpp
@@ -903,7 +903,6 @@ ValueType GurobiLpSolver<ValueType, RawMode>::getMILPGap(bool) const {
                                                           "requires this support. Please choose a version of storm with Gurobi support.";
 }
 
-
 template<typename ValueType, bool RawMode>
 void GurobiLpSolver<ValueType, RawMode>::setTimeLimit(uint64_t) {
     throw storm::exceptions::NotImplementedException() << "This version of storm was compiled without support for Gurobi. Yet, a method was called that "

--- a/src/storm/solver/GurobiLpSolver.cpp
+++ b/src/storm/solver/GurobiLpSolver.cpp
@@ -911,7 +911,7 @@ ValueType GurobiLpSolver<ValueType, RawMode>::getMILPGap(bool) const {
 
 
 template<typename ValueType, bool RawMode>
-void GurobiLpSolver<ValueType, RawMode>::setTimeLimit(uint64_t seconds) {
+void GurobiLpSolver<ValueType, RawMode>::setTimeLimit(uint64_t) {
     throw storm::exceptions::NotImplementedException() << "This version of storm was compiled without support for Gurobi. Yet, a method was called that "
                                                           "requires this support. Please choose a version of storm with Gurobi support.";
 }

--- a/src/storm/solver/GurobiLpSolver.cpp
+++ b/src/storm/solver/GurobiLpSolver.cpp
@@ -91,14 +91,6 @@ void GurobiEnvironment::setOutput(bool set) {
 #endif
 }
 
-void GurobiEnvironment::setTimeLimit(uint64_t seconds) {
-#ifdef STORM_HAVE_GUROBI
-    int error = GRBsetintparam(env, "TimeLimit", seconds);
-    STORM_LOG_THROW(error == 0, storm::exceptions::InvalidStateException,
-                    "Unable to set Gurobi time limit (" << GRBgeterrormsg(env) << ", error code " << error << ").");
-#endif
-}
-
 #ifdef STORM_HAVE_GUROBI
 
 template<typename ValueType, bool RawMode>
@@ -738,7 +730,9 @@ ValueType GurobiLpSolver<ValueType, RawMode>::getMILPGap(bool relative) const {
 
 template<typename ValueType, bool RawMode>
 void GurobiLpSolver<ValueType, RawMode>::setTimeLimit(uint64_t seconds) {
-    environment->setTimeLimit(seconds);
+    int error = GRBsetdblparam(GRBgetenv(model), GRB_DBL_PAR_TIMELIMIT, seconds);
+    STORM_LOG_THROW(error == 0, storm::exceptions::InvalidStateException,
+                    "Unable to set Gurobi time limit (" << GRBgeterrormsg(**environment) << ", error code " << error << ").");
 }
 
 #else
@@ -909,7 +903,7 @@ ValueType GurobiLpSolver<ValueType, RawMode>::getMILPGap(bool) const {
                                                           "requires this support. Please choose a version of storm with Gurobi support.";
 }
 
-t
+
 template<typename ValueType, bool RawMode>
 void GurobiLpSolver<ValueType, RawMode>::setTimeLimit(uint64_t) {
     throw storm::exceptions::NotImplementedException() << "This version of storm was compiled without support for Gurobi. Yet, a method was called that "

--- a/src/storm/solver/GurobiLpSolver.cpp
+++ b/src/storm/solver/GurobiLpSolver.cpp
@@ -93,7 +93,7 @@ void GurobiEnvironment::setOutput(bool set) {
 
 void GurobiEnvironment::setTimeLimit(uint64_t seconds) {
 #ifdef STORM_HAVE_GUROBI
-    error = GRBsetintparam(env, "TimeLimit", seconds);
+    int error = GRBsetintparam(env, "TimeLimit", seconds);
     STORM_LOG_THROW(error == 0, storm::exceptions::InvalidStateException,
                     "Unable to set Gurobi time limit (" << GRBgeterrormsg(env) << ", error code " << error << ").");
 #endif
@@ -599,8 +599,6 @@ uint64_t GurobiLpSolver<ValueType, RawMode>::getSolutionCount() const {
 template<typename ValueType, bool RawMode>
 ValueType GurobiLpSolver<ValueType, RawMode>::getContinuousValue(Variable const& variable, uint64_t const& solutionIndex) const {
     if (!this->isOptimal()) {
-        STORM_LOG_THROW(!this->isInfeasible(), storm::exceptions::InvalidAccessException,
-                        "Unable to get Gurobi solution from infeasible model (" << GRBgeterrormsg(**environment) << ").");
         STORM_LOG_THROW(this->currentModelHasBeenOptimized, storm::exceptions::InvalidAccessException,
                         "Unable to get Gurobi solution from unoptimized model (" << GRBgeterrormsg(**environment) << ").");
     }
@@ -629,8 +627,6 @@ ValueType GurobiLpSolver<ValueType, RawMode>::getContinuousValue(Variable const&
 template<typename ValueType, bool RawMode>
 int_fast64_t GurobiLpSolver<ValueType, RawMode>::getIntegerValue(Variable const& variable, uint64_t const& solutionIndex) const {
     if (!this->isOptimal()) {
-        STORM_LOG_THROW(!this->isInfeasible(), storm::exceptions::InvalidAccessException,
-                        "Unable to get Gurobi solution from infeasible model (" << GRBgeterrormsg(**environment) << ").");
         STORM_LOG_THROW(this->currentModelHasBeenOptimized, storm::exceptions::InvalidAccessException,
                         "Unable to get Gurobi solution from unoptimized model (" << GRBgeterrormsg(**environment) << ").");
     }
@@ -662,8 +658,6 @@ int_fast64_t GurobiLpSolver<ValueType, RawMode>::getIntegerValue(Variable const&
 template<typename ValueType, bool RawMode>
 bool GurobiLpSolver<ValueType, RawMode>::getBinaryValue(Variable const& variable, uint64_t const& solutionIndex) const {
     if (!this->isOptimal()) {
-        STORM_LOG_THROW(!this->isInfeasible(), storm::exceptions::InvalidAccessException,
-                        "Unable to get Gurobi solution from infeasible model (" << GRBgeterrormsg(**environment) << ").");
         STORM_LOG_THROW(this->currentModelHasBeenOptimized, storm::exceptions::InvalidAccessException,
                         "Unable to get Gurobi solution from unoptimized model (" << GRBgeterrormsg(**environment) << ").");
     }
@@ -700,9 +694,7 @@ bool GurobiLpSolver<ValueType, RawMode>::getBinaryValue(Variable const& variable
 template<typename ValueType, bool RawMode>
 ValueType GurobiLpSolver<ValueType, RawMode>::getObjectiveValue(uint64_t solutionIndex) const {
     if (!this->isOptimal()) {
-        STORM_LOG_THROW(!this->isInfeasible(), storm::exceptions::InvalidAccessException,
-                        "Unable to get Gurobi solution from infeasible model (" << GRBgeterrormsg(**environment) << ").");
-        STORMgit_LOG_THROW(this->currentModelHasBeenOptimized, storm::exceptions::InvalidAccessException,
+        STORM_LOG_THROW(this->currentModelHasBeenOptimized, storm::exceptions::InvalidAccessException,
                         "Unable to get Gurobi solution from unoptimized model (" << GRBgeterrormsg(**environment) << ").");
     }
     STORM_LOG_ASSERT(solutionIndex < getSolutionCount(), "Invalid solution index.");

--- a/src/storm/solver/GurobiLpSolver.cpp
+++ b/src/storm/solver/GurobiLpSolver.cpp
@@ -702,7 +702,7 @@ ValueType GurobiLpSolver<ValueType, RawMode>::getObjectiveValue(uint64_t solutio
     if (!this->isOptimal()) {
         STORM_LOG_THROW(!this->isInfeasible(), storm::exceptions::InvalidAccessException,
                         "Unable to get Gurobi solution from infeasible model (" << GRBgeterrormsg(**environment) << ").");
-        STORM_LOG_THROW(this->currentModelHasBeenOptimized, storm::exceptions::InvalidAccessException,
+        STORMgit_LOG_THROW(this->currentModelHasBeenOptimized, storm::exceptions::InvalidAccessException,
                         "Unable to get Gurobi solution from unoptimized model (" << GRBgeterrormsg(**environment) << ").");
     }
     STORM_LOG_ASSERT(solutionIndex < getSolutionCount(), "Invalid solution index.");

--- a/src/storm/solver/GurobiLpSolver.cpp
+++ b/src/storm/solver/GurobiLpSolver.cpp
@@ -909,7 +909,7 @@ ValueType GurobiLpSolver<ValueType, RawMode>::getMILPGap(bool) const {
                                                           "requires this support. Please choose a version of storm with Gurobi support.";
 }
 
-
+t
 template<typename ValueType, bool RawMode>
 void GurobiLpSolver<ValueType, RawMode>::setTimeLimit(uint64_t) {
     throw storm::exceptions::NotImplementedException() << "This version of storm was compiled without support for Gurobi. Yet, a method was called that "

--- a/src/storm/solver/GurobiLpSolver.h
+++ b/src/storm/solver/GurobiLpSolver.h
@@ -131,8 +131,9 @@ class GurobiLpSolver : public LpSolver<ValueType, RawMode> {
     bool getBinaryValue(Variable const& name, uint64_t const& solutionIndex) const;
     ValueType getObjectiveValue(uint64_t solutionIndex) const;
 
-    // Method for specifying and retrieving a time limit
+    // Method for specifying a time limit
     void setTimeLimit(uint64_t seconds);
+    // Retrieve the time limit in seconds. Requires that a time limit has been set before.
     uint64_t getTimeLimit();
     // Method for checking whether the model has a time limit
     bool hasTimeLimit();

--- a/src/storm/solver/GurobiLpSolver.h
+++ b/src/storm/solver/GurobiLpSolver.h
@@ -131,8 +131,14 @@ class GurobiLpSolver : public LpSolver<ValueType, RawMode> {
     bool getBinaryValue(Variable const& name, uint64_t const& solutionIndex) const;
     ValueType getObjectiveValue(uint64_t solutionIndex) const;
 
-    // Method for specifying a time limit
+    // Method for specifying and retrieving a time limit
     void setTimeLimit(uint64_t seconds);
+    uint64_t getTimeLimit();
+    // Method for checking whether the model has a time limit
+    bool hasTimeLimit();
+    // Method for checking whether the optimization has timed out
+    bool hasTimedOut();
+
 
    private:
 #ifdef STORM_HAVE_GUROBI
@@ -156,6 +162,8 @@ class GurobiLpSolver : public LpSolver<ValueType, RawMode> {
         int firstGenConstraintIndex;
     };
     std::vector<IncrementalLevel> incrementalData;
+
+    std::optional<uint64_t> timeLimit;
 };
 
 enum class GurobiSolverMethod { AUTOMATIC = -1, PRIMALSIMPLEX = 0, DUALSIMPLEX = 1, BARRIER = 2, CONCURRENT = 3, DETCONCURRENT = 4, DETCONCURRENTSIMPLEX = 5 };

--- a/src/storm/solver/GurobiLpSolver.h
+++ b/src/storm/solver/GurobiLpSolver.h
@@ -29,6 +29,7 @@ class GurobiEnvironment {
      */
     void initialize();
     void setOutput(bool set = false);
+    void setTimeLimit(uint64_t seconds);
 #ifdef STORM_HAVE_GUROBI
     GRBenv* operator*();
 #endif
@@ -130,6 +131,9 @@ class GurobiLpSolver : public LpSolver<ValueType, RawMode> {
     int_fast64_t getIntegerValue(Variable const& name, uint64_t const& solutionIndex) const;
     bool getBinaryValue(Variable const& name, uint64_t const& solutionIndex) const;
     ValueType getObjectiveValue(uint64_t solutionIndex) const;
+
+    // Method for specifying a time limit
+    void setTimeLimit(uint64_t seconds);
 
    private:
 #ifdef STORM_HAVE_GUROBI

--- a/src/storm/solver/GurobiLpSolver.h
+++ b/src/storm/solver/GurobiLpSolver.h
@@ -139,7 +139,6 @@ class GurobiLpSolver : public LpSolver<ValueType, RawMode> {
     // Method for checking whether the optimization has timed out
     bool hasTimedOut();
 
-
    private:
 #ifdef STORM_HAVE_GUROBI
     // The Gurobi model.

--- a/src/storm/solver/GurobiLpSolver.h
+++ b/src/storm/solver/GurobiLpSolver.h
@@ -29,7 +29,6 @@ class GurobiEnvironment {
      */
     void initialize();
     void setOutput(bool set = false);
-    void setTimeLimit(uint64_t seconds);
 #ifdef STORM_HAVE_GUROBI
     GRBenv* operator*();
 #endif


### PR DESCRIPTION
This PR adds the possibility to specify a time limit when using the Gurobi LP solver. This allows for stopping the solver before an optimal solution is found and retrieving sub-optimal solutions.

The following changes have been made:
- The following methods have been added to `GurobiLpSolver`: 
    * `setTimeLimit(uint64_t seconds)`: sets the parameter in the underlying Gurobi environment of the model
    * `hasTimeLimit()`: returns whether a time limit has been set
    * `getTimeLimit()`: returns the time limit if it has been set, otherwise an `InvalidAccessException` is thrown
    * `hasTimedOut()`: returns whether a time out has occurred (implemented analogously to the check of optimality)
- The methods for retrieving sub-optimal solutions have been adapted, i.e. `getContinuousValue(...)`, `getIntegerValue(...)`, `getBinaryValue(...)` and `getObjectiveValue(...)`. More precisely, the checks for infeasiblity and unboundedness have been removed. If the problem is infeasible, then the check of the solution count will be zero. If the problem is unbouded, Gurobi might still find a solution before it determines that the problem is indeed unbounded. In that case a user might still be interested in a solution.