### PR TITLE
unif+: correctly handle Markov automata with non-Markovian initial states

### DIFF
--- a/resources/examples/testfiles/ma/erlang.ma
+++ b/resources/examples/testfiles/ma/erlang.ma
@@ -1,0 +1,23 @@
+ma
+
+const int K=2;
+const double R=7;
+
+module erlang
+	s : [0..6];
+	// s=5 sink
+	// s=6 done
+	chainStage : [0..K-1];
+
+	[goToChain] s=0 -> 1 : (s'=1);
+	<> s=1 -> 1 : (s'=2);
+	<> s=2 & chainStage<K-1 -> R: (chainStage' = chainStage+1);
+	<> s=2 & chainStage=K-1 -> R: (s' = 6);
+	[goToProbs] s=0 -> 1 : (s'=3);
+	<> s=3 -> 1 : (s'=4);
+	<> s=4 -> 0.5 : (s'=6) + 0.5: (s'=5);
+	<> s=5 -> true;
+	<> s=6 -> true;
+endmodule
+
+label "done" = (s=6);

--- a/src/storm/modelchecker/csl/helper/SparseMarkovAutomatonCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/SparseMarkovAutomatonCslHelper.cpp
@@ -98,7 +98,7 @@ class UnifPlusHelper {
             } else {
                 relevantMaybeStates = relevantStates.get() % maybeStates;
             }
-            relevantMarkovianMaybeStates = *relevantMaybeStates & markovianStatesModMaybeStates;
+            relevantMarkovianMaybeStates = relevantMaybeStates.get() & markovianStatesModMaybeStates;
         } else {
             relevantMarkovianMaybeStates = markovianStatesModMaybeStates;
         }
@@ -325,11 +325,11 @@ class UnifPlusHelper {
 
         if (abortedInnerIterations && iteration > 1 && relevantMaybeStates && relevantStates) {
             // We should take the stored solution instead of the current (probably more incorrect) lower/upper values
-            storm::utility::vector::setVectorValues(result, *relevantMaybeStates, bestKnownSolution);
+            storm::utility::vector::setVectorValues(result, relevantMaybeStates.get(), bestKnownSolution);
         } else {
             // Set the values for Markovian "maybe" states
             STORM_LOG_ASSERT(markovianMaybeStates.getNumberOfSetBits() == markovianStatesModMaybeStates.getNumberOfSetBits(),
-                             "unexpected number of Markovian maybe states");
+                             "Unexpected number of Markovian maybe states");
             auto subStateIt = markovianStatesModMaybeStates.begin();
             for (auto const markovianState : markovianMaybeStates) {
                 result[markovianState] = (maybeStatesValuesLower[*subStateIt] + maybeStatesValuesUpper[*subStateIt]) / two;

--- a/src/storm/modelchecker/csl/helper/SparseMarkovAutomatonCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/SparseMarkovAutomatonCslHelper.cpp
@@ -88,13 +88,24 @@ class UnifPlusHelper {
         }
 
         boost::optional<storm::storage::BitVector> relevantMaybeStates;
+        storm::storage::BitVector relevantMarkovianMaybeStates;
         if (relevantStates) {
-            relevantMaybeStates = relevantStates.get() % maybeStates;
+            if (!relevantStates->isSubsetOf(markovianStates)) {
+                // Enhance the relevant states to also include Markovian states that are reachable in zero time from relevant probabilistic states
+                auto const enhancedRelevantStates =
+                    storm::utility::graph::getReachableStates(transitionMatrix, *relevantStates, ~markovianStates, markovianStates);
+                relevantMaybeStates = enhancedRelevantStates % maybeStates;
+            } else {
+                relevantMaybeStates = relevantStates.get() % maybeStates;
+            }
+            relevantMarkovianMaybeStates = *relevantMaybeStates & markovianStatesModMaybeStates;
+        } else {
+            relevantMarkovianMaybeStates = markovianStatesModMaybeStates;
         }
         // Store the best solution known so far (useful in cases where the computation gets aborted)
         std::vector<ValueType> bestKnownSolution;
         if (relevantMaybeStates) {
-            bestKnownSolution.resize(relevantStates->size());
+            bestKnownSolution.resize(relevantMaybeStates->getNumberOfSetBits());
         }
 
         // Get the exit rates restricted to only markovian maybe states.
@@ -257,7 +268,7 @@ class UnifPlusHelper {
                 }
 
                 // Check if the lower and upper bound are sufficiently close to each other
-                converged = checkConvergence(maybeStatesValuesLower, maybeStatesValuesUpper, relevantMaybeStates, epsilon, relativePrecision, kappa);
+                converged = checkConvergence(maybeStatesValuesLower, maybeStatesValuesUpper, relevantMarkovianMaybeStates, epsilon, relativePrecision, kappa);
                 if (converged) {
                     break;
                 }
@@ -309,42 +320,50 @@ class UnifPlusHelper {
 
         // Prepare the result vector
         std::vector<ValueType> result(transitionMatrix.getRowGroupCount(), storm::utility::zero<ValueType>());
+        // Set values of target states to 1
         storm::utility::vector::setVectorValues(result, psiStates, storm::utility::one<ValueType>());
 
         if (abortedInnerIterations && iteration > 1 && relevantMaybeStates && relevantStates) {
             // We should take the stored solution instead of the current (probably more incorrect) lower/upper values
-            storm::utility::vector::setVectorValues(result, maybeStates & relevantStates.get(), bestKnownSolution);
+            storm::utility::vector::setVectorValues(result, *relevantMaybeStates, bestKnownSolution);
         } else {
-            // We take the average of the lower and upper bounds
-            storm::utility::vector::applyPointwise<ValueType, ValueType, ValueType>(
-                maybeStatesValuesLower, maybeStatesValuesUpper, maybeStatesValuesLower,
-                [&two](ValueType const& a, ValueType const& b) -> ValueType { return (a + b) / two; });
-
-            storm::utility::vector::setVectorValues(result, maybeStates, maybeStatesValuesLower);
+            // Set the values for Markovian "maybe" states
+            STORM_LOG_ASSERT(markovianMaybeStates.getNumberOfSetBits() == markovianStatesModMaybeStates.getNumberOfSetBits(),
+                             "unexpected number of Markovian maybe states");
+            auto subStateIt = markovianStatesModMaybeStates.begin();
+            for (auto const markovianState : markovianMaybeStates) {
+                result[markovianState] = (maybeStatesValuesLower[*subStateIt] + maybeStatesValuesUpper[*subStateIt]) / two;
+                ++subStateIt;
+            }
+            // At this point, we only need to set the values for probabilistic "maybe" states.
+            // We derive the values from the values of the other states, which are reached in zero time.
+            uint64_t probSubState = 0;
+            for (auto const probabilisticState : probabilisticMaybeStates) {
+                for (auto const probStateRow : transitionMatrix.getRowGroupIndices(probabilisticState)) {
+                    eqSysRhs[probSubState] = transitionMatrix.multiplyRowWithVector(probStateRow, result);
+                    ++probSubState;
+                }
+            }
+            if (solver) {
+                solver->solveEquations(solverEnv, dir, nextProbabilisticStateValues, eqSysRhs);
+            } else {
+                storm::utility::vector::reduceVectorMinOrMax(dir, eqSysRhs, nextProbabilisticStateValues,
+                                                             probabilisticToProbabilisticTransitions.getRowGroupIndices());
+            }
+            storm::utility::vector::setVectorValues(result, probabilisticMaybeStates, nextProbabilisticStateValues);
         }
         return result;
     }
 
    private:
-    bool checkConvergence(std::vector<ValueType> const& lower, std::vector<ValueType> const& upper,
-                          boost::optional<storm::storage::BitVector> const& relevantValues, ValueType const& epsilon, bool relative, ValueType& kappa) {
-        STORM_LOG_ASSERT(!relevantValues.is_initialized() || relevantValues->size() == lower.size(), "Relevant values size mismatch.");
+    bool checkConvergence(std::vector<ValueType> const& lower, std::vector<ValueType> const& upper, storm::storage::BitVector const& relevantValues,
+                          ValueType const& epsilon, bool relative, ValueType& kappa) {
+        STORM_LOG_ASSERT(relevantValues.size() == lower.size(), "Relevant values size mismatch.");
         if (!relative) {
-            if (relevantValues) {
-                return storm::utility::vector::equalModuloPrecision(lower, upper, relevantValues.get(), epsilon * (storm::utility::one<ValueType>() - kappa),
-                                                                    false);
-            } else {
-                return storm::utility::vector::equalModuloPrecision(lower, upper, epsilon * (storm::utility::one<ValueType>() - kappa), false);
-            }
+            return storm::utility::vector::equalModuloPrecision(lower, upper, relevantValues, epsilon * (storm::utility::one<ValueType>() - kappa), false);
         }
         ValueType truncationError = epsilon * kappa;
-        for (uint64_t i = 0; i < lower.size(); ++i) {
-            if (relevantValues) {
-                i = relevantValues->getNextSetIndex(i);
-                if (i == lower.size()) {
-                    break;
-                }
-            }
+        for (uint64_t const i : relevantValues) {
             if (lower[i] == upper[i]) {
                 continue;
             }

--- a/src/test/storm/modelchecker/csl/MarkovAutomatonCslModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/csl/MarkovAutomatonCslModelCheckerTest.cpp
@@ -369,6 +369,31 @@ TYPED_TEST(MarkovAutomatonCslModelCheckerTest, simple2) {
     EXPECT_NEAR(this->parseNumber("27"), this->getQuantitativeResultAtInitialState(model, result), this->precision());
 }
 
+TYPED_TEST(MarkovAutomatonCslModelCheckerTest, erlang) {
+    std::string formulasString = "Pmin=?[F<=1 \"done\"]";
+    formulasString += "; Pmax=?[F<=1 \"done\"]";
+
+    auto modelFormulas = this->buildModelFormulas(STORM_TEST_RESOURCES_DIR "/ma/erlang.ma", formulasString);
+    auto model = std::move(modelFormulas.first);
+    auto tasks = this->getTasks(modelFormulas.second);
+    this->execute(model, [&]() {
+        EXPECT_EQ(9ul, model->getNumberOfStates());
+        EXPECT_EQ(11ul, model->getNumberOfTransitions());
+        EXPECT_EQ(10ul, model->getNumberOfChoices());
+        ASSERT_EQ(model->getType(), storm::models::ModelType::MarkovAutomaton);
+        auto checker = this->createModelChecker(model);
+        std::unique_ptr<storm::modelchecker::CheckResult> result;
+
+        if (!storm::utility::isZero(this->precision())) {
+            result = checker->check(this->env(), tasks[0]);
+            EXPECT_NEAR(this->parseNumber("0.13212055882856"), this->getQuantitativeResultAtInitialState(model, result), this->precision());
+
+            result = checker->check(this->env(), tasks[1]);
+            EXPECT_NEAR(this->parseNumber("0.50066835807513"), this->getQuantitativeResultAtInitialState(model, result), this->precision());
+        }
+    });
+}
+
 TYPED_TEST(MarkovAutomatonCslModelCheckerTest, LtlSimple) {
 #ifdef STORM_HAVE_LTL_MODELCHECKING_SUPPORT
     std::string formulasString = "Pmax=? [X X s=3]";


### PR DESCRIPTION
Fixes #897