### PR TITLE
Modernize CTMC helpers

### DIFF
--- a/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.cpp
+++ b/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.cpp
@@ -58,7 +58,6 @@ std::unique_ptr<CheckResult> SparseCtmcCslModelChecker<SparseCtmcModelType>::com
         std::unique_ptr<CheckResult> leftResultPointer = this->check(env, pathFormula.getLeftSubformula());
         std::unique_ptr<CheckResult> rightResultPointer = this->check(env, pathFormula.getRightSubformula());
         ExplicitQualitativeCheckResult const& leftResult = leftResultPointer->asExplicitQualitativeCheckResult();
-        ;
         ExplicitQualitativeCheckResult const& rightResult = rightResultPointer->asExplicitQualitativeCheckResult();
 
         STORM_LOG_THROW(pathFormula.getTimeBoundReference().isTimeBound(), storm::exceptions::NotImplementedException,
@@ -271,7 +270,6 @@ std::vector<typename SparseCtmcModelType::ValueType> SparseCtmcCslModelChecker<S
         std::unique_ptr<CheckResult> leftResultPointer = this->check(env, pathFormula.getLeftSubformula());
         std::unique_ptr<CheckResult> rightResultPointer = this->check(env, pathFormula.getRightSubformula());
         ExplicitQualitativeCheckResult const& leftResult = leftResultPointer->asExplicitQualitativeCheckResult();
-        ;
         ExplicitQualitativeCheckResult const& rightResult = rightResultPointer->asExplicitQualitativeCheckResult();
 
         std::vector<ValueType> result = storm::modelchecker::helper::SparseCtmcCslHelper::computeAllTransientProbabilities(

--- a/src/storm/modelchecker/csl/helper/HybridCtmcCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/HybridCtmcCslHelper.cpp
@@ -61,11 +61,12 @@ std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeUntilProbabilities(Envi
                                                                                psiStates, qualitative);
 }
 
-template<storm::dd::DdType DdType, typename ValueType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
+template<storm::dd::DdType DdType, typename ValueType>
+    requires storm::NumberTraits<ValueType>::SupportsExponential
 std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeBoundedUntilProbabilities(
     Environment const& env, storm::models::symbolic::Ctmc<DdType, ValueType> const& model, bool onlyInitialStatesRelevant,
     storm::dd::Add<DdType, ValueType> const& rateMatrix, storm::dd::Add<DdType, ValueType> const& exitRateVector, storm::dd::Bdd<DdType> const& phiStates,
-    storm::dd::Bdd<DdType> const& psiStates, bool qualitative, double lowerBound, double upperBound) {
+    storm::dd::Bdd<DdType> const& psiStates, bool qualitative, ValueType lowerBound, ValueType upperBound) {
     // If the time bounds are [0, inf], we rather call untimed reachability.
     if (storm::utility::isZero(lowerBound) && upperBound == storm::utility::infinity<ValueType>()) {
         return computeUntilProbabilities(env, model, rateMatrix, exitRateVector, phiStates, psiStates, qualitative);
@@ -317,20 +318,12 @@ std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeBoundedUntilProbabiliti
     }
 }
 
-template<storm::dd::DdType DdType, typename ValueType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
-std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeBoundedUntilProbabilities(
-    Environment const& /*env*/, storm::models::symbolic::Ctmc<DdType, ValueType> const& /*model*/, bool /*onlyInitialStatesRelevant*/,
-    storm::dd::Add<DdType, ValueType> const& /*rateMatrix*/, storm::dd::Add<DdType, ValueType> const& /*exitRateVector*/,
-    storm::dd::Bdd<DdType> const& /*phiStates*/, storm::dd::Bdd<DdType> const& /*psiStates*/, bool /*qualitative*/, double /*lowerBound*/,
-    double /*upperBound*/) {
-    STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Computing bounded until probabilities is unsupported for this value type.");
-}
-
-template<storm::dd::DdType DdType, typename ValueType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
+template<storm::dd::DdType DdType, typename ValueType>
+    requires storm::NumberTraits<ValueType>::SupportsExponential
 std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeInstantaneousRewards(
     Environment const& env, storm::models::symbolic::Ctmc<DdType, ValueType> const& model, bool onlyInitialStatesRelevant,
     storm::dd::Add<DdType, ValueType> const& rateMatrix, storm::dd::Add<DdType, ValueType> const& exitRateVector,
-    typename storm::models::symbolic::Model<DdType, ValueType>::RewardModelType const& rewardModel, double timeBound) {
+    typename storm::models::symbolic::Model<DdType, ValueType>::RewardModelType const& rewardModel, ValueType timeBound) {
     // Only compute the result if the model has a state-based reward model.
     STORM_LOG_THROW(rewardModel.hasStateRewards(), storm::exceptions::InvalidPropertyException,
                     "Computing instantaneous rewards for a reward model that does not define any state-rewards. The result is trivially 0.");
@@ -389,19 +382,12 @@ std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeInstantaneousRewards(
                                                                                              model.getReachableStates(), odd, result));
 }
 
