### PR TITLE
Migrate to other Mac runners

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -298,21 +298,22 @@ jobs:
     strategy:
       matrix:
         config:
-          - {name: "XCode 14.3, Intel",
-             distro: "macos-13",
-             xcode: "14.3",
-             buildType: "Debug"
-            }
+          
           - {name: "XCode 15.4, ARM",
              distro: "macos-14",
              xcode: "15.4",
              buildType: "Debug"
             }
-          - {name: "XCode 16.3, ARM",
+          - {name: "XCode Latest, ARM",
              distro: "macos-15",
-             xcode: "16.3",
+             xcode: "latest-stable",
              buildType: "Debug"
             }
+          - {name: "XCode Latest, Intel",
+             distro: "macos-15-intel",
+             xcode: "latest-stable",
+             buildType: "Debug"
+            }  
     runs-on: ${{ matrix.config.distro }}
     steps:
       - uses: maxim-lobanov/setup-xcode@v1


### PR DESCRIPTION
Mac-13 is deprecated soon, migrating to mac-15-intel. Also update the xcode version to latest stable on the new version. I suggest to keep the old version for the older mac config to support a range of versions.