### PR TITLE
Reusable workflow for updating carl-storm version

### DIFF
--- a/.github/workflows/update_carl.yml
+++ b/.github/workflows/update_carl.yml
@@ -1,0 +1,48 @@
+name: Update carl-storm version
+
+on:
+  # needed to reuse the workflow from another one
+  workflow_call:
+    inputs:
+      carl_version:
+        description: 'Carl-storm version'
+        required: true
+        type: string
+        default: 'x.y'
+    secrets:
+      # needs permissions 'pull-request' and 'workflows'
+      personal_access_token:
+        required: true
+
+jobs:
+  update_storm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git clone
+        uses: actions/checkout@v5
+        with:
+          repository: moves-rwth/storm
+      - name: Update carl-storm version
+        run: |
+          # Update STORM_CARL_GIT_TAG
+          sed -i -E 's/STORM_CARL_GIT_TAG "(.*)" "[0-9]+\.[0-9]+"\)/STORM_CARL_GIT_TAG "\1" "${{ inputs.carl_version }}"\)/' CMakeLists.txt
+          # Update carl_tag
+          sed -i -E 's/ARG carl_tag="[0-9]+\.[0-9]+"/ARG carl_tag="${{ inputs.carl_version }}"/' Dockerfile
+          sed -i -E 's/ARG carl_tag="[0-9]+\.[0-9]+"/ARG carl_tag="${{ inputs.carl_version }}"/' .github/workflows/Dockerfile.archlinux
+      - name: Commit update
+        run: |
+          git diff
+          git config user.name 'Stormchecker bot'
+          git config user.email 'dev@stormchecker.org'
+          git commit -am "Use carl-storm ${{ inputs.carl_version }}"
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.personal_access_token }}
+          branch: ci/update-carl-storm
+          delete-branch: true
+          title: 'Update carl-storm ${{ inputs.carl_version }}'
+          body: |
+            Auto-generated pull request triggered by a new carl-storm version.
+            - Manually close and reopen this PR to trigger the CI.


### PR DESCRIPTION
Workflow can be externally triggered (from carl-storm) and then updates the carl-storm version and afterwards open a PR.
The carl-storm version is changed in the following places:
- `STORM_CARL_GIT_TAG` in `CMakeLists.txt`
- `carl_tag` in `Dockerfile`
- `carl_tag` in `.github/workflows/Dockerfile.archlinux`

Requires a personal access token with permissions for 'pull-request' and 'workflows'