### PR TITLE
Clean up and fix for BitVector

### DIFF
--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -766,8 +766,10 @@ uint64_t BitVector::getNextSetIndex(uint64_t startingIndex) const {
 }
 
 uint64_t BitVector::getNextUnsetIndex(uint64_t startingIndex) const {
+#ifdef ASSERT_BITVECTOR
     STORM_LOG_ASSERT(getNextIndexWithValue<false>(buckets, startingIndex, bitCount) == (~(*this)).getNextSetIndex(startingIndex),
                      "The result is inconsistent with the next set index of the complement of this bitvector");
+#endif
     return getNextIndexWithValue<false>(buckets, startingIndex, bitCount);
 }
 
@@ -776,8 +778,10 @@ uint64_t BitVector::getStartOfZeroSequenceBefore(uint64_t endIndex) const {
 }
 
 uint64_t BitVector::getStartOfOneSequenceBefore(uint64_t endIndex) const {
+#ifdef ASSERT_BITVECTOR
     STORM_LOG_ASSERT((getNextIndexWithValue<false, true>(buckets, 0, endIndex) == (~(*this)).getStartOfZeroSequenceBefore(endIndex)),
                      "The result is inconsistent with the next set index of the complement of this bitvector");
+#endif
     return getNextIndexWithValue<false, true>(buckets, 0, endIndex);
 }
 

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -10,9 +10,8 @@
 #include "storm/utility/OsDetection.h"
 #include "storm/utility/macros.h"
 
