### PR TITLE
CI: set development version of Storm after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release new version
 # Triggered by new a release on Github
 # - deploys Docker containers
 # - updates stable branch
-# - updates Storm version in stormpy
+# - updates Storm version in stormpy via PR
+# - sets Storm development version in Storm via PR
 
 # Needs personal access token CI_token with permissions 'pull-requests' and 'workflows'
 
@@ -55,3 +56,34 @@ jobs:
       storm_version: ${{ github.event.release.tag_name }}
     secrets:
       personal_access_token: ${{ secrets.CI_token }}
+
+  set_storm_dev:
+    # Update Storm version again to reflect fufure development version
+    needs: [deploy_docker, deploy_docker_stable]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git clone
+        uses: actions/checkout@v5
+        with:
+          repository: moves-rwth/storm
+          ref: master
+      - name: Set Storm dev version
+        run: |
+          # Add .1 suffix  to Storm version
+          sed -i -E 's/(\s+)VERSION ([0-9]+\.[0-9]+\.[0-9]+)\)/\1VERSION \2.1\)/' CMakeLists.txt
+      - name: Commit update
+        run: |
+          git diff
+          git config user.name 'Stormchecker bot'
+          git config user.email 'dev@stormchecker.org'
+          git commit -am "Set development version of Storm"
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: ci/storm-dev-version
+          delete-branch: true
+          title: 'Set development version of Storm'
+          body: |
+            Auto-generated pull request triggered by a new Storm version.
+            - Manually close and reopen this PR to trigger the CI.

--- a/doc/checklist_new_release.md
+++ b/doc/checklist_new_release.md
@@ -47,6 +47,7 @@ At this point, all relevant pull requests should have been merged into Storm and
    * updates the `stable` branch
    * creates new Docker containers for both the tag and `stable` branch
    * triggers a PR in stormpy to update the Storm version
+   * triggers a PR in Storm to set the development version of Storm again
 
 
 ## After the release


### PR DESCRIPTION
After a release of Storm, the CI triggers a PR which again adds the suffix `.1` to the Storm version to indicate the next development version.