### PR TITLE
Improved parsing of commandline options (including negative numbers)

### DIFF
--- a/src/storm/settings/SettingsManager.cpp
+++ b/src/storm/settings/SettingsManager.cpp
@@ -128,8 +128,26 @@ void SettingsManager::setFromExplodedString(std::vector<std::string> const& comm
     for (uint_fast64_t i = 0; i < commandLineArguments.size(); ++i) {
         std::string const& currentArgument = commandLineArguments[i];
 
-        // Check if the given argument is a new option or belongs to a previously given option.
-        if (!currentArgument.empty() && currentArgument.at(0) == '-') {
+        // Check if the given argument is a new option or belongs to a previously given option. An argument that
+        // starts with '-' is normally considered a new option. However, if an option is currently active and still
+        // expects a mandatory (non-optional) argument, a leading '-' may also be part of the argument's value,
+        // e.g. for negative numbers in a region description.
+        bool isNewOption = !currentArgument.empty() && currentArgument.at(0) == '-';
+        if (isNewOption && optionActive) {
+            auto const& activeOptionMap = activeOptionIsShortName ? shortNameToOptions : longNameToOptions;
+            auto activeOptionIterator = activeOptionMap.find(activeOptionName);
+            bool activeOptionExpectsMandatoryArgument = activeOptionIterator != activeOptionMap.end() && !activeOptionIterator->second.empty() &&
+                                                        argumentCache.size() < activeOptionIterator->second.front()->getArgumentCount() &&
+                                                        !activeOptionIterator->second.front()->getArgument(argumentCache.size()).getIsOptional();
+            bool currentArgumentIsKnownOption = currentArgument.size() > 1 && currentArgument.at(1) == '-'
+                                                    ? longNameToOptions.find(currentArgument.substr(2)) != longNameToOptions.end()
+                                                    : shortNameToOptions.find(currentArgument.substr(1)) != shortNameToOptions.end();
+            if (activeOptionExpectsMandatoryArgument && !currentArgumentIsKnownOption) {
+                isNewOption = false;
+            }
+        }
+
+        if (isNewOption) {
             if (optionActive) {
                 // At this point we know that a new option is about to come. Hence, we need to assign the current
                 // cache content to the option that was active until now.
@@ -141,7 +159,7 @@ void SettingsManager::setFromExplodedString(std::vector<std::string> const& comm
                 optionActive = true;
             }
 
-            if (currentArgument.at(1) == '-') {
+            if (currentArgument.size() > 1 && currentArgument.at(1) == '-') {
                 // In this case, the argument has to be the long name of an option. Try to get all options that
                 // match the long name.
                 std::string optionName = currentArgument.substr(2);

--- a/src/test/storm/CMakeLists.txt
+++ b/src/test/storm/CMakeLists.txt
@@ -5,7 +5,7 @@ set(STORM_TESTS_BASE_PATH "${PROJECT_SOURCE_DIR}/src/test/storm")
 include_directories(${GTEST_INCLUDE_DIR})
 
 # Set split and non-split test directories
-set(NON_SPLIT_TESTS adapter automata builder logic model parser simulator solver storage transformer utility)
+set(NON_SPLIT_TESTS adapter automata builder logic model parser settings simulator solver storage transformer utility)
 set(MODELCHECKER_TEST_SPLITS csl exploration lexicographic multiobjective reachability)
 set(MODELCHECKER_PRCTL_TEST_SPLITS dtmc mdp)
 

--- a/src/test/storm/settings/SettingsManagerTest.cpp
+++ b/src/test/storm/settings/SettingsManagerTest.cpp
@@ -1,0 +1,66 @@
+#include "test/storm_gtest.h"
+
+#include "storm/exceptions/OptionParserException.h"
+#include "storm/settings/ArgumentBuilder.h"
+#include "storm/settings/OptionBuilder.h"
+#include "storm/settings/SettingsManager.h"
+#include "storm/settings/modules/ModuleSettings.h"
+
+namespace {
+
+class SettingsParsingTestModule : public storm::settings::modules::ModuleSettings {
+   public:
+    static const std::string moduleName;
+
+    SettingsParsingTestModule() : ModuleSettings(moduleName) {
+        this->addOption(storm::settings::OptionBuilder("settingsparsing", "optiona", false, "Test option a.")
+                            .addArgument(storm::settings::ArgumentBuilder::createStringArgument("value", "The value.").build())
+                            .build());
+        this->addOption(storm::settings::OptionBuilder("settingsparsing", "optionb", false, "Test option b.")
+                            .setShortName("ob")
+                            .addArgument(storm::settings::ArgumentBuilder::createStringArgument("value", "The value.").build())
+                            .build());
+        this->addOption(storm::settings::OptionBuilder("settingsparsing", "optionc", false, "Test option c.")
+                            .addArgument(storm::settings::ArgumentBuilder::createStringArgument("value", "The value.").build())
+                            .build());
+        this->addOption(storm::settings::OptionBuilder("settingsparsing", "optiond", false, "Test option d.")
+                            .addArgument(storm::settings::ArgumentBuilder::createStringArgument("value", "The value.").build())
+                            .build());
+    }
+
+    std::string getOptionString(std::string const& optionName) const {
+        return this->getOption(optionName).getArgumentByName("value").getValueAsString();
+    }
+};
+
+const std::string SettingsParsingTestModule::moduleName = "settingsparsing";
+
+bool ensureSettingsParsingTestModuleRegistered() {
+    if (!storm::settings::manager().hasModule("settingsparsing")) {
+        storm::settings::addModule<SettingsParsingTestModule>();
+    }
+    return true;
+}
+
+bool settingsParsingTestModuleRegistered = ensureSettingsParsingTestModuleRegistered();
+
+}  // namespace
+
+TEST(SettingsManagerTest, ValueWithLeadingDashLongOption) {
+    storm::settings::mutableManager().setFromExplodedString({"--optiona", "-1 <= x <= 1"});
+    EXPECT_EQ("-1 <= x <= 1", storm::settings::getModule<SettingsParsingTestModule>().getOptionString("optiona"));
+}
+
+TEST(SettingsManagerTest, ValueWithLeadingDashShortOption) {
+    storm::settings::mutableManager().setFromExplodedString({"-ob", "-1<=x<=1"});
+    EXPECT_EQ("-1<=x<=1", storm::settings::getModule<SettingsParsingTestModule>().getOptionString("optionb"));
+}
+
+TEST(SettingsManagerTest, ValueWithLeadingDashFollowedByKnownOption) {
+    storm::settings::mutableManager().setFromExplodedString({"--optionc", "-1 <= x <= 1", "--verbose"});
+    EXPECT_EQ("-1 <= x <= 1", storm::settings::getModule<SettingsParsingTestModule>().getOptionString("optionc"));
+}
+
+TEST(SettingsManagerTest, KnownOptionNotSwallowedAsValue) {
+    EXPECT_THROW({ storm::settings::mutableManager().setFromExplodedString({"--optiond", "--verbose"}); }, storm::exceptions::OptionParserException);
+}


### PR DESCRIPTION
Fixes https://github.com/stormchecker/storm/issues/874
Added a new test suite `test-settings`. This does not directly test the issue with region parsing (becomes this would depend on `storm-pars`) but a similar option.

Contributions from opencode bot@opencode.ai (model: opencode/big-pickle).