-#ifdef STORM_DEV
-#define ASSERT_BITVECTOR
-#endif
+// Uncomment the following line to enable additional assertions for debugging bitvector operations.
+// #define ASSERT_BITVECTOR
 
 namespace storm {
 namespace storage {

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -766,10 +766,8 @@ uint64_t BitVector::getNextSetIndex(uint64_t startingIndex) const {
 }
 
 uint64_t BitVector::getNextUnsetIndex(uint64_t startingIndex) const {
-#ifdef ASSERT_BITVECTOR
     STORM_LOG_ASSERT(getNextIndexWithValue<false>(buckets, startingIndex, bitCount) == (~(*this)).getNextSetIndex(startingIndex),
                      "The result is inconsistent with the next set index of the complement of this bitvector");
-#endif
     return getNextIndexWithValue<false>(buckets, startingIndex, bitCount);
 }
 
@@ -778,10 +776,8 @@ uint64_t BitVector::getStartOfZeroSequenceBefore(uint64_t endIndex) const {
 }
 
 uint64_t BitVector::getStartOfOneSequenceBefore(uint64_t endIndex) const {
-#ifdef ASSERT_BITVECTOR
     STORM_LOG_ASSERT((getNextIndexWithValue<false, true>(buckets, 0, endIndex) == (~(*this)).getStartOfZeroSequenceBefore(endIndex)),
                      "The result is inconsistent with the next set index of the complement of this bitvector");
-#endif
     return getNextIndexWithValue<false, true>(buckets, 0, endIndex);
 }
 

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <bit>
 #include <bitset>
 #include <iostream>
 
@@ -18,7 +19,7 @@ namespace storage {
 
 BitVector::const_iterator::const_iterator() : dataPtr(nullptr), currentIndex(0), endIndex(0) {};
 
-BitVector::const_iterator::const_iterator(uint64_t const* dataPtr, uint_fast64_t startIndex, uint_fast64_t endIndex, bool setOnFirstBit)
+BitVector::const_iterator::const_iterator(uint64_t const* dataPtr, uint64_t startIndex, uint64_t endIndex, bool setOnFirstBit)
     : dataPtr(dataPtr), endIndex(endIndex) {
     if (setOnFirstBit) {
         // Set the index of the first set bit in the vector.
@@ -60,7 +61,7 @@ BitVector::const_iterator& BitVector::const_iterator::operator+=(size_t n) {
     return *this;
 }
 
-uint_fast64_t BitVector::const_iterator::operator*() const {
+uint64_t BitVector::const_iterator::operator*() const {
     return currentIndex;
 }
 
@@ -116,7 +117,7 @@ BitVector::const_reverse_iterator& BitVector::const_reverse_iterator::operator+=
     return *this;
 }
 
-uint_fast64_t BitVector::const_reverse_iterator::operator*() const {
+uint64_t BitVector::const_reverse_iterator::operator*() const {
     return currentIndex - 1;  // the stored index is off-by-one!
 }
 
@@ -132,9 +133,9 @@ BitVector::BitVector() : bitCount(0), buckets(nullptr) {
     // Intentionally left empty.
 }
 
-BitVector::BitVector(uint_fast64_t length, bool init) : bitCount(length), buckets(nullptr) {
+BitVector::BitVector(uint64_t length, bool init) : bitCount(length), buckets(nullptr) {
     // Compute the correct number of buckets needed to store the given number of bits.
-    uint_fast64_t bucketCount = length >> 6;
+    uint64_t bucketCount = length >> 6;
     if ((length & mod64mask) != 0) {
         ++bucketCount;
     }
@@ -154,15 +155,15 @@ BitVector::~BitVector() {
 }
 
 template<typename InputIterator>
-BitVector::BitVector(uint_fast64_t length, InputIterator begin, InputIterator end) : BitVector(length) {
+BitVector::BitVector(uint64_t length, InputIterator begin, InputIterator end) : BitVector(length) {
     set(begin, end);
 }
 
-BitVector::BitVector(uint_fast64_t length, std::vector<uint_fast64_t> setEntries) : BitVector(length, setEntries.begin(), setEntries.end()) {
+BitVector::BitVector(uint64_t length, std::vector<uint64_t> setEntries) : BitVector(length, setEntries.begin(), setEntries.end()) {
     // Intentionally left empty.
 }
 
-BitVector::BitVector(uint_fast64_t bucketCount, uint_fast64_t bitCount) : bitCount(bitCount), buckets(nullptr) {
+BitVector::BitVector(uint64_t bucketCount, uint64_t bitCount) : bitCount(bitCount), buckets(nullptr) {
     STORM_LOG_ASSERT((bucketCount << 6) == bitCount, "Bit count does not match number of buckets.");
     buckets = new uint64_t[bucketCount]();
 }
@@ -240,7 +241,7 @@ bool BitVector::operator!=(BitVector const& other) const {
     return !(*this == other);
 }
 
-void BitVector::set(uint_fast64_t index, bool value) {
+void BitVector::set(uint64_t index, bool value) {
     STORM_LOG_ASSERT(index < bitCount, "Invalid call to BitVector::set: written index " << index << " out of bounds.");
     uint64_t bucket = index >> 6;
 
@@ -259,20 +260,20 @@ void BitVector::set(InputIterator begin, InputIterator end, bool value) {
     }
 }
 
-bool BitVector::operator[](uint_fast64_t index) const {
+bool BitVector::operator[](uint64_t index) const {
     uint64_t bucket = index >> 6;
     uint64_t mask = 1ull << (63 - (index & mod64mask));
     return (this->buckets[bucket] & mask) == mask;
 }
 
-bool BitVector::get(uint_fast64_t index) const {
+bool BitVector::get(uint64_t index) const {
     STORM_LOG_ASSERT(index < bitCount, "Invalid call to BitVector::get: read index " << index << " out of bounds.");
     return (*this)[index];
 }
 
-void BitVector::resize(uint_fast64_t newLength, bool init) {
+void BitVector::resize(uint64_t newLength, bool init) {
     if (newLength > bitCount) {
-        uint_fast64_t newBucketCount = newLength >> 6;
+        uint64_t newBucketCount = newLength >> 6;
         if ((newLength & mod64mask) != 0) {
             ++newBucketCount;
         }
@@ -300,7 +301,7 @@ void BitVector::resize(uint_fast64_t newLength, bool init) {
         }
         truncateLastBucket();
     } else {
-        uint_fast64_t newBucketCount = newLength >> 6;
+        uint64_t newBucketCount = newLength >> 6;
         if ((newLength & mod64mask) != 0) {
             ++newBucketCount;
         }
@@ -336,10 +337,10 @@ void BitVector::expandSize(bool init) {
     }
 }
 
-void BitVector::grow(uint_fast64_t minimumLength, bool init) {
+void BitVector::grow(uint64_t minimumLength, bool init) {
     if (minimumLength > bitCount) {
         // We double the bitcount as long as it is less then the minimum length.
-        uint_fast64_t newLength = std::max(static_cast<uint_fast64_t>(64), bitCount);
+        uint64_t newLength = std::max(static_cast<uint64_t>(64), bitCount);
         // Note that newLength has to be initialized with a non-zero number.
         while (newLength < minimumLength) {
             newLength = newLength << 1;
@@ -395,7 +396,7 @@ BitVector BitVector::operator%(BitVector const& filter) const {
     // If the current bit vector has not too many elements compared to the given bit vector we prefer iterating
     // over its elements.
     if (filter.getNumberOfSetBits() / 10 < this->getNumberOfSetBits()) {
-        uint_fast64_t position = 0;
+        uint64_t position = 0;
         for (auto bit : filter) {
             if ((*this)[bit]) {
                 result.set(position);
@@ -493,7 +494,7 @@ bool BitVector::isDisjointFrom(BitVector const& other) const {
     return true;
 }
 
-bool BitVector::matches(uint_fast64_t bitIndex, BitVector const& other) const {
+bool BitVector::matches(uint64_t bitIndex, BitVector const& other) const {
     STORM_LOG_ASSERT((bitIndex & mod64mask) == 0, "Bit index must be a multiple of 64.");
     STORM_LOG_ASSERT(other.size() <= this->size() - bitIndex, "Bit vector argument is too long.");
 
@@ -537,7 +538,7 @@ BitVector BitVector::permuteGroupedVector(const std::vector<uint64_t>& inversePe
     return result;
 }
 
-void BitVector::set(uint_fast64_t bitIndex, BitVector const& other) {
+void BitVector::set(uint64_t bitIndex, BitVector const& other) {
     STORM_LOG_ASSERT((bitIndex & mod64mask) == 0, "Bit index must be a multiple of 64.");
     STORM_LOG_ASSERT(other.size() <= this->size() - bitIndex, "Bit vector argument is too long.");
 
@@ -561,7 +562,7 @@ void BitVector::setMultiple(uint64_t bitIndex, uint64_t nrOfBits, bool newValue)
     }
 }
 
-storm::storage::BitVector BitVector::get(uint_fast64_t bitIndex, uint_fast64_t numberOfBits) const {
+storm::storage::BitVector BitVector::get(uint64_t bitIndex, uint64_t numberOfBits) const {
     uint64_t numberOfBuckets = numberOfBits >> 6;
     uint64_t index = bitIndex >> 6;
     STORM_LOG_ASSERT(index + numberOfBuckets <= this->bucketCount(), "Argument is out-of-range.");
@@ -572,47 +573,26 @@ storm::storage::BitVector BitVector::get(uint_fast64_t bitIndex, uint_fast64_t n
     return result;
 }
 
-uint_fast64_t BitVector::getAsInt(uint_fast64_t bitIndex, uint_fast64_t numberOfBits) const {
+uint64_t BitVector::getAsInt(uint64_t bitIndex, uint64_t numberOfBits) const {
+    if (numberOfBits == 0) {  // It is necessary to catch this case as we might have an empty bitvector (i.e. uninitialized buckets).
+        return 0;
+    }
     STORM_LOG_ASSERT(numberOfBits <= 64, "Number of bits must be <= 64.");
-    uint64_t bucket = bitIndex >> 6;
-    uint64_t bitIndexInBucket = bitIndex & mod64mask;
+    uint64_t const firstBucket = bitIndex >> 6;                                                   // the bucket where the value starts
+    uint8_t const bitIndexInFirstBucket = bitIndex & mod64mask;                                   // the index within that bucket
+    uint8_t const availableBitsInFirstBucket = static_cast<uint8_t>(64 - bitIndexInFirstBucket);  // number of available bits in that bucket
 
-    uint64_t mask;
-    if (bitIndexInBucket == 0) {
-        mask = -1ull;
-    } else {
-        mask = (1ull << (64 - bitIndexInBucket)) - 1ull;
+    // First get the result in the form rr...rrxx...xx (r = result, x = garbage)
+    uint64_t result = buckets[firstBucket] << bitIndexInFirstBucket;
+    // We might have to look at the next bucket, too
+    if (availableBitsInFirstBucket < numberOfBits) {
+        result |= buckets[firstBucket + 1] >> availableBitsInFirstBucket;
     }
-
-    if (bitIndexInBucket + numberOfBits < 64) {
-        // If the value stops before the end of the bucket, we need to erase some lower bits.
-        mask &= ~((1ull << (64 - (bitIndexInBucket + numberOfBits))) - 1ull);
-        return (buckets[bucket] & mask) >> (64 - (bitIndexInBucket + numberOfBits));
-    } else if (bitIndexInBucket + numberOfBits > 64) {
-        // In this case, the integer "crosses" the bucket line.
-        uint64_t result = (buckets[bucket] & mask);
-        ++bucket;
-
-        // Compute the remaining number of bits.
-        numberOfBits -= (64 - bitIndexInBucket);
-
-        // Shift the intermediate result to the right location.
-        result <<= numberOfBits;
-
-        // Strip away everything from the second bucket that is beyond the final index and add it to the
-        // intermediate result.
-        mask = ~((1ull << (64 - numberOfBits)) - 1ull);
-        uint64_t lowerBits = buckets[bucket] & mask;
-        result |= (lowerBits >> (64 - numberOfBits));
-
-        return result;
-    } else {
-        // In this case, it suffices to take the current mask.
-        return buckets[bucket] & mask;
-    }
+    // Get rid of the garbage bits and return the result.
+    return result >> (64 - numberOfBits);
 }
 
-uint_fast64_t BitVector::getTwoBitsAligned(uint_fast64_t bitIndex) const {
+uint64_t BitVector::getTwoBitsAligned(uint64_t bitIndex) const {
     // Check whether it is aligned.
     STORM_LOG_ASSERT(bitIndex % 64 != 63, "Bits not aligned.");
     uint64_t bucket = bitIndex >> 6;
@@ -635,7 +615,7 @@ uint_fast64_t BitVector::getTwoBitsAligned(uint_fast64_t bitIndex) const {
     }
 }
 
-void BitVector::setFromInt(uint_fast64_t bitIndex, uint_fast64_t numberOfBits, uint64_t value) {
+void BitVector::setFromInt(uint64_t bitIndex, uint64_t numberOfBits, uint64_t value) {
     STORM_LOG_ASSERT(numberOfBits <= 64, "Number of bits must be <= 64.");
     STORM_LOG_ASSERT(numberOfBits == 64 || (value >> numberOfBits) == 0,
                      "Integer value (" << value << ") too large to fit in the given number of bits (" << numberOfBits << ").");
@@ -708,59 +688,34 @@ void BitVector::fill() {
     truncateLastBucket();
 }
 
-uint_fast64_t BitVector::getNumberOfSetBits() const {
+uint64_t BitVector::getNumberOfSetBits() const {
     return getNumberOfSetBitsBeforeIndex(bitCount);
 }
 
-uint_fast64_t BitVector::getNumberOfSetBitsBeforeIndex(uint_fast64_t index) const {
-    uint_fast64_t result = 0;
+uint64_t BitVector::getNumberOfSetBitsBeforeIndex(uint64_t index) const {
+    STORM_LOG_ASSERT(index <= bitCount, "Invalid call to BitVector::getNumberOfSetBitsBeforeIndex: read index " << index << " out of bounds.");
+    uint64_t const lastBucketIndex = index >> 6;
+    uint64_t result = 0;
 
     // First, count all full buckets.
-    uint_fast64_t bucket = index >> 6;
-    for (uint_fast64_t i = 0; i < bucket; ++i) {
-        // Check if we are using g++ or clang++ and, if so, use the built-in function
-#if (defined(__GNUG__) || defined(__clang__))
-        result += __builtin_popcountll(buckets[i]);
-#elif defined WINDOWS
-#include <nmmintrin.h>
-        // If the target machine does not support SSE4, this will fail.
-        result += _mm_popcnt_u64(bucketVector[i]);
-#else
-        uint_fast32_t cnt;
-        uint_fast64_t bitset = buckets[i];
-        for (cnt = 0; bitset; cnt++) {
-            bitset &= bitset - 1;
-        }
-        result += cnt;
-#endif
+    for (uint64_t i = 0; i < lastBucketIndex; ++i) {
+        result += std::popcount(buckets[i]);
     }
 
     // Now check if we have to count part of a bucket.
-    uint64_t tmp = index & mod64mask;
-    if (tmp != 0) {
-        tmp = ~((1ll << (64 - (tmp & mod64mask))) - 1ll);
-        tmp &= buckets[bucket];
-        // Check if we are using g++ or clang++ and, if so, use the built-in function
-#if (defined(__GNUG__) || defined(__clang__))
-        result += __builtin_popcountll(tmp);
-#else
-        uint_fast32_t cnt;
-        uint64_t bitset = tmp;
-        for (cnt = 0; bitset; cnt++) {
-            bitset &= bitset - 1;
-        }
-        result += cnt;
-#endif
+    uint8_t const endIndexInLastBucket = index & mod64mask;
+    if (endIndexInLastBucket != 0) {
+        result += std::popcount(buckets[lastBucketIndex] >> (64 - endIndexInLastBucket));
     }
 
     return result;
 }
 
-std::vector<uint_fast64_t> BitVector::getNumberOfSetBitsBeforeIndices() const {
-    std::vector<uint_fast64_t> bitsSetBeforeIndices;
+std::vector<uint64_t> BitVector::getNumberOfSetBitsBeforeIndices() const {
+    std::vector<uint64_t> bitsSetBeforeIndices;
     bitsSetBeforeIndices.reserve(this->size());
-    uint_fast64_t lastIndex = 0;
-    uint_fast64_t currentNumberOfSetBits = 0;
+    uint64_t lastIndex = 0;
+    uint64_t currentNumberOfSetBits = 0;
     for (auto index : *this) {
         while (lastIndex <= index) {
             bitsSetBeforeIndices.push_back(currentNumberOfSetBits);
@@ -806,11 +761,11 @@ BitVector::const_reverse_iterator BitVector::rend() const {
     return const_reverse_iterator(buckets, 0ull, 0ull, false);
 }
 
-uint_fast64_t BitVector::getNextSetIndex(uint_fast64_t startingIndex) const {
+uint64_t BitVector::getNextSetIndex(uint64_t startingIndex) const {
     return getNextIndexWithValue<true>(buckets, startingIndex, bitCount);
 }
 
-uint_fast64_t BitVector::getNextUnsetIndex(uint_fast64_t startingIndex) const {
+uint64_t BitVector::getNextUnsetIndex(uint64_t startingIndex) const {
 #ifdef ASSERT_BITVECTOR
     STORM_LOG_ASSERT(getNextIndexWithValue<false>(buckets, startingIndex, bitCount) == (~(*this)).getNextSetIndex(startingIndex),
                      "The result is inconsistent with the next set index of the complement of this bitvector");
@@ -831,7 +786,7 @@ uint64_t BitVector::getStartOfOneSequenceBefore(uint64_t endIndex) const {
 }
 
 template<bool Value, bool Backward>
-uint_fast64_t BitVector::getNextIndexWithValue(uint64_t const* dataPtr, uint64_t startingIndex, uint64_t endIndex) {
+uint64_t BitVector::getNextIndexWithValue(uint64_t const* dataPtr, uint64_t startingIndex, uint64_t endIndex) {
     if (startingIndex >= endIndex) {
         return Backward ? startingIndex : endIndex;
     }
@@ -913,19 +868,19 @@ uint_fast64_t BitVector::getNextIndexWithValue(uint64_t const* dataPtr, uint64_t
 #endif
 }
 
-storm::storage::BitVector BitVector::getAsBitVector(uint_fast64_t start, uint_fast64_t length) const {
+storm::storage::BitVector BitVector::getAsBitVector(uint64_t start, uint64_t length) const {
     STORM_LOG_ASSERT(start + length <= bitCount, "Invalid range.");
 #ifdef ASSERT_BITVECTOR
     BitVector original(*this);
 #endif
     storm::storage::BitVector result(length, false);
 
-    uint_fast64_t offset = start % 64;
+    uint64_t offset = start % 64;
     uint64_t* getBucket = buckets + (start / 64);
     uint64_t* insertBucket = result.buckets;
-    uint_fast64_t getValue;
-    uint_fast64_t writeValue = 0;
-    uint_fast64_t noBits = 0;
+    uint64_t getValue;
+    uint64_t writeValue = 0;
+    uint64_t noBits = 0;
     if (offset == 0) {
         // Copy complete buckets
         for (; noBits + 64 <= length; ++getBucket, ++insertBucket, noBits += 64) {
@@ -950,7 +905,7 @@ storm::storage::BitVector BitVector::getAsBitVector(uint_fast64_t start, uint_fa
     }
 
     // Write last bits
-    uint_fast64_t remainingBits = length - noBits;
+    uint64_t remainingBits = length - noBits;
     STORM_LOG_ASSERT(getBucket != buckets + bucketCount(), "Bucket index incorrect.");
     // Get remaining bits
     getValue = (*getBucket >> (64 - remainingBits)) << (64 - remainingBits);
@@ -973,7 +928,7 @@ storm::storage::BitVector BitVector::getAsBitVector(uint_fast64_t start, uint_fa
 
 #ifdef ASSERT_BITVECTOR
     // Check correctness of getter
-    for (uint_fast64_t i = 0; i < length; ++i) {
+    for (uint64_t i = 0; i < length; ++i) {
         if (result.get(i) != get(start + i)) {
             STORM_LOG_ERROR("Getting of bits not correct for index " << i);
             STORM_LOG_ERROR("Getting from " << start << " with length " << length);
@@ -985,7 +940,7 @@ storm::storage::BitVector BitVector::getAsBitVector(uint_fast64_t start, uint_fa
             STORM_LOG_ASSERT(false, "Getting of bits not correct.");
         }
     }
-    for (uint_fast64_t i = 0; i < bitCount; ++i) {
+    for (uint64_t i = 0; i < bitCount; ++i) {
         if (i < start || i >= start + length) {
             if (original.get(i) != get(i)) {
                 STORM_LOG_ERROR("Getting did change bitvector at index " << i);
@@ -1004,18 +959,18 @@ storm::storage::BitVector BitVector::getAsBitVector(uint_fast64_t start, uint_fa
     return result;
 }
 
-void BitVector::setFromBitVector(uint_fast64_t start, BitVector const& other) {
+void BitVector::setFromBitVector(uint64_t start, BitVector const& other) {
 #ifdef ASSERT_BITVECTOR
     BitVector original(*this);
 #endif
     STORM_LOG_ASSERT(start + other.bitCount <= bitCount, "Range invalid.");
 
-    uint_fast64_t offset = start % 64;
+    uint64_t offset = start % 64;
     uint64_t* insertBucket = buckets + (start / 64);
     uint64_t* getBucket = other.buckets;
-    uint_fast64_t getValue;
-    uint_fast64_t writeValue = 0;
-    uint_fast64_t noBits = 0;
+    uint64_t getValue;
+    uint64_t writeValue = 0;
+    uint64_t noBits = 0;
     if (offset == 0) {
         // Copy complete buckets
         for (; noBits + 64 <= other.bitCount; ++insertBucket, ++getBucket, noBits += 64) {
@@ -1043,7 +998,7 @@ void BitVector::setFromBitVector(uint_fast64_t start, BitVector const& other) {
     }
 
     // Write last bits
-    uint_fast64_t remainingBits = other.bitCount - noBits;
+    uint64_t remainingBits = other.bitCount - noBits;
     STORM_LOG_ASSERT(remainingBits < 64, "Too many remaining bits.");
     STORM_LOG_ASSERT(insertBucket != buckets + bucketCount(), "Bucket index incorrect.");
     STORM_LOG_ASSERT(getBucket != other.buckets + other.bucketCount(), "Bucket index incorrect.");
@@ -1066,7 +1021,7 @@ void BitVector::setFromBitVector(uint_fast64_t start, BitVector const& other) {
 
 #ifdef ASSERT_BITVECTOR
     // Check correctness of setter
-    for (uint_fast64_t i = 0; i < other.bitCount; ++i) {
+    for (uint64_t i = 0; i < other.bitCount; ++i) {
         if (other.get(i) != get(start + i)) {
             STORM_LOG_ERROR("Setting of bits not correct for index " << i);
             STORM_LOG_ERROR("Setting from " << start << " with length " << other.bitCount);
@@ -1078,7 +1033,7 @@ void BitVector::setFromBitVector(uint_fast64_t start, BitVector const& other) {
             STORM_LOG_ASSERT(false, "Setting of bits not correct.");
         }
     }
-    for (uint_fast64_t i = 0; i < bitCount; ++i) {
+    for (uint64_t i = 0; i < bitCount; ++i) {
         if (i < start || i >= start + other.bitCount) {
             if (original.get(i) != get(i)) {
                 STORM_LOG_ERROR("Setting did change bitvector at index " << i);
@@ -1095,11 +1050,11 @@ void BitVector::setFromBitVector(uint_fast64_t start, BitVector const& other) {
 #endif
 }
 
-bool BitVector::compareAndSwap(uint_fast64_t start1, uint_fast64_t start2, uint_fast64_t length) {
+bool BitVector::compareAndSwap(uint64_t start1, uint64_t start2, uint64_t length) {
     if (length < 64) {
         // Just use one number
-        uint_fast64_t elem1 = getAsInt(start1, length);
-        uint_fast64_t elem2 = getAsInt(start2, length);
+        uint64_t elem1 = getAsInt(start1, length);
+        uint64_t elem2 = getAsInt(start2, length);
         if (elem1 < elem2) {
             // Swap elements
             setFromInt(start1, length, elem2);
@@ -1116,7 +1071,7 @@ bool BitVector::compareAndSwap(uint_fast64_t start1, uint_fast64_t start2, uint_
             // Elements already sorted
 #ifdef ASSERT_BITVECTOR
             // Check that sorted
-            for (uint_fast64_t i = 0; i < length; ++i) {
+            for (uint64_t i = 0; i < length; ++i) {
                 if (get(start1 + i) > get(start2 + i)) {
                     break;
                 }
@@ -1137,7 +1092,7 @@ bool BitVector::compareAndSwap(uint_fast64_t start1, uint_fast64_t start2, uint_
 #ifdef ASSERT_BITVECTOR
         // Check correctness of swapping
         bool tmp;
-        for (uint_fast64_t i = 0; i < length; ++i) {
+        for (uint64_t i = 0; i < length; ++i) {
             tmp = check.get(i + start1);
             check.set(i + start1, check.get(i + start2));
             check.set(i + start2, tmp);
@@ -1145,7 +1100,7 @@ bool BitVector::compareAndSwap(uint_fast64_t start1, uint_fast64_t start2, uint_
         STORM_LOG_ASSERT(*this == check, "Swapping not correct");
 
         // Check that sorted
-        for (uint_fast64_t i = 0; i < length; ++i) {
+        for (uint64_t i = 0; i < length; ++i) {
             if (get(start1 + i) > get(start2 + i)) {
                 break;
             }
@@ -1183,7 +1138,7 @@ std::ostream& operator<<(std::ostream& out, BitVector const& bitvector) {
 
 void BitVector::printBits(std::ostream& out) const {
     out << "bit vector(" << getNumberOfSetBits() << "/" << bitCount << ") ";
-    uint_fast64_t index = 0;
+    uint64_t index = 0;
     for (; index * 64 + 64 <= bitCount; ++index) {
         std::bitset<64> tmp(buckets[index]);
         out << tmp << "|";
@@ -1447,17 +1402,14 @@ BitVector BitVector::load(std::string const& description) {
 }
 
 // All necessary explicit template instantiations.
-template BitVector::BitVector(uint_fast64_t length, std::vector<uint_fast64_t>::iterator begin, std::vector<uint_fast64_t>::iterator end);
-template BitVector::BitVector(uint_fast64_t length, std::vector<uint_fast64_t>::const_iterator begin, std::vector<uint_fast64_t>::const_iterator end);
-template BitVector::BitVector(uint_fast64_t length, storm::storage::FlatSet<uint_fast64_t>::iterator begin,
-                              storm::storage::FlatSet<uint_fast64_t>::iterator end);
-template BitVector::BitVector(uint_fast64_t length, storm::storage::FlatSet<uint_fast64_t>::const_iterator begin,
-                              storm::storage::FlatSet<uint_fast64_t>::const_iterator end);
-template void BitVector::set(std::vector<uint_fast64_t>::iterator begin, std::vector<uint_fast64_t>::iterator end, bool value);
-template void BitVector::set(std::vector<uint_fast64_t>::const_iterator begin, std::vector<uint_fast64_t>::const_iterator end, bool value);
-template void BitVector::set(storm::storage::FlatSet<uint_fast64_t>::iterator begin, storm::storage::FlatSet<uint_fast64_t>::iterator end, bool value);
-template void BitVector::set(storm::storage::FlatSet<uint_fast64_t>::const_iterator begin, storm::storage::FlatSet<uint_fast64_t>::const_iterator end,
-                             bool value);
+template BitVector::BitVector(uint64_t length, std::vector<uint64_t>::iterator begin, std::vector<uint64_t>::iterator end);
+template BitVector::BitVector(uint64_t length, std::vector<uint64_t>::const_iterator begin, std::vector<uint64_t>::const_iterator end);
+template BitVector::BitVector(uint64_t length, storm::storage::FlatSet<uint64_t>::iterator begin, storm::storage::FlatSet<uint64_t>::iterator end);
+template BitVector::BitVector(uint64_t length, storm::storage::FlatSet<uint64_t>::const_iterator begin, storm::storage::FlatSet<uint64_t>::const_iterator end);
+template void BitVector::set(std::vector<uint64_t>::iterator begin, std::vector<uint64_t>::iterator end, bool value);
+template void BitVector::set(std::vector<uint64_t>::const_iterator begin, std::vector<uint64_t>::const_iterator end, bool value);
+template void BitVector::set(storm::storage::FlatSet<uint64_t>::iterator begin, storm::storage::FlatSet<uint64_t>::iterator end, bool value);
+template void BitVector::set(storm::storage::FlatSet<uint64_t>::const_iterator begin, storm::storage::FlatSet<uint64_t>::const_iterator end, bool value);
 
 template struct Murmur3BitVectorHash<uint32_t>;
 template struct Murmur3BitVectorHash<uint64_t>;

--- a/src/storm/storage/BitVector.h
+++ b/src/storm/storage/BitVector.h
@@ -29,10 +29,10 @@ class BitVector {
        public:
         // Define iterator
         using iterator_category = std::forward_iterator_tag;
-        using value_type = uint_fast64_t;
+        using value_type = uint64_t;
         using difference_type = std::ptrdiff_t;
-        using pointer = uint_fast64_t*;
-        using reference = uint_fast64_t&;
+        using pointer = uint64_t*;
+        using reference = uint64_t&;
 
         const_iterator();
 
@@ -46,7 +46,7 @@ class BitVector {
          * first bit upon construction.
          * @param endIndex The index at which to abort the iteration process.
          */
-        const_iterator(uint64_t const* dataPtr, uint_fast64_t startIndex, uint_fast64_t endIndex, bool setOnFirstBit = true);
+        const_iterator(uint64_t const* dataPtr, uint64_t startIndex, uint64_t endIndex, bool setOnFirstBit = true);
 
         /*!
          * Constructs an iterator by copying the given iterator.
@@ -89,7 +89,7 @@ class BitVector {
          *
          * @return The index of the current bit to which this iterator points.
          */
-        uint_fast64_t operator*() const;
+        uint64_t operator*() const;
 
         /*!
          * Compares the iterator with another iterator for inequality.
@@ -112,10 +112,10 @@ class BitVector {
         uint64_t const* dataPtr;
 
         // The index of the bit this iterator currently points to.
-        uint_fast64_t currentIndex;
+        uint64_t currentIndex;
 
         // The index of the bit that is past the end of the range of this iterator.
-        uint_fast64_t endIndex;
+        uint64_t endIndex;
     };
     /*!
      * A class that enables iterating over the indices of the bit vector whose corresponding bits are set to
@@ -129,10 +129,10 @@ class BitVector {
        public:
         // Define iterator
         using iterator_category = std::forward_iterator_tag;
-        using value_type = uint_fast64_t;
+        using value_type = uint64_t;
         using difference_type = std::ptrdiff_t;
-        using pointer = uint_fast64_t*;
-        using reference = uint_fast64_t&;
+        using pointer = uint64_t*;
+        using reference = uint64_t&;
 
         /*!
          * Constructs a reverse iterator over the indices of the set bits in the given bit vector, starting and
@@ -171,7 +171,7 @@ class BitVector {
          *
          * @return The index of the current bit to which this iterator points.
          */
-        uint_fast64_t operator*() const;
+        uint64_t operator*() const;
 
         /*!
          * Compares the iterator with another iterator for inequality.
@@ -217,7 +217,7 @@ class BitVector {
      * @param length The number of bits the bit vector should be able to hold.
      * @param init The initial value of the first |length| bits.
      */
-    explicit BitVector(uint_fast64_t length, bool init = false);
+    explicit BitVector(uint64_t length, bool init = false);
 
     /*!
      * Creates a bit vector that has exactly the bits set that are given by the provided input iterator range
@@ -228,12 +228,12 @@ class BitVector {
      * @param last The end of the iterator range.
      */
     template<typename InputIterator>
-    BitVector(uint_fast64_t length, InputIterator first, InputIterator last);
+    BitVector(uint64_t length, InputIterator first, InputIterator last);
 
     /*!
      * Creates a bit vector that has exactly the bits set that are given by the vector
      */
-    BitVector(uint_fast64_t length, std::vector<uint_fast64_t> setEntries);
+    BitVector(uint64_t length, std::vector<uint64_t> setEntries);
 
     /*!
      * Performs a deep copy of the given bit vector.
@@ -297,7 +297,7 @@ class BitVector {
      * @param index The index where to set the truth value.
      * @param value The truth value to set.
      */
-    void set(uint_fast64_t index, bool value = true);
+    void set(uint64_t index, bool value = true);
 
     /*!
      * Sets all bits in the given iterator range [first, last).
@@ -315,7 +315,7 @@ class BitVector {
      * @param index The index of the bit to access.
      * @return True iff the bit at the given index is set.
      */
-    bool operator[](uint_fast64_t index) const;
+    bool operator[](uint64_t index) const;
 
     /*!
      * Retrieves the truth value of the bit at the given index and performs a bound check. If the access is
@@ -324,7 +324,7 @@ class BitVector {
      * @param index The index of the bit to access.
      * @return True iff the bit at the given index is set.
      */
-    bool get(uint_fast64_t index) const;
+    bool get(uint64_t index) const;
 
     /*!
      * Resizes the bit vector to hold the given new number of bits. If the bit vector becomes smaller this way,
@@ -333,7 +333,7 @@ class BitVector {
      * @param newLength The new number of bits the bit vector can hold.
      * @param init The truth value to which to initialize newly created bits.
      */
-    void resize(uint_fast64_t newLength, bool init = false);
+    void resize(uint64_t newLength, bool init = false);
 
     /*!
      * Concatenate this bitvector with another bitvector. The result is stored in this bitvector.
@@ -357,7 +357,7 @@ class BitVector {
      * @param minimumLength The minimum number of bits that the bit vector should hold.
      * @param init The truth value to which to initialize newly created bits.
      */
-    void grow(uint_fast64_t minimumLength, bool init = false);
+    void grow(uint64_t minimumLength, bool init = false);
 
     /*!
      * Performs a logical "and" with the given bit vector. In case the sizes of the bit vectors do not match,
@@ -478,7 +478,7 @@ class BitVector {
      * @param other The bit vector with which to compare.
      * @return bool True iff the bits match exactly.
      */
-    bool matches(uint_fast64_t bitIndex, BitVector const& other) const;
+    bool matches(uint64_t bitIndex, BitVector const& other) const;
 
     /*!
      * Sets the exact bit pattern of the given bit vector starting at the given bit index. Note: the given bit
@@ -488,7 +488,7 @@ class BitVector {
      * 64.
      * @param other The bit vector whose pattern to set.
      */
-    void set(uint_fast64_t bitIndex, BitVector const& other);
+    void set(uint64_t bitIndex, BitVector const& other);
 
     /*!
      * Sets multiple bits to the given value.
@@ -519,7 +519,7 @@ class BitVector {
      * @param numberOfBits The number of bits to get. This value must be a multiple of 64.
      * @return A new bit vector holding the selected bits.
      */
-    storm::storage::BitVector get(uint_fast64_t bitIndex, uint_fast64_t numberOfBits) const;
+    storm::storage::BitVector get(uint64_t bitIndex, uint64_t numberOfBits) const;
 
     /*!
      * Retrieves the content of the current bit vector at the given index for the given number of bits as an
@@ -528,14 +528,14 @@ class BitVector {
      * @param bitIndex The index of the first bit to get.
      * @param numberOfBits The number of bits to get. This value must be less or equal than 64.
      */
-    uint_fast64_t getAsInt(uint_fast64_t bitIndex, uint_fast64_t numberOfBits) const;
+    uint64_t getAsInt(uint64_t bitIndex, uint64_t numberOfBits) const;
 
     /*!
      *
      * @param bitIndex The index of the first of the two bits to get
      * @return A value between 0 and 3, encoded as a byte.
      */
-    uint_fast64_t getTwoBitsAligned(uint_fast64_t bitIndex) const;
+    uint64_t getTwoBitsAligned(uint64_t bitIndex) const;
 
     /*!
      * Sets the selected number of lowermost bits of the provided value at the given bit index.
@@ -544,7 +544,7 @@ class BitVector {
      * @param numberOfBits The number of bits to set.
      * @param value The integer whose lowermost bits to set.
      */
-    void setFromInt(uint_fast64_t bitIndex, uint_fast64_t numberOfBits, uint64_t value);
+    void setFromInt(uint64_t bitIndex, uint64_t numberOfBits, uint64_t value);
 
     /*!
      * Retrieves whether no bits are set to true in this bit vector.
@@ -576,7 +576,7 @@ class BitVector {
      *
      * @return The number of bits that are set to true in this bit vector.
      */
-    uint_fast64_t getNumberOfSetBits() const;
+    uint64_t getNumberOfSetBits() const;
 
     /*!
      * Retrieves the number of bits set in this bit vector with an index strictly smaller than the given one.
@@ -584,14 +584,14 @@ class BitVector {
      * @param index The index for which to retrieve the number of set bits with a smaller index.
      * @return The number of bits set in this bit vector with an index strictly smaller than the given one.
      */
-    uint_fast64_t getNumberOfSetBitsBeforeIndex(uint_fast64_t index) const;
+    uint64_t getNumberOfSetBitsBeforeIndex(uint64_t index) const;
 
     /*!
      * Retrieves a vector that holds at position i the number of bits set before index i.
      *
      * @return The resulting vector of 'offsets'.
      */
-    std::vector<uint_fast64_t> getNumberOfSetBitsBeforeIndices() const;
+    std::vector<uint64_t> getNumberOfSetBitsBeforeIndices() const;
 
     /*
      * @return True, if the number of set bits is 1, false otherwise.
@@ -655,7 +655,7 @@ class BitVector {
      * bit at this index itself is included in the search range.
      * @return The index of the next bit that is set after the given index.
      */
-    uint_fast64_t getNextSetIndex(uint_fast64_t startingIndex) const;
+    uint64_t getNextSetIndex(uint64_t startingIndex) const;
 
     /*!
      * Retrieves the index of the bit that is the next bit set to false in the bit vector. If there is none,
@@ -666,7 +666,7 @@ class BitVector {
      * bit at this index itself is included in the search range.
      * @return The index of the next bit that is set after the given index.
      */
-    uint_fast64_t getNextUnsetIndex(uint_fast64_t startingIndex) const;
+    uint64_t getNextUnsetIndex(uint64_t startingIndex) const;
 
     /*!
      * Retrieves the smallest index i such that all bits in the range [i,endIndex) are 0.
@@ -699,7 +699,7 @@ class BitVector {
      * @param length Length of both intervals.
      * @return True, if the intervals were swapped, false if nothing changed.
      */
-    bool compareAndSwap(uint_fast64_t start1, uint_fast64_t start2, uint_fast64_t length);
+    bool compareAndSwap(uint64_t start1, uint64_t start2, uint64_t length);
 
     friend std::ostream& operator<<(std::ostream& out, BitVector const& bitVector);
 
@@ -719,7 +719,7 @@ class BitVector {
      * @param bucketCount The number of buckets to create.
      * @param bitCount This must be the number of buckets times 64.
      */
-    BitVector(uint_fast64_t bucketCount, uint_fast64_t bitCount);
+    BitVector(uint64_t bucketCount, uint64_t bitCount);
 
     /*!
      * Retrieves the index of the next bit that is set to the given value.
@@ -735,7 +735,7 @@ class BitVector {
      *         If startIndex >= endIndex, this returns (Backward ? startIndex : endIndex)
      */
     template<bool Value, bool Backward = false>
-    static uint_fast64_t getNextIndexWithValue(uint64_t const* dataPtr, uint_fast64_t startingIndex, uint_fast64_t endIndex);
+    static uint64_t getNextIndexWithValue(uint64_t const* dataPtr, uint64_t startingIndex, uint64_t endIndex);
 
     /*!
      * Truncate the last bucket so that no bits are set starting from bitCount.
@@ -749,7 +749,7 @@ class BitVector {
      * @param length The number of bits to get.
      * @return A new bit vector holding the selected bits.
      */
-    BitVector getAsBitVector(uint_fast64_t start, uint_fast64_t length) const;
+    BitVector getAsBitVector(uint64_t start, uint64_t length) const;
 
     /*!
      * Sets the exact bit pattern of the given bit vector starting at the given bit index. Note: the given bit
@@ -758,7 +758,7 @@ class BitVector {
      * @param start The index of the first bit that is supposed to be set.
      * @param other The bit vector whose pattern to set.
      */
-    void setFromBitVector(uint_fast64_t start, BitVector const& other);
+    void setFromBitVector(uint64_t start, BitVector const& other);
 
     /*!
      * Print bit vector and display all bits.
@@ -775,13 +775,13 @@ class BitVector {
     size_t bucketCount() const;
 
     // The number of bits that this bit vector can hold.
-    uint_fast64_t bitCount;
+    uint64_t bitCount;
 
     // The underlying storage of 64-bit buckets for all bits of this bit vector.
     uint64_t* buckets;
 
     // A bit mask that can be used to reduce a modulo 64 operation to a logical "and".
-    static const uint_fast64_t mod64mask = (1 << 6) - 1;
+    static const uint64_t mod64mask = (1 << 6) - 1;
 };
 
 static_assert(std::ranges::forward_range<BitVector>);

--- a/src/storm/storage/BitVector.h
+++ b/src/storm/storage/BitVector.h
@@ -1,5 +1,4 @@
-#ifndef STORM_STORAGE_BITVECTOR_H_
-#define STORM_STORAGE_BITVECTOR_H_
+#pragma once
 
 #include <cmath>
 #include <cstdint>
@@ -9,8 +8,7 @@
 #include <ranges>
 #include <vector>
 
-namespace storm {
-namespace storage {
+namespace storm::storage {
 
 /*!
  * A bit vector that is internally represented as a vector of 64-bit values.
@@ -795,8 +793,7 @@ struct Murmur3BitVectorHash {
     StateType operator()(storm::storage::BitVector const& bv) const;
 };
 
-}  // namespace storage
-}  // namespace storm
+}  // namespace storm::storage
 
 namespace std {
 template<>
@@ -804,5 +801,3 @@ struct hash<storm::storage::BitVector> {
     std::size_t operator()(storm::storage::BitVector const& bv) const;
 };
 }  // namespace std
-
-#endif  // STORM_STORAGE_BITVECTOR_H_

--- a/src/test/storm/storage/BitVectorTest.cpp
+++ b/src/test/storm/storage/BitVectorTest.cpp
@@ -6,7 +6,7 @@
 TEST(BitVectorTest, InitToZero) {
     storm::storage::BitVector vector(32);
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         ASSERT_FALSE(vector.get(i));
     }
 
@@ -17,7 +17,7 @@ TEST(BitVectorTest, InitToZero) {
 TEST(BitVectorTest, InitToOne) {
     storm::storage::BitVector vector(32, true);
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         ASSERT_TRUE(vector.get(i));
     }
     ASSERT_FALSE(vector.empty());
@@ -25,12 +25,12 @@ TEST(BitVectorTest, InitToOne) {
 }
 
 TEST(BitVectorTest, InitFromIterator) {
-    std::vector<uint_fast64_t> valueVector = {0, 4, 10};
+    std::vector<uint64_t> valueVector = {0, 4, 10};
     storm::storage::BitVector vector(32, valueVector.begin(), valueVector.end());
 
     ASSERT_EQ(32ul, vector.size());
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         if (i == 0 || i == 4 || i == 10) {
             ASSERT_TRUE(vector.get(i));
         } else {
@@ -40,12 +40,12 @@ TEST(BitVectorTest, InitFromIterator) {
 }
 
 TEST(BitVectorTest, InitFromIntVector) {
-    std::vector<uint_fast64_t> valueVector = {0, 4, 10};
+    std::vector<uint64_t> valueVector = {0, 4, 10};
     storm::storage::BitVector vector(32, valueVector);
 
     ASSERT_EQ(32ul, vector.size());
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         if (i == 0 || i == 4 || i == 10) {
             ASSERT_TRUE(vector.get(i));
         } else {
@@ -57,11 +57,11 @@ TEST(BitVectorTest, InitFromIntVector) {
 TEST(BitVectorTest, GetSet) {
     storm::storage::BitVector vector(32);
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         vector.set(i, i % 2 == 0);
     }
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         ASSERT_EQ(i % 2 == 0, vector.get(i));
     }
 }
@@ -152,7 +152,7 @@ TEST(BitVectorDeathTest, GetSetAssertion) {
 TEST(BitVectorTest, Resize) {
     storm::storage::BitVector vector(32);
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         vector.set(i);
     }
 
@@ -161,11 +161,11 @@ TEST(BitVectorTest, Resize) {
     ASSERT_EQ(70ul, vector.size());
     ASSERT_EQ(32ul, vector.getNumberOfSetBits());
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         ASSERT_TRUE(vector.get(i));
     }
     bool result;
-    for (uint_fast64_t i = 32; i < 70; ++i) {
+    for (uint64_t i = 32; i < 70; ++i) {
         result = true;
         ASSERT_NO_THROW(result = vector.get(i));
         ASSERT_FALSE(result);
@@ -173,18 +173,19 @@ TEST(BitVectorTest, Resize) {
 
     vector.resize(72, true);
 
+    std::cout << vector << std::endl;
     ASSERT_EQ(72ul, vector.size());
     ASSERT_EQ(34ul, vector.getNumberOfSetBits());
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         ASSERT_TRUE(vector.get(i));
     }
-    for (uint_fast64_t i = 32; i < 70; ++i) {
+    for (uint64_t i = 32; i < 70; ++i) {
         result = true;
         ASSERT_NO_THROW(result = vector.get(i));
         ASSERT_FALSE(result);
     }
-    for (uint_fast64_t i = 70; i < 72; ++i) {
+    for (uint64_t i = 70; i < 72; ++i) {
         ASSERT_TRUE(vector.get(i));
     }
 
@@ -192,7 +193,7 @@ TEST(BitVectorTest, Resize) {
     ASSERT_EQ(16ul, vector.size());
     ASSERT_EQ(16ul, vector.getNumberOfSetBits());
 
-    for (uint_fast64_t i = 0; i < 16; ++i) {
+    for (uint64_t i = 0; i < 16; ++i) {
         ASSERT_TRUE(vector.get(i));
     }
 
@@ -213,7 +214,7 @@ TEST(BitVectorTest, OperatorAnd) {
     vector2.set(31);
 
     storm::storage::BitVector andResult = vector1 & vector2;
-    for (uint_fast64_t i = 0; i < 31; ++i) {
+    for (uint64_t i = 0; i < 31; ++i) {
         ASSERT_FALSE(andResult.get(i));
     }
     ASSERT_TRUE(andResult.get(31));
@@ -232,7 +233,7 @@ TEST(BitVectorTest, OperatorAndEqual) {
 
     vector1 &= vector2;
 
-    for (uint_fast64_t i = 0; i < 31; ++i) {
+    for (uint64_t i = 0; i < 31; ++i) {
         ASSERT_FALSE(vector1.get(i));
     }
     ASSERT_TRUE(vector1.get(31));
@@ -242,7 +243,7 @@ TEST(BitVectorTest, OperatorOr) {
     storm::storage::BitVector vector1(32);
     storm::storage::BitVector vector2(32);
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         vector1.set(i, i % 2 == 0);
         vector2.set(i, i % 2 == 1);
     }
@@ -251,7 +252,7 @@ TEST(BitVectorTest, OperatorOr) {
 
     storm::storage::BitVector orResult = vector1 | vector2;
 
-    for (uint_fast64_t i = 0; i < 31; ++i) {
+    for (uint64_t i = 0; i < 31; ++i) {
         ASSERT_TRUE(orResult.get(i));
     }
     ASSERT_FALSE(orResult.get(31));
@@ -261,7 +262,7 @@ TEST(BitVectorTest, OperatorOrEqual) {
     storm::storage::BitVector vector1(32);
     storm::storage::BitVector vector2(32);
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         vector1.set(i, i % 2 == 0);
         vector2.set(i, i % 2 == 1);
     }
@@ -270,7 +271,7 @@ TEST(BitVectorTest, OperatorOrEqual) {
 
     vector1 |= vector2;
 
-    for (uint_fast64_t i = 0; i < 31; ++i) {
+    for (uint64_t i = 0; i < 31; ++i) {
         ASSERT_TRUE(vector1.get(i));
     }
     ASSERT_FALSE(vector1.get(31));
@@ -280,7 +281,7 @@ TEST(BitVectorTest, OperatorXor) {
     storm::storage::BitVector vector1(32);
     storm::storage::BitVector vector2(32);
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         vector1.set(i);
         vector2.set(i, i % 2 == 1);
     }
@@ -289,7 +290,7 @@ TEST(BitVectorTest, OperatorXor) {
     storm::storage::BitVector vector4 = ~vector2;
     storm::storage::BitVector vector5 = vector1 ^ vector1;
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         ASSERT_EQ(vector3.get(i), vector4.get(i));
         ASSERT_FALSE(vector5.get(i));
     }
@@ -299,7 +300,7 @@ TEST(BitVectorTest, OperatorModulo) {
     storm::storage::BitVector vector1(32);
     storm::storage::BitVector vector2(32);
 
-    for (uint_fast64_t i = 0; i < 15; ++i) {
+    for (uint64_t i = 0; i < 15; ++i) {
         vector2.set(i, i % 2 == 0);
     }
 
@@ -312,7 +313,7 @@ TEST(BitVectorTest, OperatorModulo) {
     ASSERT_EQ(8ul, moduloResult.size());
     ASSERT_EQ(2ul, moduloResult.getNumberOfSetBits());
 
-    for (uint_fast64_t i = 0; i < 8; ++i) {
+    for (uint64_t i = 0; i < 8; ++i) {
         if (i == 1 || i == 3) {
             ASSERT_TRUE(moduloResult.get(i));
         } else {
@@ -325,14 +326,14 @@ TEST(BitVectorTest, OperatorNot) {
     storm::storage::BitVector vector1(32);
     storm::storage::BitVector vector2(32);
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         vector1.set(i, i % 2 == 0);
         vector2.set(i, i % 2 == 1);
     }
 
     storm::storage::BitVector notResult = ~vector2;
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         ASSERT_EQ(vector1.get(i), notResult.get(i));
     }
 }
@@ -341,14 +342,14 @@ TEST(BitVectorTest, Complement) {
     storm::storage::BitVector vector1(32);
     storm::storage::BitVector vector2(32);
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         vector1.set(i, i % 2 == 0);
         vector2.set(i, i % 2 == 1);
     }
 
     vector2.complement();
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         ASSERT_EQ(vector1.get(i), vector2.get(i));
     }
 }
@@ -374,7 +375,7 @@ TEST(BitVectorTest, Increment) {
     EXPECT_EQ(vector1, vector2);
 
     vector1.clear();
-    for (uint_fast64_t i = 0; i < 66; ++i) {
+    for (uint64_t i = 0; i < 66; ++i) {
         vector1.set(i, true);
     }
     vector1.increment();
@@ -417,7 +418,7 @@ TEST(BitVectorTest, Implies) {
     storm::storage::BitVector vector1(32);
     storm::storage::BitVector vector2(32, true);
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         vector1.set(i, i % 2 == 0);
     }
     vector2.set(31, false);
@@ -425,7 +426,7 @@ TEST(BitVectorTest, Implies) {
 
     storm::storage::BitVector impliesResult = vector1.implies(vector2);
 
-    for (uint_fast64_t i = 0; i < 30; ++i) {
+    for (uint64_t i = 0; i < 30; ++i) {
         ASSERT_TRUE(impliesResult.get(i));
     }
     ASSERT_FALSE(impliesResult.get(30));
@@ -436,7 +437,7 @@ TEST(BitVectorTest, Subset) {
     storm::storage::BitVector vector1(32);
     storm::storage::BitVector vector2(32, true);
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         vector1.set(i, i % 2 == 0);
     }
 
@@ -451,7 +452,7 @@ TEST(BitVectorTest, Disjoint) {
     storm::storage::BitVector vector1(32);
     storm::storage::BitVector vector2(32);
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         vector1.set(i, i % 2 == 0);
         vector2.set(i, i % 2 == 1);
     }
@@ -496,7 +497,7 @@ TEST(BitVectorTest, Full) {
 TEST(BitVectorTest, NumberOfSetBits) {
     storm::storage::BitVector vector(32);
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         vector.set(i, i % 2 == 0);
     }
 
@@ -506,7 +507,7 @@ TEST(BitVectorTest, NumberOfSetBits) {
 TEST(BitVectorTest, NumberOfSetBitsBeforeIndex) {
     storm::storage::BitVector vector(32);
 
-    for (uint_fast64_t i = 0; i < 32; ++i) {
+    for (uint64_t i = 0; i < 32; ++i) {
         vector.set(i, i % 2 == 0);
     }
 
@@ -652,4 +653,19 @@ TEST(BitVectorTest, Assignment) {
     v1 = v2;
     v1.set(9999);
     ASSERT_TRUE(v1.get(9999));
+}
+
+TEST(BitVectorTest, ZeroSized) {
+    storm::storage::BitVector v(0);
+    EXPECT_EQ(0, v.size());
+    EXPECT_TRUE(v.empty());
+    EXPECT_TRUE(v.full());
+    EXPECT_EQ(0, v.getNumberOfSetBits());
+    EXPECT_EQ(0, v.getAsInt(0, 0));
+    EXPECT_EQ(0, v.getNextSetIndex(0));
+    EXPECT_EQ(v, v);
+    EXPECT_EQ(v, ~v);
+    for (auto const& entry : v) {
+        FAIL() << "Should not iterate over an empty bit vector.";
+    }
 }

--- a/src/test/storm/storage/BitVectorTest.cpp
+++ b/src/test/storm/storage/BitVectorTest.cpp
@@ -136,13 +136,8 @@ TEST(BitVectorDeathTest, GetSetAssertion) {
     storm::storage::BitVector vector(32);
 
 #ifndef NDEBUG
-#ifdef WINDOWS
-    EXPECT_EXIT(vector.get(32), ::testing::ExitedWithCode(0), ".*");
-    EXPECT_EXIT(vector.set(32), ::testing::ExitedWithCode(0), ".*");
-#else
     EXPECT_DEATH_IF_SUPPORTED(vector.get(32), "");
     EXPECT_DEATH_IF_SUPPORTED(vector.set(32), "");
-#endif
 #else
     std::cerr << "WARNING: Not testing GetSetAssertions, as they are disabled in release mode.\n";
     SUCCEED();


### PR DESCRIPTION
- simplify code for getAsInt and getNumberOfSetBitsBeforeIndex (using c++20 std::popcount)
- correctly handle 0-sized bit vectors for getAsInt method (fixes #753)
- add a test case for 0-sized bit vectors
- replace all uint_fast64_t by uint64_t in Bitvector[Test]