### PR TITLE
Lexicographic: Fail for unsupported properties, remove deprecated --lex switch.

### DIFF
--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -438,7 +438,7 @@ inline std::pair<SymbolicInput, ModelProcessingInformation> preprocessSymbolicIn
                         "Can not translate properties to multi-objective formula because no properties were specified.");
         // If we come from storm-pars, the following fails as multiObjectiveSettings are not loaded
         auto multiObjSettings = storm::settings::getModule<storm::settings::modules::MultiObjectiveSettings>();
-        output.properties = {storm::api::createMultiObjectiveProperty(output.properties, multiObjSettings.isLexicographicModelCheckingSet())};
+        output.properties = {storm::api::createMultiObjectiveProperty(output.properties, false)};
     }
 
     // Substitute constant definitions in symbolic input.

--- a/src/storm/environment/modelchecker/MultiObjectiveModelCheckerEnvironment.cpp
+++ b/src/storm/environment/modelchecker/MultiObjectiveModelCheckerEnvironment.cpp
@@ -51,7 +51,6 @@ MultiObjectiveModelCheckerEnvironment::MultiObjectiveModelCheckerEnvironment() {
     }
 
     printResults = multiobjectiveSettings.isPrintResultsSet();
-    useLexicographicModelChecking = multiobjectiveSettings.isLexicographicModelCheckingSet();
 }
 
 MultiObjectiveModelCheckerEnvironment::~MultiObjectiveModelCheckerEnvironment() {
@@ -208,11 +207,4 @@ void MultiObjectiveModelCheckerEnvironment::setPrintResults(bool value) {
     printResults = value;
 }
 
-bool MultiObjectiveModelCheckerEnvironment::isLexicographicModelCheckingSet() const {
-    return useLexicographicModelChecking;
-}
-
-void MultiObjectiveModelCheckerEnvironment::setLexicographicModelChecking(bool value) {
-    useLexicographicModelChecking = value;
-}
 }  // namespace storm

--- a/src/storm/environment/modelchecker/MultiObjectiveModelCheckerEnvironment.h
+++ b/src/storm/environment/modelchecker/MultiObjectiveModelCheckerEnvironment.h
@@ -80,9 +80,6 @@ class MultiObjectiveModelCheckerEnvironment {
     bool isPrintResultsSet() const;
     void setPrintResults(bool value);
 
-    bool isLexicographicModelCheckingSet() const;
-    void setLexicographicModelChecking(bool value);
-
    private:
     storm::modelchecker::multiobjective::MultiObjectiveMethod method;
     boost::optional<std::string> plotPathUnderApprox, plotPathOverApprox, plotPathParetoPoints;
@@ -96,6 +93,5 @@ class MultiObjectiveModelCheckerEnvironment {
     boost::optional<storm::RationalNumber> approximationTradeoff;
     boost::optional<storm::storage::SchedulerClass> schedulerRestriction;
     bool printResults;
-    bool useLexicographicModelChecking;
 };
 }  // namespace storm