-template<storm::dd::DdType DdType, typename ValueType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
-std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeInstantaneousRewards(
-    Environment const& /*env*/, storm::models::symbolic::Ctmc<DdType, ValueType> const& /*model*/, bool /*onlyInitialStatesRelevant*/,
-    storm::dd::Add<DdType, ValueType> const& /*rateMatrix*/, storm::dd::Add<DdType, ValueType> const& /*exitRateVector*/,
-    typename storm::models::symbolic::Model<DdType, ValueType>::RewardModelType const& /*rewardModel*/, double /*timeBound*/) {
-    STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Computing instantaneous rewards is unsupported for this value type.");
-}
-
-template<storm::dd::DdType DdType, typename ValueType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
+template<storm::dd::DdType DdType, typename ValueType>
+    requires storm::NumberTraits<ValueType>::SupportsExponential
 std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeCumulativeRewards(
     Environment const& env, storm::models::symbolic::Ctmc<DdType, ValueType> const& model, bool onlyInitialStatesRelevant,
     storm::dd::Add<DdType, ValueType> const& rateMatrix, storm::dd::Add<DdType, ValueType> const& exitRateVector,
-    typename storm::models::symbolic::Model<DdType, ValueType>::RewardModelType const& rewardModel, double timeBound) {
+    typename storm::models::symbolic::Model<DdType, ValueType>::RewardModelType const& rewardModel, ValueType timeBound) {
     // Only compute the result if the model has a state-based reward model.
     STORM_LOG_THROW(!rewardModel.empty(), storm::exceptions::InvalidPropertyException, "Missing reward model for formula. Skipping formula.");
 
@@ -474,14 +460,6 @@ std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeCumulativeRewards(
     return std::unique_ptr<CheckResult>(new HybridQuantitativeCheckResult<DdType, ValueType>(model.getReachableStates(), model.getManager().getBddZero(),
                                                                                              model.getManager().template getAddZero<ValueType>(),
                                                                                              model.getReachableStates(), std::move(odd), std::move(result)));
-}
-
-template<storm::dd::DdType DdType, typename ValueType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
-std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeCumulativeRewards(
-    Environment const& /*env*/, storm::models::symbolic::Ctmc<DdType, ValueType> const& /*model*/, bool /*onlyInitialStatesRelevant*/,
-    storm::dd::Add<DdType, ValueType> const& /*rateMatrix*/, storm::dd::Add<DdType, ValueType> const& /*exitRateVector*/,
-    typename storm::models::symbolic::Model<DdType, ValueType>::RewardModelType const& /*rewardModel*/, double /*timeBound*/) {
-    STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Computing cumulative rewards is unsupported for this value type.");
 }
 
 template<storm::dd::DdType DdType, class ValueType>
@@ -584,21 +562,6 @@ template storm::dd::Add<storm::dd::DdType::Sylvan, double> HybridCtmcCslHelper::
     double uniformizationRate);
 
 // Sylvan, rational number.
-template std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeBoundedUntilProbabilities(
-    Environment const& env, storm::models::symbolic::Ctmc<storm::dd::DdType::Sylvan, storm::RationalNumber> const& model, bool onlyInitialStatesRelevant,
-    storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalNumber> const& rateMatrix,
-    storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalNumber> const& exitRateVector, storm::dd::Bdd<storm::dd::DdType::Sylvan> const& phiStates,
-    storm::dd::Bdd<storm::dd::DdType::Sylvan> const& psiStates, bool qualitative, double lowerBound, double upperBound);
-template std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeInstantaneousRewards(
-    Environment const& env, storm::models::symbolic::Ctmc<storm::dd::DdType::Sylvan, storm::RationalNumber> const& model, bool onlyInitialStatesRelevant,
-    storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalNumber> const& rateMatrix,
-    storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalNumber> const& exitRateVector,
-    typename storm::models::symbolic::Model<storm::dd::DdType::Sylvan, storm::RationalNumber>::RewardModelType const& rewardModel, double timeBound);
-template std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeCumulativeRewards(
-    Environment const& env, storm::models::symbolic::Ctmc<storm::dd::DdType::Sylvan, storm::RationalNumber> const& model, bool onlyInitialStatesRelevant,
-    storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalNumber> const& rateMatrix,
-    storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalNumber> const& exitRateVector,
-    typename storm::models::symbolic::Model<storm::dd::DdType::Sylvan, storm::RationalNumber>::RewardModelType const& rewardModel, double timeBound);
 template std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeUntilProbabilities(
     Environment const& env, storm::models::symbolic::Ctmc<storm::dd::DdType::Sylvan, storm::RationalNumber> const& model,
     storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalNumber> const& rateMatrix,
@@ -624,21 +587,6 @@ template storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalNumber> Hybrid
     storm::RationalNumber uniformizationRate);
 
 // Sylvan, rational function.
