### PR TITLE
Only require MultiObjectiveSettings if needed

### DIFF
--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -430,6 +430,7 @@ inline std::pair<SymbolicInput, ModelProcessingInformation> preprocessSymbolicIn
     if (ioSettings.isPropertiesAsMultiSet()) {
         STORM_LOG_THROW(!input.properties.empty(), storm::exceptions::InvalidArgumentException,
                         "Can not translate properties to multi-objective formula because no properties were specified.");
+        // If we come from storm-pars, the following fails as multiObjectiveSettings are not loaded
         auto multiObjSettings = storm::settings::getModule<storm::settings::modules::MultiObjectiveSettings>();
         output.properties = {storm::api::createMultiObjectiveProperty(output.properties, multiObjSettings.isLexicographicModelCheckingSet())};
     }


### PR DESCRIPTION
Running `storm-pars` lead to an error `Cannot retrieve unknown module 'multiobjective'.`. This is fixed now by only requiring the setting if needed. There might be a more elegant solution though.

Was introduced with https://github.com/moves-rwth/storm/pull/805