### PR TITLE
Revised check for probabilistic transition matrix

### DIFF
--- a/src/storm/models/sparse/Model.cpp
+++ b/src/storm/models/sparse/Model.cpp
@@ -66,9 +66,6 @@ void Model<ValueType, RewardModelType>::assertValidityOfComponents(
     STORM_LOG_ASSERT(
         components.rateTransitions || this->hasParameters() || this->hasUncertainty() || this->getTransitionMatrix().isProbabilistic(stochasticTolerance),
         "The matrix is not probabilistic.");
-    if (this->hasUncertainty()) {
-        STORM_LOG_ASSERT(this->getTransitionMatrix().hasOnlyPositiveEntries(), "Not all entries are (strictly) positive.");
-    }
     STORM_LOG_THROW(this->getStateLabeling().getNumberOfItems() == stateCount, storm::exceptions::IllegalArgumentException,
                     "Invalid item count (" << this->getStateLabeling().getNumberOfItems() << ") of state labeling (states: " << stateCount << ").");
     for (auto const& rewardModel : this->getRewardModels()) {

--- a/src/storm/models/sparse/Model.cpp
+++ b/src/storm/models/sparse/Model.cpp
@@ -65,9 +65,8 @@ void Model<ValueType, RewardModelType>::assertValidityOfComponents(
                     "Invalid column count of transition matrix.");
     {
         std::string reasonNotProbabilistic [[maybe_unused]];
-        STORM_LOG_ASSERT(
-            components.rateTransitions || this->hasParameters() || this->getTransitionMatrix().isProbabilistic(stochasticTolerance, reasonNotProbabilistic),
-            "The matrix is not probabilistic. " << reasonNotProbabilistic);
+        STORM_LOG_ASSERT(components.rateTransitions || this->getTransitionMatrix().isProbabilistic(stochasticTolerance, reasonNotProbabilistic),
+                         "The matrix is not probabilistic. " << reasonNotProbabilistic);
     }
     STORM_LOG_THROW(this->getStateLabeling().getNumberOfItems() == stateCount, storm::exceptions::IllegalArgumentException,
                     "Invalid item count (" << this->getStateLabeling().getNumberOfItems() << ") of state labeling (states: " << stateCount << ").");

--- a/src/storm/models/sparse/Model.cpp
+++ b/src/storm/models/sparse/Model.cpp
@@ -63,9 +63,12 @@ void Model<ValueType, RewardModelType>::assertValidityOfComponents(
     // general components for all model types.
     STORM_LOG_THROW(this->getTransitionMatrix().getColumnCount() == stateCount, storm::exceptions::IllegalArgumentException,
                     "Invalid column count of transition matrix.");
-    STORM_LOG_ASSERT(
-        components.rateTransitions || this->hasParameters() || this->hasUncertainty() || this->getTransitionMatrix().isProbabilistic(stochasticTolerance),
-        "The matrix is not probabilistic.");
+    {
+        std::string reasonNotProbabilistic [[maybe_unused]];
+        STORM_LOG_ASSERT(
+            components.rateTransitions || this->hasParameters() || this->getTransitionMatrix().isProbabilistic(stochasticTolerance, reasonNotProbabilistic),
+            "The matrix is not probabilistic. " << reasonNotProbabilistic);
+    }
     STORM_LOG_THROW(this->getStateLabeling().getNumberOfItems() == stateCount, storm::exceptions::IllegalArgumentException,
                     "Invalid item count (" << this->getStateLabeling().getNumberOfItems() << ") of state labeling (states: " << stateCount << ").");
     for (auto const& rewardModel : this->getRewardModels()) {

--- a/src/storm/storage/SparseMatrix.cpp
+++ b/src/storm/storage/SparseMatrix.cpp
@@ -2267,6 +2267,8 @@ bool SparseMatrix<ValueType>::isProbabilistic(ValueType const& tolerance, storm:
     BaseType const oneMinusTolerance = storm::utility::one<BaseType>() - toBaseType(tolerance);
 
     auto isContained = [&toBaseType](ValueType const& value, BaseType const& lower, BaseType const& upper) {
+        // surpress unused lambda capture warning for toBaseType in case it is not needed for the given ValueType.
+        (void)toBaseType;
         if constexpr (storm::IsIntervalType<ValueType>) {
             // check if the interval contains some value in [lower,upper]
             return value.lower() <= upper && value.upper() >= lower;

--- a/src/storm/storage/SparseMatrix.cpp
+++ b/src/storm/storage/SparseMatrix.cpp
@@ -2251,19 +2251,62 @@ typename SparseMatrix<ValueType>::index_type SparseMatrix<ValueType>::getNoncons
 }
 
 template<typename ValueType>
-bool SparseMatrix<ValueType>::isProbabilistic(ValueType const& tolerance) const {
-    storm::utility::ConstantsComparator<ValueType> comparator(tolerance);
-    for (index_type row = 0; row < this->rowCount; ++row) {
-        auto rowSum = getRowSum(row);
-        if (!comparator.isOne(rowSum)) {
-            return false;
+bool SparseMatrix<ValueType>::isProbabilistic(ValueType const& tolerance, storm::OptionalRef<std::string> reason) const {
+    using BaseType =
+        std::conditional_t<std::is_same_v<ValueType, storm::RationalFunction>, storm::RationalFunctionCoefficient, storm::IntervalBaseType<ValueType>>;
+    auto toBaseType = [](ValueType const& value) {
+        if constexpr (std::is_same_v<ValueType, BaseType>) {
+            return value;
+        } else {
+            return storm::utility::convertNumber<BaseType>(value);
         }
-    }
-    for (auto const& entry : *this) {
-        if (storm::utility::isConstant(entry.getValue())) {
-            if (!storm::utility::isNonNegative(entry.getValue())) {
+    };
+    STORM_LOG_ASSERT(storm::utility::isConstant(tolerance), "Expected constant tolerance. Got " << tolerance);
+    BaseType const zeroMinusTolerance = storm::utility::zero<BaseType>() - toBaseType(tolerance);
+    BaseType const onePlusTolerance = storm::utility::one<BaseType>() + toBaseType(tolerance);
+    BaseType const oneMinusTolerance = storm::utility::one<BaseType>() - toBaseType(tolerance);
+
+    auto isContained = [&toBaseType](ValueType const& value, BaseType const& lower, BaseType const& upper) {
+        if constexpr (storm::IsIntervalType<ValueType>) {
+            // check if the interval contains some value in [lower,upper]
+            return value.lower() <= upper && value.upper() >= lower;
+        } else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) {
+            // for rational functions, we only perform a check if the value is constant.
+            if (storm::utility::isConstant(value)) {
+                auto const constValue = toBaseType(value);
+                return constValue <= upper && constValue >= lower;
+            }
+            return true;
+        } else {
+            // in all other cases, we expect the value to be constant
+            STORM_LOG_ASSERT(storm::utility::isConstant(value), "Expected constant value. Got " << value);
+            return value <= upper && value >= lower;
+        }
+    };
+
+    auto toString = [](ValueType const& value) {
+        std::stringstream s;
+        s << value;
+        return s.str();
+    };
+
+    for (index_type row = 0; row < this->rowCount; ++row) {
+        auto rowSum = storm::utility::zero<ValueType>();
+        for (auto const& entry : getRow(row)) {
+            if (!isContained(entry.getValue(), zeroMinusTolerance, onePlusTolerance)) {
+                if (reason) {
+                    *reason = "Entry in row " + std::to_string(row) + " is not a probability: " + toString(entry.getValue());
+                }
                 return false;
             }
+            rowSum += entry.getValue();
+        }
+        if (!isContained(rowSum, oneMinusTolerance, onePlusTolerance)) {
+            if (reason) {
+                // print sum-1 to ensure that the reason is informative even if the sum is very close to one.
+                *reason = "Sum of entries in row " + std::to_string(row) + " is not one: sum-1=" + toString(rowSum - storm::utility::one<ValueType>());
+            }
+            return false;
         }
     }
     return true;

--- a/src/storm/storage/SparseMatrix.h
+++ b/src/storm/storage/SparseMatrix.h
@@ -14,6 +14,7 @@
 #include "storm/storage/BitVector.h"
 #include "storm/storage/sparse/StateType.h"
 
+#include "storm/utility/OptionalRef.h"
 #include "storm/utility/constants.h"
 
 // Forward declaration for adapter classes.
@@ -1016,9 +1017,13 @@ class SparseMatrix {
     index_type getNonconstantRowGroupCount() const;
 
     /*!
-     * Checks for each row whether it sums to one.
+     * Checks for each row whether (i) each entry is between zero and one and (ii) all entries sum to one.
+     * For interval models, we check if each interval contains a value between zero and one and if the sum contains one.
+     * For rational functions, we only do these checks if they are constant, i.e., do not contain any parameter.
+     * @param tolerance The tolerance used when comparing values to zero and one.
+     * @param reason if the matrix is not probabilistic, this string will be filled with a human-readable explanation of why the matrix is not probabilistic.
      */
-    bool isProbabilistic(ValueType const& tolerance) const;
+    bool isProbabilistic(ValueType const& tolerance, storm::OptionalRef<std::string> reason = {}) const;
 
     /*!
      * Checks whether each present entry is strictly positive (omitted entries are not considered).

--- a/src/test/storm/storage/SparseMatrixTest.cpp
+++ b/src/test/storm/storage/SparseMatrixTest.cpp
@@ -992,3 +992,23 @@ TEST(SparseMatrix, DropZeroEntries) {
     ASSERT_TRUE(matrixX == matrix4);
     ASSERT_FALSE(matrixX.getEntryCount() == matrix4.getEntryCount());
 }
+
+TEST(SparseMatrix, isProbabilistic) {
+    storm::storage::SparseMatrixBuilder<double> builder(4, 4, 7, true);
+    ASSERT_NO_THROW(builder.addNextValue(0, 1, storm::utility::sqrt(2.0)));
+    ASSERT_NO_THROW(builder.addNextValue(0, 2, 1.0 - storm::utility::sqrt(2.0)));
+    ASSERT_NO_THROW(builder.addNextValue(1, 2, storm::utility::sqrt(2.0)));
+    ASSERT_NO_THROW(builder.addNextValue(1, 3, 1.0 - storm::utility::sqrt(2.0)));
+    ASSERT_NO_THROW(builder.addNextValue(2, 0, storm::utility::sqrt(2.0)));
+    ASSERT_NO_THROW(builder.addNextValue(2, 3, 1.0 - storm::utility::sqrt(2.0)));
+    ASSERT_NO_THROW(builder.addNextValue(3, 3, 1.0));
+    storm::storage::SparseMatrix<double> matrix;
+    ASSERT_NO_THROW(matrix = builder.build());
+    std::string reason;
+    ASSERT_FALSE(matrix.isProbabilistic(0.0, reason)) << reason;
+    ASSERT_TRUE(matrix.isProbabilistic(0.5, reason)) << reason;
+    for (auto& entry : matrix) {
+        entry.setValue(storm::utility::abs(entry.getValue()) / 2.0);
+    }
+    ASSERT_FALSE(matrix.isProbabilistic(0, reason)) << reason;
+}


### PR DESCRIPTION
Intervals like [0,0.4] should not be disallowed on a global level.
