### PR TITLE
Remove eigen from Dockerfile.archlinux

### DIFF
--- a/.github/workflows/Dockerfile.archlinux
+++ b/.github/workflows/Dockerfile.archlinux
@@ -54,7 +54,6 @@ RUN pacman -S --noconfirm \
         git \
         boost \
         cln \
-        eigen \
         ginac \
         glpk \
         gmp \


### PR DESCRIPTION
Removed 'eigen' from the list of installed packages on arch, relates to #865 