### PR TITLE
Fix compilation on recent clang

### DIFF
--- a/src/storm/builder/BuilderType.cpp
+++ b/src/storm/builder/BuilderType.cpp
@@ -30,7 +30,7 @@ storm::jani::ModelFeatures getSupportedJaniFeatures(BuilderType const& builderTy
 
 template<typename ValueType>
 bool canHandle(BuilderType const& builderType, storm::storage::SymbolicModelDescription const& modelDescription,
-               boost::optional<std::vector<storm::jani::Property>> const& properties) {
+               storm::OptionalRef<std::vector<storm::jani::Property> const> properties) {
     storm::dd::DdType const ddType = storm::dd::DdType::Sylvan;
     if (!modelDescription.hasModel()) {
         // If there is no model to be build, we assume that the task of obtaining a model is either not required or can be accomplished somehow.
@@ -57,11 +57,11 @@ bool canHandle(BuilderType const& builderType, storm::storage::SymbolicModelDesc
 }
 
 template bool canHandle<double>(BuilderType const& builderType, storm::storage::SymbolicModelDescription const& modelDescription,
-                                boost::optional<std::vector<storm::jani::Property>> const& properties);
+                                storm::OptionalRef<std::vector<storm::jani::Property> const> properties);
 template bool canHandle<storm::RationalNumber>(BuilderType const& builderType, storm::storage::SymbolicModelDescription const& modelDescription,
-                                               boost::optional<std::vector<storm::jani::Property>> const& properties);
+                                               storm::OptionalRef<std::vector<storm::jani::Property> const> properties);
 template bool canHandle<storm::RationalFunction>(BuilderType const& builderType, storm::storage::SymbolicModelDescription const& modelDescription,
-                                                 boost::optional<std::vector<storm::jani::Property>> const& properties);
+                                                 storm::OptionalRef<std::vector<storm::jani::Property> const> properties);
 
 }  // namespace builder
 }  // namespace storm

--- a/src/storm/builder/BuilderType.h
+++ b/src/storm/builder/BuilderType.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <boost/optional.hpp>
 #include <vector>
+
+#include "storm/utility/OptionalRef.h"
 
 namespace storm {
 namespace storage {
@@ -19,6 +20,6 @@ storm::jani::ModelFeatures getSupportedJaniFeatures(BuilderType const& builderTy
 
 template<typename ValueType>
 bool canHandle(BuilderType const& builderType, storm::storage::SymbolicModelDescription const& modelDescription,
-               boost::optional<std::vector<storm::jani::Property>> const& properties = boost::none);
+               storm::OptionalRef<std::vector<storm::jani::Property> const> properties = storm::NullRef);
 }  // namespace builder
 }  // namespace storm

--- a/src/storm/builder/DdJaniModelBuilder.cpp
+++ b/src/storm/builder/DdJaniModelBuilder.cpp
@@ -51,7 +51,7 @@ storm::jani::ModelFeatures DdJaniModelBuilder<Type, ValueType>::getSupportedJani
 }
 
 template<storm::dd::DdType Type, typename ValueType>
-bool DdJaniModelBuilder<Type, ValueType>::canHandle(storm::jani::Model const& model, boost::optional<std::vector<storm::jani::Property>> const& properties) {
+bool DdJaniModelBuilder<Type, ValueType>::canHandle(storm::jani::Model const& model, storm::OptionalRef<std::vector<storm::jani::Property> const> properties) {
     // Check jani features
     auto features = model.getModelFeatures();
     features.remove(storm::jani::ModelFeature::Arrays);  // can be substituted
@@ -71,7 +71,7 @@ bool DdJaniModelBuilder<Type, ValueType>::canHandle(storm::jani::Model const& mo
     // Check nonTrivial reward expressions
     if (properties) {
         std::set<std::string> rewardModels;
-        for (auto const& p : properties.get()) {
+        for (auto const& p : properties.value()) {
             p.gatherReferencedRewardModels(rewardModels);
         }
         for (auto const& r : rewardModels) {

--- a/src/storm/builder/DdJaniModelBuilder.h
+++ b/src/storm/builder/DdJaniModelBuilder.h
@@ -5,6 +5,7 @@
 #include "storm/storage/dd/DdType.h"
 #include "storm/storage/expressions/Variable.h"
 #include "storm/storage/jani/Property.h"
+#include "storm/utility/OptionalRef.h"
 
 #include "storm/builder/TerminalStatesGetter.h"
 #include "storm/logic/Formula.h"
@@ -36,7 +37,7 @@ class DdJaniModelBuilder {
      * This method only over-approximates the set of models that can be handled, i.e., if this
      * returns true, the model might still be unsupported.
      */
-    static bool canHandle(storm::jani::Model const& model, boost::optional<std::vector<storm::jani::Property>> const& properties = boost::none);
+    static bool canHandle(storm::jani::Model const& model, storm::OptionalRef<std::vector<storm::jani::Property> const> properties = storm::NullRef);
 
     struct Options {
         /*!


### PR DESCRIPTION
Should fix the failing build

https://github.com/stormchecker/storm/actions/runs/24984410065/job/73154004843

Also avoids creating an unnecessary copy of the properties vector.