--- a/src/storm/modelchecker/AbstractModelChecker.cpp
+++ b/src/storm/modelchecker/AbstractModelChecker.cpp
@@ -290,7 +290,7 @@ std::unique_ptr<CheckResult> AbstractModelChecker<ModelType>::checkStateFormula(
         return this->checkGameFormula(env, checkTask.substituteFormula(stateFormula.asGameFormula()));
     } else if (stateFormula.isMultiObjectiveFormula()) {
         auto const& mof = stateFormula.asMultiObjectiveFormula();
-        if (mof.isLexicographic() || env.modelchecker().multi().isLexicographicModelCheckingSet()) {
+        if (mof.isLexicographic()) {
             return this->checkLexObjectiveFormula(env, checkTask.substituteFormula(mof));
         } else {
             STORM_LOG_ASSERT(mof.isTradeoff(), "Unexpected multi-objective formula type.");

--- a/src/storm/modelchecker/lexicographic/LexicographicModelChecking.cpp
+++ b/src/storm/modelchecker/lexicographic/LexicographicModelChecking.cpp
@@ -2,6 +2,8 @@
 
 #include "storm/adapters/RationalNumberAdapter.h"
 #include "storm/environment/Environment.h"
+#include "storm/exceptions/NotSupportedException.h"
+#include "storm/exceptions/IllegalFunctionCallException.h"
 #include "storm/models/sparse/Mdp.h"
 #include "storm/utility/macros.h"
 
@@ -13,9 +15,16 @@ template<typename SparseModelType, typename ValueType>
 helper::MDPSparseModelCheckingHelperReturnType<ValueType> check(Environment const&, SparseModelType const& model,
                                                                 CheckTask<storm::logic::MultiObjectiveFormula, ValueType> const& checkTask,
                                                                 CheckFormulaCallback const& formulaChecker) {
-    STORM_LOG_ASSERT(model.getInitialStates().getNumberOfSetBits() == 1,
-                     "Lexicographic Model checking on model with multiple initial states is not supported.");
     storm::logic::MultiObjectiveFormula const& formula = checkTask.getFormula();
+    auto const& subformulas = formula.getSubformulas();
+
+    // Ensure that the query is supported
+    STORM_LOG_THROW(model.getInitialStates().getNumberOfSetBits() == 1, storm::exceptions::NotSupportedException,
+                     "Lexicographic Model checking on model with multiple initial states is not supported.");
+    STORM_LOG_THROW(formula.isLexicographic(), storm::exceptions::IllegalFunctionCallException, "Invoked lexicographic model checking with a non-lexicographic formula " << formula << ".");
+    STORM_LOG_THROW(std::all_of(subformulas.begin(), subformulas.end(), [](auto const& f) {
+        return f->isProbabilityOperatorFormula() && !f->asOperatorFormula().hasBound() && f->asOperatorFormula().hasOptimalityType() && storm::solver::maximize(f->asOperatorFormula().getOptimalityType());
+    }), storm::exceptions::NotSupportedException, "Lexicographic model checking only supports Pmax=? [...]  subformulas. Got " << formula << " as input.");
 
     // Define the helper that contains all functions
     helper::lexicographic::LexicographicModelCheckerHelper<SparseModelType, ValueType, true> lMC =

--- a/src/storm/modelchecker/lexicographic/LexicographicModelChecking.cpp
+++ b/src/storm/modelchecker/lexicographic/LexicographicModelChecking.cpp
@@ -2,8 +2,8 @@
 
 #include "storm/adapters/RationalNumberAdapter.h"
 #include "storm/environment/Environment.h"
-#include "storm/exceptions/NotSupportedException.h"
 #include "storm/exceptions/IllegalFunctionCallException.h"
+#include "storm/exceptions/NotSupportedException.h"
 #include "storm/models/sparse/Mdp.h"
 #include "storm/utility/macros.h"
 
@@ -20,11 +20,16 @@ helper::MDPSparseModelCheckingHelperReturnType<ValueType> check(Environment cons
 
     // Ensure that the query is supported
     STORM_LOG_THROW(model.getInitialStates().getNumberOfSetBits() == 1, storm::exceptions::NotSupportedException,
-                     "Lexicographic Model checking on model with multiple initial states is not supported.");
-    STORM_LOG_THROW(formula.isLexicographic(), storm::exceptions::IllegalFunctionCallException, "Invoked lexicographic model checking with a non-lexicographic formula " << formula << ".");
-    STORM_LOG_THROW(std::all_of(subformulas.begin(), subformulas.end(), [](auto const& f) {
-        return f->isProbabilityOperatorFormula() && !f->asOperatorFormula().hasBound() && f->asOperatorFormula().hasOptimalityType() && storm::solver::maximize(f->asOperatorFormula().getOptimalityType());
-    }), storm::exceptions::NotSupportedException, "Lexicographic model checking only supports Pmax=? [...]  subformulas. Got " << formula << " as input.");
+                    "Lexicographic Model checking on model with multiple initial states is not supported.");
+    STORM_LOG_THROW(formula.isLexicographic(), storm::exceptions::IllegalFunctionCallException,
+                    "Invoked lexicographic model checking with a non-lexicographic formula " << formula << ".");
+    STORM_LOG_THROW(std::all_of(subformulas.begin(), subformulas.end(),
+                                [](auto const& f) {
+                                    return f->isProbabilityOperatorFormula() && !f->asOperatorFormula().hasBound() &&
+                                           f->asOperatorFormula().hasOptimalityType() && storm::solver::maximize(f->asOperatorFormula().getOptimalityType());
+                                }),
+                    storm::exceptions::NotSupportedException,
+                    "Lexicographic model checking only supports Pmax=? [...]  subformulas. Got " << formula << " as input.");
 
     // Define the helper that contains all functions
     helper::lexicographic::LexicographicModelCheckerHelper<SparseModelType, ValueType, true> lMC =

--- a/src/storm/modelchecker/multiobjective/MultiObjectiveModelChecking.cpp
+++ b/src/storm/modelchecker/multiobjective/MultiObjectiveModelChecking.cpp
@@ -2,11 +2,11 @@
 
 #include "storm/environment/modelchecker/MultiObjectiveModelCheckerEnvironment.h"
 #include "storm/environment/solver/SolverEnvironment.h"
+#include "storm/exceptions/IllegalFunctionCallException.h"
 #include "storm/exceptions/InvalidArgumentException.h"
 #include "storm/exceptions/InvalidEnvironmentException.h"
 #include "storm/exceptions/NotImplementedException.h"
 #include "storm/exceptions/NotSupportedException.h"
-#include "storm/exceptions/IllegalFunctionCallException.h"
 #include "storm/modelchecker/multiobjective/MultiObjectivePostprocessing.h"
 #include "storm/modelchecker/multiobjective/constraintbased/SparseCbAchievabilityQuery.h"
 #include "storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsAchievabilityChecker.h"
@@ -32,9 +32,9 @@ std::unique_ptr<CheckResult> performMultiObjectiveModelChecking(Environment cons
     storm::utility::Stopwatch swTotal(true);
     storm::utility::Stopwatch swPreprocessing(true);
     STORM_LOG_THROW(model.getInitialStates().getNumberOfSetBits() == 1, storm::exceptions::NotSupportedException,
-                     "Multi-objective Model checking on model with multiple initial states is not supported.");
-    STORM_LOG_THROW(formula.isTradeoff(), storm::exceptions::IllegalFunctionCallException, "Invoked multi-objective model checking with a non-tradeoff formula " << formula << ".");
-
+                    "Multi-objective Model checking on model with multiple initial states is not supported.");
+    STORM_LOG_THROW(formula.isTradeoff(), storm::exceptions::IllegalFunctionCallException,
+                    "Invoked multi-objective model checking with a non-tradeoff formula " << formula << ".");
 
     // If we consider an MA, ensure that it is closed
     if (model.isOfType(storm::models::ModelType::MarkovAutomaton)) {

--- a/src/storm/modelchecker/multiobjective/MultiObjectiveModelChecking.cpp
+++ b/src/storm/modelchecker/multiobjective/MultiObjectiveModelChecking.cpp
@@ -5,6 +5,8 @@
 #include "storm/exceptions/InvalidArgumentException.h"
 #include "storm/exceptions/InvalidEnvironmentException.h"
 #include "storm/exceptions/NotImplementedException.h"
+#include "storm/exceptions/NotSupportedException.h"
+#include "storm/exceptions/IllegalFunctionCallException.h"
 #include "storm/modelchecker/multiobjective/MultiObjectivePostprocessing.h"
 #include "storm/modelchecker/multiobjective/constraintbased/SparseCbAchievabilityQuery.h"
 #include "storm/modelchecker/multiobjective/deterministicScheds/DeterministicSchedsAchievabilityChecker.h"
@@ -29,8 +31,10 @@ std::unique_ptr<CheckResult> performMultiObjectiveModelChecking(Environment cons
                                                                 storm::logic::MultiObjectiveFormula const& formula, bool produceScheduler) {
     storm::utility::Stopwatch swTotal(true);
     storm::utility::Stopwatch swPreprocessing(true);
-    STORM_LOG_ASSERT(model.getInitialStates().getNumberOfSetBits() == 1,
+    STORM_LOG_THROW(model.getInitialStates().getNumberOfSetBits() == 1, storm::exceptions::NotSupportedException,
                      "Multi-objective Model checking on model with multiple initial states is not supported.");
+    STORM_LOG_THROW(formula.isTradeoff(), storm::exceptions::IllegalFunctionCallException, "Invoked multi-objective model checking with a non-tradeoff formula " << formula << ".");
+
 
     // If we consider an MA, ensure that it is closed
     if (model.isOfType(storm::models::ModelType::MarkovAutomaton)) {

--- a/src/storm/settings/modules/MultiObjectiveSettings.cpp
+++ b/src/storm/settings/modules/MultiObjectiveSettings.cpp
@@ -19,7 +19,6 @@ const std::string MultiObjectiveSettings::maxStepsOptionName = "maxsteps";
 const std::string MultiObjectiveSettings::schedulerRestrictionOptionName = "purescheds";
 const std::string MultiObjectiveSettings::printResultsOptionName = "printres";
 const std::string MultiObjectiveSettings::encodingOptionName = "encoding";
-const std::string MultiObjectiveSettings::lexicographicOptionName = "lex";
 
 MultiObjectiveSettings::MultiObjectiveSettings() : ModuleSettings(moduleName) {
     std::vector<std::string> methods = {"pcaa", "constraintbased"};
@@ -105,10 +104,6 @@ MultiObjectiveSettings::MultiObjectiveSettings() : ModuleSettings(moduleName) {
                                          .setDefaultValueBoolean(false)
                                          .makeOptional()
                                          .build())
-                        .build());
-
-    this->addOption(storm::settings::OptionBuilder(moduleName, lexicographicOptionName, false,
-                                                   "(Deprecated) If set, lexicographic model checking instead of normal multi objective is performed.")
                         .build());
 }
 
@@ -230,15 +225,6 @@ bool MultiObjectiveSettings::isIndicatorConstraintsSet() const {
 
 bool MultiObjectiveSettings::isRedundantBsccConstraintsSet() const {
     return this->getOption(encodingOptionName).getArgumentByName("redundant").getValueAsBoolean();
-}
-
-bool MultiObjectiveSettings::isLexicographicModelCheckingSet() const {
-    return this->getOption(lexicographicOptionName).getHasOptionBeenSet();
-}
-
-void MultiObjectiveSettings::finalize() {
-    STORM_LOG_WARN_COND(!isLexicographicModelCheckingSet(),
-                        "Option '--" << moduleName << ":" << lexicographicOptionName << "' is deprecated. Use a `multilex(..)` formula instead.");
 }
 
 bool MultiObjectiveSettings::check() const {

--- a/src/storm/settings/modules/MultiObjectiveSettings.h
+++ b/src/storm/settings/modules/MultiObjectiveSettings.h
@@ -130,11 +130,6 @@ class MultiObjectiveSettings : public ModuleSettings {
     bool isIndicatorConstraintsSet() const;
 
     /*!
-     * Retrieves whether lexicographic model checking has been set
-     */
-    bool isLexicographicModelCheckingSet() const;
-
-    /*!
      * Retrieves whether redundant BSCC constraints are to be added
      */
     bool isRedundantBsccConstraintsSet() const;
@@ -145,9 +140,7 @@ class MultiObjectiveSettings : public ModuleSettings {
      * @return True if the settings are consistent.
      */
     virtual bool check() const override;
-
-    virtual void finalize() override;
-
+    
     const static std::string moduleName;
 
    private:
@@ -159,7 +152,6 @@ class MultiObjectiveSettings : public ModuleSettings {
     const static std::string schedulerRestrictionOptionName;
     const static std::string printResultsOptionName;
     const static std::string encodingOptionName;
-    const static std::string lexicographicOptionName;
 };
 
 }  // namespace modules

--- a/src/storm/settings/modules/MultiObjectiveSettings.h
+++ b/src/storm/settings/modules/MultiObjectiveSettings.h
@@ -140,7 +140,7 @@ class MultiObjectiveSettings : public ModuleSettings {
      * @return True if the settings are consistent.
      */
     virtual bool check() const override;
-    
+
     const static std::string moduleName;
 
    private:

--- a/src/test/storm/modelchecker/lexicographic/LexicographicModelCheckingTest.cpp
+++ b/src/test/storm/modelchecker/lexicographic/LexicographicModelCheckingTest.cpp
@@ -17,7 +17,7 @@ TEST(LexicographicModelCheckingTest, prob_sched1) {
     GTEST_SKIP() << "Spot not available.";
 #endif
     typedef double ValueType;
-    std::string formulasString = "multi(Pmax=? [GF y=2], Pmax=? [GF y=1], Pmax=? [GF y=3]);";
+    std::string formulasString = "multilex(Pmax=? [GF y=2], Pmax=? [GF y=1], Pmax=? [GF y=3]);";
     std::string pathToPrismFile = STORM_TEST_RESOURCES_DIR "/mdp/prob_sched.prism";
     std::pair<std::shared_ptr<storm::models::sparse::Mdp<ValueType>>, std::vector<std::shared_ptr<storm::logic::Formula const>>> modelFormulas;
     storm::prism::Program program = storm::api::parseProgram(pathToPrismFile);
@@ -53,7 +53,7 @@ TEST(LexicographicModelCheckingTest, prob_sched2) {
     GTEST_SKIP() << "Spot not available.";
 #endif
     typedef double ValueType;
-    std::string formulasString = "multi(Pmax=? [GF y=1], Pmax=? [GF y=2], Pmax=? [GF y=3]);";
+    std::string formulasString = "multilex(Pmax=? [GF y=1], Pmax=? [GF y=2], Pmax=? [GF y=3]);";
     std::string pathToPrismFile = STORM_TEST_RESOURCES_DIR "/mdp/prob_sched.prism";
     std::pair<std::shared_ptr<storm::models::sparse::Mdp<ValueType>>, std::vector<std::shared_ptr<storm::logic::Formula const>>> modelFormulas;
     storm::prism::Program program = storm::api::parseProgram(pathToPrismFile);


### PR DESCRIPTION
- Lexicographic model checking now fails for unsupported inputs (instead of giving an unexpected result)
- The deprecated --lex switch has been removed. Lexicographic model checking can be invoked using the `multilex(..)` syntax for PRISM-style properties or via JANI