-template std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeBoundedUntilProbabilities(
-    Environment const& env, storm::models::symbolic::Ctmc<storm::dd::DdType::Sylvan, storm::RationalFunction> const& model, bool onlyInitialStatesRelevant,
-    storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalFunction> const& rateMatrix,
-    storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalFunction> const& exitRateVector, storm::dd::Bdd<storm::dd::DdType::Sylvan> const& phiStates,
-    storm::dd::Bdd<storm::dd::DdType::Sylvan> const& psiStates, bool qualitative, double lowerBound, double upperBound);
-template std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeInstantaneousRewards(
-    Environment const& env, storm::models::symbolic::Ctmc<storm::dd::DdType::Sylvan, storm::RationalFunction> const& model, bool onlyInitialStatesRelevant,
-    storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalFunction> const& rateMatrix,
-    storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalFunction> const& exitRateVector,
-    typename storm::models::symbolic::Model<storm::dd::DdType::Sylvan, storm::RationalFunction>::RewardModelType const& rewardModel, double timeBound);
-template std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeCumulativeRewards(
-    Environment const& env, storm::models::symbolic::Ctmc<storm::dd::DdType::Sylvan, storm::RationalFunction> const& model, bool onlyInitialStatesRelevant,
-    storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalFunction> const& rateMatrix,
-    storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalFunction> const& exitRateVector,
-    typename storm::models::symbolic::Model<storm::dd::DdType::Sylvan, storm::RationalFunction>::RewardModelType const& rewardModel, double timeBound);
 template std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeUntilProbabilities(
     Environment const& env, storm::models::symbolic::Ctmc<storm::dd::DdType::Sylvan, storm::RationalFunction> const& model,
     storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalFunction> const& rateMatrix,

--- a/src/storm/modelchecker/csl/helper/HybridCtmcCslHelper.h
+++ b/src/storm/modelchecker/csl/helper/HybridCtmcCslHelper.h
@@ -1,5 +1,4 @@
-#ifndef STORM_MODELCHECKER_HYBRID_CTMC_CSL_MODELCHECKER_HELPER_H_
-#define STORM_MODELCHECKER_HYBRID_CTMC_CSL_MODELCHECKER_HELPER_H_
+#pragma once
 
 #include <memory>
 
@@ -15,50 +14,32 @@ namespace storm {
 
 class Environment;
 
-namespace modelchecker {
-namespace helper {
+namespace modelchecker::helper {
 
 class HybridCtmcCslHelper {
    public:
-    template<storm::dd::DdType DdType, typename ValueType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
+    template<storm::dd::DdType DdType, typename ValueType>
+        requires storm::NumberTraits<ValueType>::SupportsExponential
     static std::unique_ptr<CheckResult> computeBoundedUntilProbabilities(Environment const& env, storm::models::symbolic::Ctmc<DdType, ValueType> const& model,
                                                                          bool onlyInitialStatesRelevant, storm::dd::Add<DdType, ValueType> const& rateMatrix,
                                                                          storm::dd::Add<DdType, ValueType> const& exitRateVector,
                                                                          storm::dd::Bdd<DdType> const& phiStates, storm::dd::Bdd<DdType> const& psiStates,
-                                                                         bool qualitative, double lowerBound, double upperBound);
+                                                                         bool qualitative, ValueType lowerBound, ValueType upperBound);
 
-    template<storm::dd::DdType DdType, typename ValueType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
-    static std::unique_ptr<CheckResult> computeBoundedUntilProbabilities(Environment const& env, storm::models::symbolic::Ctmc<DdType, ValueType> const& model,
-                                                                         bool onlyInitialStatesRelevant, storm::dd::Add<DdType, ValueType> const& rateMatrix,
-                                                                         storm::dd::Add<DdType, ValueType> const& exitRateVector,
-                                                                         storm::dd::Bdd<DdType> const& phiStates, storm::dd::Bdd<DdType> const& psiStates,
-                                                                         bool qualitative, double lowerBound, double upperBound);
-
-    template<storm::dd::DdType DdType, typename ValueType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
+    template<storm::dd::DdType DdType, typename ValueType>
+        requires storm::NumberTraits<ValueType>::SupportsExponential
     static std::unique_ptr<CheckResult> computeInstantaneousRewards(
         Environment const& env, storm::models::symbolic::Ctmc<DdType, ValueType> const& model, bool onlyInitialStatesRelevant,
         storm::dd::Add<DdType, ValueType> const& rateMatrix, storm::dd::Add<DdType, ValueType> const& exitRateVector,
-        typename storm::models::symbolic::Model<DdType, ValueType>::RewardModelType const& rewardModel, double timeBound);
+        typename storm::models::symbolic::Model<DdType, ValueType>::RewardModelType const& rewardModel, ValueType timeBound);
 
-    template<storm::dd::DdType DdType, typename ValueType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
-    static std::unique_ptr<CheckResult> computeInstantaneousRewards(
-        Environment const& env, storm::models::symbolic::Ctmc<DdType, ValueType> const& model, bool onlyInitialStatesRelevant,
-        storm::dd::Add<DdType, ValueType> const& rateMatrix, storm::dd::Add<DdType, ValueType> const& exitRateVector,
-        typename storm::models::symbolic::Model<DdType, ValueType>::RewardModelType const& rewardModel, double timeBound);
-
-    template<storm::dd::DdType DdType, typename ValueType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
+    template<storm::dd::DdType DdType, typename ValueType>
+        requires storm::NumberTraits<ValueType>::SupportsExponential
     static std::unique_ptr<CheckResult> computeCumulativeRewards(Environment const& env, storm::models::symbolic::Ctmc<DdType, ValueType> const& model,
                                                                  bool onlyInitialStatesRelevant, storm::dd::Add<DdType, ValueType> const& rateMatrix,
                                                                  storm::dd::Add<DdType, ValueType> const& exitRateVector,
                                                                  typename storm::models::symbolic::Model<DdType, ValueType>::RewardModelType const& rewardModel,
-                                                                 double timeBound);
-
-    template<storm::dd::DdType DdType, typename ValueType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
-    static std::unique_ptr<CheckResult> computeCumulativeRewards(Environment const& env, storm::models::symbolic::Ctmc<DdType, ValueType> const& model,
-                                                                 bool onlyInitialStatesRelevant, storm::dd::Add<DdType, ValueType> const& rateMatrix,
-                                                                 storm::dd::Add<DdType, ValueType> const& exitRateVector,
-                                                                 typename storm::models::symbolic::Model<DdType, ValueType>::RewardModelType const& rewardModel,
-                                                                 double timeBound);
+                                                                 ValueType timeBound);
 
     template<storm::dd::DdType DdType, typename ValueType>
     static std::unique_ptr<CheckResult> computeUntilProbabilities(Environment const& env, storm::models::symbolic::Ctmc<DdType, ValueType> const& model,
@@ -107,8 +88,5 @@ class HybridCtmcCslHelper {
                                                                       storm::dd::Bdd<DdType> const& maybeStates, ValueType uniformizationRate);
 };
 
-}  // namespace helper
-}  // namespace modelchecker
+}  // namespace modelchecker::helper
 }  // namespace storm
