### PR TITLE
Updated Dockerfile for Alpine

### DIFF
--- a/.github/workflows/Dockerfile.alpine
+++ b/.github/workflows/Dockerfile.alpine
@@ -6,7 +6,7 @@
 # --build-arg BASE_IMAGE=<new_base_image>
 
 # Set base image
-ARG BASE_IMAGE=alpine:latest
+ARG BASE_IMAGE=alpine:edge
 FROM $BASE_IMAGE
 LABEL org.opencontainers.image.authors="dev@stormchecker.org"
 
@@ -44,8 +44,6 @@ ARG cmake_args=""
 # Additional Alpine packages
 ARG packages=""
 
-RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
-RUN echo "@community https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 RUN apk add --no-cache \
     bash \
     cmake \
@@ -57,12 +55,13 @@ RUN apk add --no-cache \
     automake \
     libc-dev \
     linux-headers \
+    patch \
     boost-dev \
     gmp-dev \
-    cln-dev@testing \
-    ginac-dev@testing \
-    z3-dev@community \
-    glpk-dev@community \
+    cln-dev \
+    ginac-dev \
+    z3-dev \
+    glpk-dev \
     $packages
 
 

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -202,7 +202,7 @@ jobs:
               buildType: "Debug",
               Developer: "ON",
               cmakeArgs: "-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DSTORM_WARNING_AS_ERROR=ON",
-              packages: "patch", # Needed for gmm patch
+              packages: "",
               distro: "alpine"
             }
     steps:


### PR DESCRIPTION
Fixed Dockerfile for Alpine after recent failures in CI.

Use Docker tag `edge` instead of `latest`.
@sjunges Is this tag correct or should we use the latest release?

Packages `cln-dev` and `ginac-dev` are part of `community` now. Added `patch` packages into Dockerfile.