### PR TITLE
Fixed ConstantComparator

### DIFF
--- a/src/storm/utility/ConstantsComparator.cpp
+++ b/src/storm/utility/ConstantsComparator.cpp
@@ -70,7 +70,7 @@ bool ConstantsComparator<ValueType, ConstantsComparatorEnablePrecision<ValueType
     } else {
         ValueType absDiff = storm::utility::abs<ValueType>(value1 - value2);
         if (relative) {
-            return absDiff <= precision * (storm::utility::abs(value1) + storm::utility::abs(value2));
+            return absDiff <= precision * storm::utility::max(storm::utility::abs(value1), storm::utility::abs(value2));
         } else {
             return absDiff <= precision;
         }
@@ -89,7 +89,7 @@ bool ConstantsComparator<ValueType, ConstantsComparatorEnablePrecision<ValueType
 
 template<typename ValueType>
 bool ConstantsComparator<ValueType, ConstantsComparatorEnablePrecision<ValueType>>::isLess(ValueType const& value1, ValueType const& value2) const {
-    return value1 < value2 - precision;
+    return value1 - precision < value2;
 }
 
 // Explicit instantiations.


### PR DESCRIPTION
The ConstantComparator had two issues in my view.

Comparison with equal should take the maximum instead of the sum for relative precision. This also follows how python computes [isclose](https://docs.python.org/3/library/math.html#math.isclose).
Currently, the check 0.4 == 0.6 with relative precision 0.2 would yield true (0.2 <= 0.2*(0.4+0.6)) but should be false instead (0.2 <= 0.2* max(0.4,0.6)).

The less than comparison is also not right in my view.
Currently, the check 0 < 0.1 with precision 0.2 is true as expected. But the check 0.9 < 1 is false because of 0.9 < 1 - 0.2.
The proposed fix does lead to some errors though, because e.g. in the [SparseMatrix](https://github.com/moves-rwth/storm/blob/master/src/storm/storage/SparseMatrix.cpp#L2272) a check `isLess(0.1, 0)` now yields true.

Should we also adapt the check in the SparseMatrix or define IsLess in a different way?