-
-#endif /* STORM_MODELCHECKER_HYBRID_CTMC_CSL_MODELCHECKER_HELPER_H_ */

--- a/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
@@ -66,11 +66,12 @@ bool SparseCtmcCslHelper::checkAndUpdateTransientProbabilityEpsilon(storm::Envir
     }
 }
 
-template<typename ValueType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
+template<typename ValueType>
+    requires storm::NumberTraits<ValueType>::SupportsExponential
 std::vector<ValueType> SparseCtmcCslHelper::computeBoundedUntilProbabilities(
     Environment const& env, storm::solver::SolveGoal<ValueType>&& goal, storm::storage::SparseMatrix<ValueType> const& rateMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
-    std::vector<ValueType> const& exitRates, bool qualitative, double lowerBound, double upperBound) {
+    std::vector<ValueType> const& exitRates, bool qualitative, ValueType lowerBound, ValueType upperBound) {
     STORM_LOG_THROW(!env.solver().isForceExact(), storm::exceptions::InvalidOperationException,
                     "Exact computations not possible for bounded until probabilities.");
 
@@ -265,15 +266,6 @@ std::vector<ValueType> SparseCtmcCslHelper::computeBoundedUntilProbabilities(
     return result;
 }
 
-template<typename ValueType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
-std::vector<ValueType> SparseCtmcCslHelper::computeBoundedUntilProbabilities(Environment const&, storm::solver::SolveGoal<ValueType>&&,
-                                                                             storm::storage::SparseMatrix<ValueType> const&,
-                                                                             storm::storage::SparseMatrix<ValueType> const&, storm::storage::BitVector const&,
-                                                                             storm::storage::BitVector const&, std::vector<ValueType> const&, bool, double,
-                                                                             double) {
-    STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Computing bounded until probabilities is unsupported for this value type.");
-}
-
 template<typename ValueType>
 std::vector<ValueType> SparseCtmcCslHelper::computeUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
                                                                       storm::storage::SparseMatrix<ValueType> const& rateMatrix,
@@ -302,11 +294,12 @@ std::vector<ValueType> SparseCtmcCslHelper::computeNextProbabilities(Environment
     return SparseDtmcPrctlHelper<ValueType>::computeNextProbabilities(env, computeProbabilityMatrix(rateMatrix, exitRateVector), nextStates);
 }
 
-template<typename ValueType, typename RewardModelType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
+template<typename ValueType, typename RewardModelType>
+    requires storm::NumberTraits<ValueType>::SupportsExponential
 std::vector<ValueType> SparseCtmcCslHelper::computeInstantaneousRewards(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
                                                                         storm::storage::SparseMatrix<ValueType> const& rateMatrix,
                                                                         std::vector<ValueType> const& exitRateVector, RewardModelType const& rewardModel,
-                                                                        double timeBound) {
+                                                                        ValueType timeBound) {
     // Only compute the result if the model has a state-based reward model.
     STORM_LOG_THROW(rewardModel.hasStateRewards(), storm::exceptions::InvalidPropertyException,
                     "Computing instantaneous rewards for a reward model that does not define any state-rewards. The result is trivially 0.");
@@ -362,18 +355,12 @@ std::vector<ValueType> SparseCtmcCslHelper::computeInstantaneousRewards(Environm
     return result;
 }
 
-template<typename ValueType, typename RewardModelType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
-std::vector<ValueType> SparseCtmcCslHelper::computeInstantaneousRewards(Environment const&, storm::solver::SolveGoal<ValueType>&&,
-                                                                        storm::storage::SparseMatrix<ValueType> const&, std::vector<ValueType> const&,
-                                                                        RewardModelType const&, double) {
-    STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Computing instantaneous rewards is unsupported for this value type.");
-}
-
-template<typename ValueType, typename RewardModelType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
+template<typename ValueType, typename RewardModelType>
+    requires storm::NumberTraits<ValueType>::SupportsExponential
 std::vector<ValueType> SparseCtmcCslHelper::computeCumulativeRewards(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
                                                                      storm::storage::SparseMatrix<ValueType> const& rateMatrix,
                                                                      std::vector<ValueType> const& exitRateVector, RewardModelType const& rewardModel,
-                                                                     double timeBound) {
+                                                                     ValueType timeBound) {
     STORM_LOG_THROW(!env.solver().isForceExact(), storm::exceptions::InvalidOperationException,
                     "Exact computations not possible for cumulative expected rewards.");
 
@@ -433,13 +420,6 @@ std::vector<ValueType> SparseCtmcCslHelper::computeCumulativeRewards(Environment
     } while (checkAndUpdateTransientProbabilityEpsilon(env, epsilon, result, relevantValues));
 
     return result;
-}
-
-template<typename ValueType, typename RewardModelType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
-std::vector<ValueType> SparseCtmcCslHelper::computeCumulativeRewards(Environment const&, storm::solver::SolveGoal<ValueType>&&,
-                                                                     storm::storage::SparseMatrix<ValueType> const&, std::vector<ValueType> const&,
-                                                                     RewardModelType const&, double) {
-    STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Computing cumulative rewards is unsupported for this value type.");
 }
 
 template<typename ValueType>
@@ -542,12 +522,13 @@ std::vector<ValueType> SparseCtmcCslHelper::computeTotalRewards(Environment cons
                                                                                               dtmcRewardModel, qualitative);
 }
 
-template<typename ValueType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
+template<typename ValueType>
+    requires storm::NumberTraits<ValueType>::SupportsExponential
 std::vector<ValueType> SparseCtmcCslHelper::computeAllTransientProbabilities(Environment const& env, storm::storage::SparseMatrix<ValueType> const& rateMatrix,
                                                                              storm::storage::BitVector const& initialStates,
                                                                              storm::storage::BitVector const& phiStates,
                                                                              storm::storage::BitVector const& psiStates,
-                                                                             std::vector<ValueType> const& exitRates, double timeBound) {
+                                                                             std::vector<ValueType> const& exitRates, ValueType timeBound) {
     // Compute transient probabilities going from initial state
     // Instead of y=Px we now compute y=xP <=> y^T=P^Tx^T via transposition
     uint_fast64_t numberOfStates = rateMatrix.getRowCount();
@@ -614,14 +595,8 @@ std::vector<ValueType> SparseCtmcCslHelper::computeAllTransientProbabilities(Env
     return result;
 }
 
-template<typename ValueType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
-std::vector<ValueType> SparseCtmcCslHelper::computeAllTransientProbabilities(Environment const&, storm::storage::SparseMatrix<ValueType> const&,
-                                                                             storm::storage::BitVector const&, storm::storage::BitVector const&,
-                                                                             storm::storage::BitVector const&, std::vector<ValueType> const&, double) {
-    STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Computing bounded until probabilities is unsupported for this value type.");
-}
-
-template<typename ValueType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
+template<typename ValueType>
+    requires storm::NumberTraits<ValueType>::SupportsExponential
 storm::storage::SparseMatrix<ValueType> SparseCtmcCslHelper::computeUniformizedMatrix(storm::storage::SparseMatrix<ValueType> const& rateMatrix,
                                                                                       storm::storage::BitVector const& maybeStates,
                                                                                       ValueType uniformizationRate, std::vector<ValueType> const& exitRates) {
@@ -650,7 +625,8 @@ storm::storage::SparseMatrix<ValueType> SparseCtmcCslHelper::computeUniformizedM
     return uniformizedMatrix;
 }
 
-template<typename ValueType, bool useMixedPoissonProbabilities, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type>
+template<typename ValueType, bool useMixedPoissonProbabilities>
+    requires storm::NumberTraits<ValueType>::SupportsExponential
 std::vector<ValueType> SparseCtmcCslHelper::computeTransientProbabilities(Environment const& env,
                                                                           storm::storage::SparseMatrix<ValueType> const& uniformizedMatrix,
                                                                           std::vector<ValueType> const* addVector, ValueType timeBound,
@@ -856,15 +832,6 @@ template std::vector<double> SparseCtmcCslHelper::computeTransientProbabilities(
                                                                                 double uniformizationRate, std::vector<double> values, double epsilon);
 
 #ifdef STORM_HAVE_CARL
-template std::vector<storm::RationalNumber> SparseCtmcCslHelper::computeBoundedUntilProbabilities(
-    Environment const& env, storm::solver::SolveGoal<storm::RationalNumber>&& goal, storm::storage::SparseMatrix<storm::RationalNumber> const& rateMatrix,
-    storm::storage::SparseMatrix<storm::RationalNumber> const& backwardTransitions, storm::storage::BitVector const& phiStates,
-    storm::storage::BitVector const& psiStates, std::vector<storm::RationalNumber> const& exitRates, bool qualitative, double lowerBound, double upperBound);
-template std::vector<storm::RationalFunction> SparseCtmcCslHelper::computeBoundedUntilProbabilities(
-    Environment const& env, storm::solver::SolveGoal<storm::RationalFunction>&& goal, storm::storage::SparseMatrix<storm::RationalFunction> const& rateMatrix,
-    storm::storage::SparseMatrix<storm::RationalFunction> const& backwardTransitions, storm::storage::BitVector const& phiStates,
-    storm::storage::BitVector const& psiStates, std::vector<storm::RationalFunction> const& exitRates, bool qualitative, double lowerBound, double upperBound);
-
 template std::vector<storm::RationalNumber> SparseCtmcCslHelper::computeUntilProbabilities(
     Environment const& env, storm::solver::SolveGoal<storm::RationalNumber>&& goal, storm::storage::SparseMatrix<storm::RationalNumber> const& rateMatrix,
     storm::storage::SparseMatrix<storm::RationalNumber> const& backwardTransitions, std::vector<storm::RationalNumber> const& exitRateVector,
@@ -890,15 +857,6 @@ template std::vector<storm::RationalNumber> SparseCtmcCslHelper::computeNextProb
 template std::vector<storm::RationalFunction> SparseCtmcCslHelper::computeNextProbabilities(
     Environment const& env, storm::storage::SparseMatrix<storm::RationalFunction> const& rateMatrix, std::vector<storm::RationalFunction> const& exitRateVector,
     storm::storage::BitVector const& nextStates);
-
-template std::vector<storm::RationalNumber> SparseCtmcCslHelper::computeInstantaneousRewards(
-    Environment const& env, storm::solver::SolveGoal<storm::RationalNumber>&& goal, storm::storage::SparseMatrix<storm::RationalNumber> const& rateMatrix,
-    std::vector<storm::RationalNumber> const& exitRateVector, storm::models::sparse::StandardRewardModel<storm::RationalNumber> const& rewardModel,
-    double timeBound);
-template std::vector<storm::RationalFunction> SparseCtmcCslHelper::computeInstantaneousRewards(
-    Environment const& env, storm::solver::SolveGoal<storm::RationalFunction>&& goal, storm::storage::SparseMatrix<storm::RationalFunction> const& rateMatrix,
-    std::vector<storm::RationalFunction> const& exitRateVector, storm::models::sparse::StandardRewardModel<storm::RationalFunction> const& rewardModel,
-    double timeBound);
 
 template std::vector<storm::RationalNumber> SparseCtmcCslHelper::computeReachabilityTimes(
     Environment const& env, storm::solver::SolveGoal<storm::RationalNumber>&& goal, storm::storage::SparseMatrix<storm::RationalNumber> const& rateMatrix,
@@ -926,24 +884,6 @@ template std::vector<storm::RationalFunction> SparseCtmcCslHelper::computeTotalR
     Environment const& env, storm::solver::SolveGoal<storm::RationalFunction>&& goal, storm::storage::SparseMatrix<storm::RationalFunction> const& rateMatrix,
     storm::storage::SparseMatrix<storm::RationalFunction> const& backwardTransitions, std::vector<storm::RationalFunction> const& exitRateVector,
     storm::models::sparse::StandardRewardModel<storm::RationalFunction> const& rewardModel, bool qualitative);
-
-template std::vector<storm::RationalNumber> SparseCtmcCslHelper::computeCumulativeRewards(
-    Environment const& env, storm::solver::SolveGoal<storm::RationalNumber>&& goal, storm::storage::SparseMatrix<storm::RationalNumber> const& rateMatrix,
-    std::vector<storm::RationalNumber> const& exitRateVector, storm::models::sparse::StandardRewardModel<storm::RationalNumber> const& rewardModel,
-    double timeBound);
-template std::vector<storm::RationalFunction> SparseCtmcCslHelper::computeCumulativeRewards(
-    Environment const& env, storm::solver::SolveGoal<storm::RationalFunction>&& goal, storm::storage::SparseMatrix<storm::RationalFunction> const& rateMatrix,
-    std::vector<storm::RationalFunction> const& exitRateVector, storm::models::sparse::StandardRewardModel<storm::RationalFunction> const& rewardModel,
-    double timeBound);
-
-template std::vector<storm::RationalNumber> SparseCtmcCslHelper::computeAllTransientProbabilities(
-    Environment const& env, storm::storage::SparseMatrix<storm::RationalNumber> const& rateMatrix, storm::storage::BitVector const& initialStates,
-    storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates, std::vector<storm::RationalNumber> const& exitRates,
-    double timeBound);
-template std::vector<storm::RationalFunction> SparseCtmcCslHelper::computeAllTransientProbabilities(
-    Environment const& env, storm::storage::SparseMatrix<storm::RationalFunction> const& rateMatrix, storm::storage::BitVector const& initialStates,
-    storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates, std::vector<storm::RationalFunction> const& exitRates,
-    double timeBound);
 
 template storm::storage::SparseMatrix<double> SparseCtmcCslHelper::computeProbabilityMatrix(storm::storage::SparseMatrix<double> const& rateMatrix,
                                                                                             std::vector<double> const& exitRates);

--- a/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.h
+++ b/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.h
@@ -1,5 +1,4 @@
-#ifndef STORM_MODELCHECKER_SPARSE_CTMC_CSL_MODELCHECKER_HELPER_H_
-#define STORM_MODELCHECKER_SPARSE_CTMC_CSL_MODELCHECKER_HELPER_H_
+#pragma once
 
 #include "storm/storage/BitVector.h"
 
@@ -15,29 +14,17 @@ namespace storm {
 
 class Environment;
 
-namespace storage {
-class StronglyConnectedComponent;
-}
-
-namespace modelchecker {
-namespace helper {
+namespace modelchecker::helper {
 class SparseCtmcCslHelper {
    public:
-    template<typename ValueType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
+    template<typename ValueType>
+        requires storm::NumberTraits<ValueType>::SupportsExponential
     static std::vector<ValueType> computeBoundedUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
                                                                    storm::storage::SparseMatrix<ValueType> const& rateMatrix,
                                                                    storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                    storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
-                                                                   std::vector<ValueType> const& exitRates, bool qualitative, double lowerBound,
-                                                                   double upperBound);
-
-    template<typename ValueType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
-    static std::vector<ValueType> computeBoundedUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
-                                                                   storm::storage::SparseMatrix<ValueType> const& rateMatrix,
-                                                                   storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                                   storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
-                                                                   std::vector<ValueType> const& exitRates, bool qualitative, double lowerBound,
-                                                                   double upperBound);
+                                                                   std::vector<ValueType> const& exitRates, bool qualitative, ValueType lowerBound,
+                                                                   ValueType upperBound);
 
     template<typename ValueType>
     static std::vector<ValueType> computeUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
@@ -56,27 +43,19 @@ class SparseCtmcCslHelper {
     static std::vector<ValueType> computeNextProbabilities(Environment const& env, storm::storage::SparseMatrix<ValueType> const& rateMatrix,
                                                            std::vector<ValueType> const& exitRateVector, storm::storage::BitVector const& nextStates);
 
-    template<typename ValueType, typename RewardModelType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
+    template<typename ValueType, typename RewardModelType>
+        requires storm::NumberTraits<ValueType>::SupportsExponential
     static std::vector<ValueType> computeInstantaneousRewards(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
                                                               storm::storage::SparseMatrix<ValueType> const& rateMatrix,
                                                               std::vector<ValueType> const& exitRateVector, RewardModelType const& rewardModel,
-                                                              double timeBound);
+                                                              ValueType timeBound);
 
-    template<typename ValueType, typename RewardModelType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
-    static std::vector<ValueType> computeInstantaneousRewards(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
-                                                              storm::storage::SparseMatrix<ValueType> const& rateMatrix,
-                                                              std::vector<ValueType> const& exitRateVector, RewardModelType const& rewardModel,
-                                                              double timeBound);
-
-    template<typename ValueType, typename RewardModelType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
+    template<typename ValueType, typename RewardModelType>
+        requires storm::NumberTraits<ValueType>::SupportsExponential
     static std::vector<ValueType> computeCumulativeRewards(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
                                                            storm::storage::SparseMatrix<ValueType> const& rateMatrix,
-                                                           std::vector<ValueType> const& exitRateVector, RewardModelType const& rewardModel, double timeBound);
-
-    template<typename ValueType, typename RewardModelType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
-    static std::vector<ValueType> computeCumulativeRewards(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
-                                                           storm::storage::SparseMatrix<ValueType> const& rateMatrix,
-                                                           std::vector<ValueType> const& exitRateVector, RewardModelType const& rewardModel, double timeBound);
+                                                           std::vector<ValueType> const& exitRateVector, RewardModelType const& rewardModel,
+                                                           ValueType timeBound);
 
     template<typename ValueType, typename RewardModelType>
     static std::vector<ValueType> computeReachabilityRewards(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
@@ -98,16 +77,12 @@ class SparseCtmcCslHelper {
                                                            std::vector<ValueType> const& exitRateVector, storm::storage::BitVector const& targetStates,
                                                            bool qualitative);
 
-    template<typename ValueType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
+    template<typename ValueType>
+        requires storm::NumberTraits<ValueType>::SupportsExponential
     static std::vector<ValueType> computeAllTransientProbabilities(Environment const& env, storm::storage::SparseMatrix<ValueType> const& rateMatrix,
                                                                    storm::storage::BitVector const& initialStates, storm::storage::BitVector const& phiStates,
                                                                    storm::storage::BitVector const& psiStates, std::vector<ValueType> const& exitRates,
-                                                                   double timeBound);
-    template<typename ValueType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
-    static std::vector<ValueType> computeAllTransientProbabilities(Environment const& env, storm::storage::SparseMatrix<ValueType> const& rateMatrix,
-                                                                   storm::storage::BitVector const& initialStates, storm::storage::BitVector const& phiStates,
-                                                                   storm::storage::BitVector const& psiStates, std::vector<ValueType> const& exitRates,
-                                                                   double timeBound);
+                                                                   ValueType timeBound);
 
     /*!
      * Computes the matrix representing the transitions of the uniformized CTMC.
@@ -118,7 +93,8 @@ class SparseCtmcCslHelper {
      * @param exitRates The exit rates of all states.
      * @return The uniformized matrix.
      */
-    template<typename ValueType, typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
+    template<typename ValueType>
+        requires storm::NumberTraits<ValueType>::SupportsExponential
     static storm::storage::SparseMatrix<ValueType> computeUniformizedMatrix(storm::storage::SparseMatrix<ValueType> const& rateMatrix,
                                                                             storm::storage::BitVector const& maybeStates, ValueType uniformizationRate,
                                                                             std::vector<ValueType> const& exitRates);
@@ -137,8 +113,8 @@ class SparseCtmcCslHelper {
      * poisson probabilities are used.
      * @return The vector of transient probabilities.
      */
-    template<typename ValueType, bool useMixedPoissonProbabilities = false,
-             typename std::enable_if<storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
+    template<typename ValueType, bool useMixedPoissonProbabilities = false>
+        requires storm::NumberTraits<ValueType>::SupportsExponential
     static std::vector<ValueType> computeTransientProbabilities(Environment const& env, storm::storage::SparseMatrix<ValueType> const& uniformizedMatrix,
                                                                 std::vector<ValueType> const* addVector, ValueType timeBound, ValueType uniformizationRate,
                                                                 std::vector<ValueType> values, ValueType epsilon);
@@ -176,8 +152,5 @@ class SparseCtmcCslHelper {
     static bool checkAndUpdateTransientProbabilityEpsilon(storm::Environment const& env, ValueType& epsilon, std::vector<ValueType> const& resultVector,
                                                           storm::storage::BitVector const& relevantPositions);
 };
-}  // namespace helper
-}  // namespace modelchecker
+}  // namespace modelchecker::helper
 }  // namespace storm
-
-#endif /* STORM_MODELCHECKER_SPARSE_CTMC_CSL_MODELCHECKER_HELPER_H_ */

--- a/src/test/storm/modelchecker/csl/CtmcCslModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/csl/CtmcCslModelCheckerTest.cpp
@@ -500,7 +500,7 @@ TEST(CtmcCslModelCheckerTest, TransientProbabilities) {
     storm::storage::BitVector psiStates(2);
     storm::Environment env;
     std::vector<double> result =
-        storm::modelchecker::helper::SparseCtmcCslHelper::computeAllTransientProbabilities(env, matrix, initialStates, phiStates, psiStates, exitRates, 1);
+        storm::modelchecker::helper::SparseCtmcCslHelper::computeAllTransientProbabilities(env, matrix, initialStates, phiStates, psiStates, exitRates, 1.0);
 
     EXPECT_NEAR(0.404043, result[0], 1e-6);
     EXPECT_NEAR(0.595957, result[1], 1e-6);


### PR DESCRIPTION
- use `requires` instead of `std::enable_if`
- Don't provide functions for unsupported `ValueType`s; use `constexpr if` on caller side instead.