### PR TITLE
add two strings into stormoptions.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,7 +466,8 @@ if(STORM_VERSION_DEV GREATER 0)
 endif()
 
 message(STATUS "Storm - Version is ${STORM_VERSION_STRING}.")
-
+export_option(STORM_VERSION) # We want this information also in the more accessible stormOptions.cmake
+export_option(STORM_VERSION_DEV) # We want this information also in the more accessible stormOptions.cmake
 
 # Configure a header file to pass some of the CMake settings to the source code
 configure_file (


### PR DESCRIPTION
This helps for checking storm-versions when building python extension beyond stormpy, see also  https://github.com/moves-rwth/stormpy/issues/260 