### PR TITLE
cleanup in state elimination

### DIFF
--- a/src/storm/environment/SubEnvironment.cpp
+++ b/src/storm/environment/SubEnvironment.cpp
@@ -53,6 +53,7 @@ template class SubEnvironment<MultiObjectiveModelCheckerEnvironment>;
 template class SubEnvironment<ModelCheckerEnvironment>;
 
 template class SubEnvironment<SolverEnvironment>;
+template class SubEnvironment<EliminationSolverEnvironment>;
 template class SubEnvironment<EigenSolverEnvironment>;
 template class SubEnvironment<GmmxxSolverEnvironment>;
 template class SubEnvironment<NativeSolverEnvironment>;

--- a/src/storm/environment/solver/AllSolverEnvironments.h
+++ b/src/storm/environment/solver/AllSolverEnvironments.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "storm/environment/solver/EigenSolverEnvironment.h"
+#include "storm/environment/solver/EliminationSolverEnvironment.h"
 #include "storm/environment/solver/GameSolverEnvironment.h"
 #include "storm/environment/solver/GmmxxSolverEnvironment.h"
 #include "storm/environment/solver/LongRunAverageSolverEnvironment.h"

--- a/src/storm/environment/solver/EliminationSolverEnvironment.cpp
+++ b/src/storm/environment/solver/EliminationSolverEnvironment.cpp
@@ -1,0 +1,53 @@
+#include "storm/environment/solver/EliminationSolverEnvironment.h"
+
+#include "storm/settings/SettingsManager.h"
+#include "storm/settings/modules/EliminationSettings.h"
+
+namespace storm {
+
+EliminationSolverEnvironment::EliminationSolverEnvironment() {
+    auto const& eliminationSettings = storm::settings::getModule<storm::settings::modules::EliminationSettings>();
+
+    order = eliminationSettings.getEliminationOrder();
+    method = eliminationSettings.getEliminationMethod();
+    maximalSccSize = eliminationSettings.getMaximalSccSize();
+    eliminateEntryStatesLast = eliminationSettings.isEliminateEntryStatesLastSet();
+}
+
+EliminationSolverEnvironment::~EliminationSolverEnvironment() {
+    // Intentionally left empty
+}
+
+storm::solver::stateelimination::EliminationOrder const& EliminationSolverEnvironment::getOrder() const {
+    return order;
+}
+
+void EliminationSolverEnvironment::setOrder(storm::solver::stateelimination::EliminationOrder value) {
+    order = value;
+}
+
+storm::solver::stateelimination::EliminationMethod const& EliminationSolverEnvironment::getMethod() const {
+    return method;
+}
+
+void EliminationSolverEnvironment::setMethod(storm::solver::stateelimination::EliminationMethod value) {
+    method = value;
+}
+
+uint64_t const& EliminationSolverEnvironment::getMaximalSccSize() const {
+    return maximalSccSize;
+}
+
+void EliminationSolverEnvironment::setMaximalSccSize(uint64_t value) {
+    maximalSccSize = value;
+}
+
+bool const& EliminationSolverEnvironment::isEliminateEntryStatesLastSet() const {
+    return eliminateEntryStatesLast;
+}
+
+void EliminationSolverEnvironment::setEliminateEntryStatesLast(bool value) {
+    eliminateEntryStatesLast = value;
+}
+
+}  // namespace storm

--- a/src/storm/environment/solver/EliminationSolverEnvironment.h
+++ b/src/storm/environment/solver/EliminationSolverEnvironment.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "storm/environment/solver/SolverEnvironment.h"
+#include "storm/solver/stateelimination/EliminationMethod.h"
+#include "storm/solver/stateelimination/EliminationOrder.h"
+
+namespace storm {
+
+class EliminationSolverEnvironment {
+   public:
+    EliminationSolverEnvironment();
+    ~EliminationSolverEnvironment();
+
+    storm::solver::stateelimination::EliminationOrder const& getOrder() const;
+    void setOrder(storm::solver::stateelimination::EliminationOrder value);
+    storm::solver::stateelimination::EliminationMethod const& getMethod() const;
+    void setMethod(storm::solver::stateelimination::EliminationMethod value);
+    uint64_t const& getMaximalSccSize() const;
+    void setMaximalSccSize(uint64_t value);
+    bool const& isEliminateEntryStatesLastSet() const;
+    void setEliminateEntryStatesLast(bool value);
+
+   private:
+    storm::solver::stateelimination::EliminationOrder order;
+    storm::solver::stateelimination::EliminationMethod method;
+    uint64_t maximalSccSize;
+    bool eliminateEntryStatesLast;
+};
+}  // namespace storm

--- a/src/storm/environment/solver/SolverEnvironment.cpp
+++ b/src/storm/environment/solver/SolverEnvironment.cpp
@@ -96,6 +96,14 @@ TopologicalSolverEnvironment const& SolverEnvironment::topological() const {
     return topologicalSolverEnvironment.get();
 }
 
+EliminationSolverEnvironment& SolverEnvironment::elimination() {
+    return eliminationSolverEnvironment.get();
+}
+
+EliminationSolverEnvironment const& SolverEnvironment::elimination() const {
+    return eliminationSolverEnvironment.get();
+}
+
 OviSolverEnvironment& SolverEnvironment::ovi() {
     return oviSolverEnvironment.get();
 }

--- a/src/storm/environment/solver/SolverEnvironment.h
+++ b/src/storm/environment/solver/SolverEnvironment.h
@@ -21,6 +21,7 @@ class MultiplierEnvironment;
 class GameSolverEnvironment;
 class TopologicalSolverEnvironment;
 class OviSolverEnvironment;
+class EliminationSolverEnvironment;
 
 class SolverEnvironment {
    public:
@@ -47,6 +48,8 @@ class SolverEnvironment {
     GameSolverEnvironment const& game() const;
     TopologicalSolverEnvironment& topological();
     TopologicalSolverEnvironment const& topological() const;
+    EliminationSolverEnvironment& elimination();
+    EliminationSolverEnvironment const& elimination() const;
 
     bool isForceSoundness() const;
     void setForceSoundness(bool value);
@@ -73,6 +76,7 @@ class SolverEnvironment {
     SubEnvironment<MinMaxSolverEnvironment> minMaxSolverEnvironment;
     SubEnvironment<MultiplierEnvironment> multiplierEnvironment;
     SubEnvironment<OviSolverEnvironment> oviSolverEnvironment;
+    SubEnvironment<EliminationSolverEnvironment> eliminationSolverEnvironment;
 
     storm::solver::EquationSolverType linearEquationSolverType;
     bool linearEquationSolverTypeSetFromDefault;

--- a/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.cpp
+++ b/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.cpp
@@ -5,30 +5,29 @@
 #include <random>
 
 #include "storm/adapters/RationalFunctionAdapter.h"
+#include "storm/environment/solver/EliminationSolverEnvironment.h"
+#include "storm/environment/solver/SolverEnvironment.h"
 #include "storm/exceptions/IllegalArgumentException.h"
 #include "storm/exceptions/InvalidPropertyException.h"
 #include "storm/logic/FragmentSpecification.h"
 #include "storm/modelchecker/results/ExplicitQualitativeCheckResult.h"
 #include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
 #include "storm/settings/SettingsManager.h"
-#include "storm/settings/modules/CoreSettings.h"
 #include "storm/settings/modules/EliminationSettings.h"
 #include "storm/solver/stateelimination/ConditionalStateEliminator.h"
 #include "storm/solver/stateelimination/DynamicStatePriorityQueue.h"
 #include "storm/solver/stateelimination/MultiValueStateEliminator.h"
 #include "storm/solver/stateelimination/PrioritizedStateEliminator.h"
+#include "storm/solver/stateelimination/StateEliminationUtility.h"
 #include "storm/solver/stateelimination/StaticStatePriorityQueue.h"
 #include "storm/storage/StronglyConnectedComponentDecomposition.h"
 #include "storm/utility/constants.h"
 #include "storm/utility/graph.h"
 #include "storm/utility/macros.h"
-#include "storm/utility/stateelimination.h"
 #include "storm/utility/vector.h"
 
 namespace storm {
 namespace modelchecker {
-
-using namespace storm::utility::stateelimination;
 
 template<typename SparseDtmcModelType>
 SparseDtmcEliminationModelChecker<SparseDtmcModelType>::SparseDtmcEliminationModelChecker(storm::models::sparse::Dtmc<ValueType> const& model)
@@ -100,8 +99,8 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
 
         std::vector<ValueType> stateValues(maybeStates.size(), storm::utility::zero<ValueType>());
         storm::utility::vector::setVectorValues(stateValues, psiStates, storm::utility::one<ValueType>());
-        result =
-            computeLongRunValues(transitionMatrix, backwardTransitions, initialStates, maybeStates, checkTask.isOnlyInitialStatesRelevantSet(), stateValues);
+        result = computeLongRunValues(env, transitionMatrix, backwardTransitions, initialStates, maybeStates, checkTask.isOnlyInitialStatesRelevantSet(),
+                                      stateValues);
     }
 
     // Construct check result based on whether we have computed values for all states or just the initial states.
@@ -165,7 +164,7 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
             maybeStates &= reachableStates;
         }
 
-        result = computeLongRunValues(transitionMatrix, backwardTransitions, initialStates, maybeStates, checkTask.isOnlyInitialStatesRelevantSet(),
+        result = computeLongRunValues(env, transitionMatrix, backwardTransitions, initialStates, maybeStates, checkTask.isOnlyInitialStatesRelevantSet(),
                                       stateRewardValues);
     }
 
@@ -181,7 +180,8 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
 
 template<typename SparseDtmcModelType>
 std::vector<typename SparseDtmcEliminationModelChecker<SparseDtmcModelType>::SolutionType>
-SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeLongRunValues(storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeLongRunValues(Environment const& env,
+                                                                             storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                                              storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                              storm::storage::BitVector const& initialStates,
                                                                              storm::storage::BitVector const& maybeStates,
@@ -205,11 +205,10 @@ SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeLongRunValues(sto
 
     std::chrono::high_resolution_clock::time_point modelCheckingStart = std::chrono::high_resolution_clock::now();
 
-    storm::settings::modules::EliminationSettings::EliminationOrder order =
-        storm::settings::getModule<storm::settings::modules::EliminationSettings>().getEliminationOrder();
+    EliminationOrder order = env.solver().elimination().getOrder();
     boost::optional<std::vector<uint_fast64_t>> distanceBasedPriorities;
     if (eliminationOrderNeedsDistances(order)) {
-        distanceBasedPriorities = getDistanceBasedPriorities(transitionMatrix, backwardTransitions, initialStates, stateValues,
+        distanceBasedPriorities = getDistanceBasedPriorities(order, transitionMatrix, backwardTransitions, initialStates, stateValues,
                                                              eliminationOrderNeedsForwardDistances(order), eliminationOrderNeedsReversedDistances(order));
     }
 
@@ -239,7 +238,7 @@ SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeLongRunValues(sto
 
     // First, we eliminate all states in BSCCs (except for the representative states).
     std::shared_ptr<StatePriorityQueue> priorityQueue =
-        createStatePriorityQueue(distanceBasedPriorities, flexibleMatrix, flexibleBackwardTransitions, stateValues, regularStatesInBsccs);
+        createStatePriorityQueue(order, distanceBasedPriorities, flexibleMatrix, flexibleBackwardTransitions, stateValues, regularStatesInBsccs);
     storm::solver::stateelimination::MultiValueStateEliminator<ValueType> stateEliminator(flexibleMatrix, flexibleBackwardTransitions, priorityQueue,
                                                                                           stateValues, averageTimeInStates);
 
@@ -301,7 +300,7 @@ SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeLongRunValues(sto
     // We only need to eliminate the remaining states if there was some BSCC that has a non-zero value, i.e.
     // that consists of maybe states.
     if (!relevantBsccs.empty()) {
-        performOrdinaryStateElimination(flexibleMatrix, flexibleBackwardTransitions, remainingStates, initialStates, computeResultsForInitialStatesOnly,
+        performOrdinaryStateElimination(env, flexibleMatrix, flexibleBackwardTransitions, remainingStates, initialStates, computeResultsForInitialStatesOnly,
                                         stateValues, distanceBasedPriorities);
     }
 
@@ -457,13 +456,13 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
     storm::storage::BitVector const& phiStates = leftResultPointer->template asExplicitQualitativeCheckResult<ValueType>().getTruthValuesVector();
     storm::storage::BitVector const& psiStates = rightResultPointer->template asExplicitQualitativeCheckResult<ValueType>().getTruthValuesVector();
 
-    return computeUntilProbabilities(this->getModel().getTransitionMatrix(), this->getModel().getBackwardTransitions(), this->getModel().getInitialStates(),
-                                     phiStates, psiStates, checkTask.isOnlyInitialStatesRelevantSet());
+    return computeUntilProbabilities(env, this->getModel().getTransitionMatrix(), this->getModel().getBackwardTransitions(),
+                                     this->getModel().getInitialStates(), phiStates, psiStates, checkTask.isOnlyInitialStatesRelevantSet());
 }
 
 template<typename SparseDtmcModelType>
 std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeUntilProbabilities(
-    storm::storage::SparseMatrix<ValueType> const& probabilityMatrix, storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
+    Environment const& env, storm::storage::SparseMatrix<ValueType> const& probabilityMatrix, storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
     storm::storage::BitVector const& initialStates, storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
     bool computeForInitialStatesOnly) {
     // Then, compute the subset of states that has a probability of 0 or 1, respectively.
@@ -506,7 +505,7 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
         storm::storage::SparseMatrix<ValueType> submatrix = probabilityMatrix.getSubmatrix(false, maybeStates, maybeStates);
         storm::storage::SparseMatrix<ValueType> submatrixTransposed = submatrix.transpose();
 
-        std::vector<ValueType> subresult = computeReachabilityValues(submatrix, oneStepProbabilities, submatrixTransposed, newInitialStates,
+        std::vector<ValueType> subresult = computeReachabilityValues(env, submatrix, oneStepProbabilities, submatrixTransposed, newInitialStates,
                                                                      computeForInitialStatesOnly, oneStepProbabilities);
         storm::utility::vector::setVectorValues<ValueType>(result, maybeStates, subresult);
     }
@@ -542,7 +541,7 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
 
     STORM_LOG_THROW(!rewardModel.empty(), storm::exceptions::IllegalArgumentException, "Input model does not have a reward model.");
     return computeReachabilityRewards(
-        this->getModel().getTransitionMatrix(), this->getModel().getBackwardTransitions(), this->getModel().getInitialStates(), targetStates,
+        env, this->getModel().getTransitionMatrix(), this->getModel().getBackwardTransitions(), this->getModel().getInitialStates(), targetStates,
         [&](uint_fast64_t numberOfRows, storm::storage::SparseMatrix<ValueType> const& transitionMatrix, storm::storage::BitVector const& maybeStates) {
             return rewardModel.getTotalRewardVector(numberOfRows, transitionMatrix, maybeStates);
         },
@@ -551,11 +550,11 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
 
 template<typename SparseDtmcModelType>
 std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeReachabilityRewards(
-    storm::storage::SparseMatrix<ValueType> const& probabilityMatrix, storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
+    Environment const& env, storm::storage::SparseMatrix<ValueType> const& probabilityMatrix, storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
     storm::storage::BitVector const& initialStates, storm::storage::BitVector const& targetStates, std::vector<ValueType>& stateRewardValues,
     bool computeForInitialStatesOnly) {
     return computeReachabilityRewards(
-        probabilityMatrix, backwardTransitions, initialStates, targetStates,
+        env, probabilityMatrix, backwardTransitions, initialStates, targetStates,
         [&](uint_fast64_t numberOfRows, storm::storage::SparseMatrix<ValueType> const&, storm::storage::BitVector const& maybeStates) {
             std::vector<ValueType> result(numberOfRows);
             storm::utility::vector::selectVectorValues(result, maybeStates, stateRewardValues);
@@ -566,7 +565,7 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
 
 template<typename SparseDtmcModelType>
 std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeReachabilityRewards(
-    storm::storage::SparseMatrix<ValueType> const& probabilityMatrix, storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
+    Environment const& env, storm::storage::SparseMatrix<ValueType> const& probabilityMatrix, storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
     storm::storage::BitVector const& initialStates, storm::storage::BitVector const& targetStates,
     std::function<std::vector<ValueType>(uint_fast64_t, storm::storage::SparseMatrix<ValueType> const&, storm::storage::BitVector const&)> const&
         totalStateRewardVectorGetter,
@@ -615,7 +614,7 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
         std::vector<ValueType> stateRewardValues = totalStateRewardVectorGetter(submatrix.getRowCount(), probabilityMatrix, maybeStates);
 
         std::vector<ValueType> subresult =
-            computeReachabilityValues(submatrix, stateRewardValues, submatrixTransposed, newInitialStates, computeForInitialStatesOnly,
+            computeReachabilityValues(env, submatrix, stateRewardValues, submatrixTransposed, newInitialStates, computeForInitialStatesOnly,
                                       probabilityMatrix.getConstrainedRowSumVector(maybeStates, targetStates));
         storm::utility::vector::setVectorValues<ValueType>(result, maybeStates, subresult);
     }
@@ -651,10 +650,6 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
     storm::storage::BitVector psiStates = rightResultPointer->template asExplicitQualitativeCheckResult<ValueType>().getTruthValuesVector();
     storm::storage::BitVector trueStates(this->getModel().getNumberOfStates(), true);
 
-    // Do some sanity checks to establish some required properties.
-    // STORM_LOG_WARN_COND(storm::settings::getModule<storm::settings::modules::EliminationSettings>().getEliminationMethod() ==
-    // storm::settings::modules::EliminationSettings::EliminationMethod::State, "The chosen elimination method is not available for computing conditional
-    // probabilities. Falling back to regular state elimination.");
     STORM_LOG_THROW(this->getModel().getInitialStates().getNumberOfSetBits() == 1, storm::exceptions::IllegalArgumentException,
                     "Input model is required to have exactly one initial state.");
     STORM_LOG_THROW(checkTask.isOnlyInitialStatesRelevantSet(), storm::exceptions::IllegalArgumentException,
@@ -722,10 +717,9 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
     // Before starting the model checking process, we assign priorities to states so we can use them to
     // impose ordering constraints later.
     boost::optional<std::vector<uint_fast64_t>> distanceBasedPriorities;
-    storm::settings::modules::EliminationSettings::EliminationOrder order =
-        storm::settings::getModule<storm::settings::modules::EliminationSettings>().getEliminationOrder();
+    EliminationOrder order = env.solver().elimination().getOrder();
     if (eliminationOrderNeedsDistances(order)) {
-        distanceBasedPriorities = getDistanceBasedPriorities(submatrix, submatrixTransposed, newInitialStates, oneStepProbabilities,
+        distanceBasedPriorities = getDistanceBasedPriorities(order, submatrix, submatrixTransposed, newInitialStates, oneStepProbabilities,
                                                              eliminationOrderNeedsForwardDistances(order), eliminationOrderNeedsReversedDistances(order));
     }
 
@@ -733,7 +727,7 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
     storm::storage::FlexibleSparseMatrix<ValueType> flexibleBackwardTransitions(submatrixTransposed, true);
 
     std::shared_ptr<StatePriorityQueue> statePriorities =
-        createStatePriorityQueue(distanceBasedPriorities, flexibleMatrix, flexibleBackwardTransitions, oneStepProbabilities, statesToEliminate);
+        createStatePriorityQueue(order, distanceBasedPriorities, flexibleMatrix, flexibleBackwardTransitions, oneStepProbabilities, statesToEliminate);
 
     STORM_LOG_INFO("Computing conditional probilities.\n");
     uint_fast64_t numberOfStatesToEliminate = statePriorities->size();
@@ -883,11 +877,11 @@ void SparseDtmcEliminationModelChecker<SparseDtmcModelType>::performPrioritizedS
 
 template<typename SparseDtmcModelType>
 void SparseDtmcEliminationModelChecker<SparseDtmcModelType>::performOrdinaryStateElimination(
-    storm::storage::FlexibleSparseMatrix<ValueType>& transitionMatrix, storm::storage::FlexibleSparseMatrix<ValueType>& backwardTransitions,
+    Environment const& env, storm::storage::FlexibleSparseMatrix<ValueType>& transitionMatrix, storm::storage::FlexibleSparseMatrix<ValueType>& backwardTransitions,
     storm::storage::BitVector const& subsystem, storm::storage::BitVector const& initialStates, bool computeResultsForInitialStatesOnly,
     std::vector<ValueType>& values, boost::optional<std::vector<uint_fast64_t>> const& distanceBasedPriorities) {
     std::shared_ptr<StatePriorityQueue> statePriorities =
-        createStatePriorityQueue(distanceBasedPriorities, transitionMatrix, backwardTransitions, values, subsystem);
+        createStatePriorityQueue(env.solver().elimination().getOrder(), distanceBasedPriorities, transitionMatrix, backwardTransitions, values, subsystem);
 
     std::size_t numberOfStatesToEliminate = statePriorities->size();
     STORM_LOG_DEBUG("Eliminating " << numberOfStatesToEliminate << " states using the state elimination technique.\n");
@@ -897,19 +891,19 @@ void SparseDtmcEliminationModelChecker<SparseDtmcModelType>::performOrdinaryStat
 
 template<typename SparseDtmcModelType>
 uint_fast64_t SparseDtmcEliminationModelChecker<SparseDtmcModelType>::performHybridStateElimination(
-    storm::storage::SparseMatrix<ValueType> const& forwardTransitions, storm::storage::FlexibleSparseMatrix<ValueType>& transitionMatrix,
+    Environment const& env, storm::storage::SparseMatrix<ValueType> const& forwardTransitions, storm::storage::FlexibleSparseMatrix<ValueType>& transitionMatrix,
     storm::storage::FlexibleSparseMatrix<ValueType>& backwardTransitions, storm::storage::BitVector const& subsystem,
     storm::storage::BitVector const& initialStates, bool computeResultsForInitialStatesOnly, std::vector<ValueType>& values,
     boost::optional<std::vector<uint_fast64_t>> const& distanceBasedPriorities) {
     // When using the hybrid technique, we recursively treat the SCCs up to some size.
     std::vector<storm::storage::sparse::state_type> entryStateQueue;
     STORM_LOG_DEBUG("Eliminating " << subsystem.size() << " states using the hybrid elimination technique.\n");
-    uint_fast64_t maximalDepth = treatScc(transitionMatrix, values, initialStates, subsystem, initialStates, forwardTransitions, backwardTransitions, false, 0,
-                                          storm::settings::getModule<storm::settings::modules::EliminationSettings>().getMaximalSccSize(), entryStateQueue,
-                                          computeResultsForInitialStatesOnly, distanceBasedPriorities);
+    uint_fast64_t maximalDepth = treatScc(env, transitionMatrix, values, initialStates, subsystem, initialStates, forwardTransitions, backwardTransitions,
+                                          false, 0, env.solver().elimination().getMaximalSccSize(), entryStateQueue, computeResultsForInitialStatesOnly,
+                                          distanceBasedPriorities);
 
     // If the entry states were to be eliminated last, we need to do so now.
-    if (storm::settings::getModule<storm::settings::modules::EliminationSettings>().isEliminateEntryStatesLastSet()) {
+    if (env.solver().elimination().isEliminateEntryStatesLastSet()) {
         STORM_LOG_DEBUG("Eliminating " << entryStateQueue.size() << " entry states as a last step.");
         std::vector<storm::storage::sparse::state_type> sortedStates(entryStateQueue.begin(), entryStateQueue.end());
         std::shared_ptr<StatePriorityQueue> queuePriorities = std::make_shared<StaticStatePriorityQueue>(sortedStates);
@@ -921,7 +915,8 @@ uint_fast64_t SparseDtmcEliminationModelChecker<SparseDtmcModelType>::performHyb
 
 template<typename SparseDtmcModelType>
 std::vector<typename SparseDtmcEliminationModelChecker<SparseDtmcModelType>::ValueType>
-SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeReachabilityValues(storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeReachabilityValues(Environment const& env,
+                                                                                  storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                                                   std::vector<ValueType>& values,
                                                                                   storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                                   storm::storage::BitVector const& initialStates,
@@ -931,24 +926,21 @@ SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeReachabilityValue
     storm::storage::FlexibleSparseMatrix<ValueType> flexibleMatrix(transitionMatrix);
     storm::storage::FlexibleSparseMatrix<ValueType> flexibleBackwardTransitions(backwardTransitions);
 
-    storm::settings::modules::EliminationSettings::EliminationOrder order =
-        storm::settings::getModule<storm::settings::modules::EliminationSettings>().getEliminationOrder();
+    EliminationOrder order = env.solver().elimination().getOrder();
     boost::optional<std::vector<uint_fast64_t>> distanceBasedPriorities;
     if (eliminationOrderNeedsDistances(order)) {
-        distanceBasedPriorities = getDistanceBasedPriorities(transitionMatrix, backwardTransitions, initialStates, oneStepProbabilitiesToTarget,
+        distanceBasedPriorities = getDistanceBasedPriorities(order, transitionMatrix, backwardTransitions, initialStates, oneStepProbabilitiesToTarget,
                                                              eliminationOrderNeedsForwardDistances(order), eliminationOrderNeedsReversedDistances(order));
     }
 
     // Create a bit vector that represents the subsystem of states we still have to eliminate.
     storm::storage::BitVector subsystem = storm::storage::BitVector(transitionMatrix.getRowCount(), true);
 
-    if (storm::settings::getModule<storm::settings::modules::EliminationSettings>().getEliminationMethod() ==
-        storm::settings::modules::EliminationSettings::EliminationMethod::State) {
-        performOrdinaryStateElimination(flexibleMatrix, flexibleBackwardTransitions, subsystem, initialStates, computeResultsForInitialStatesOnly, values,
+    if (env.solver().elimination().getMethod() == EliminationMethod::State) {
+        performOrdinaryStateElimination(env, flexibleMatrix, flexibleBackwardTransitions, subsystem, initialStates, computeResultsForInitialStatesOnly, values,
                                         distanceBasedPriorities);
-    } else if (storm::settings::getModule<storm::settings::modules::EliminationSettings>().getEliminationMethod() ==
-               storm::settings::modules::EliminationSettings::EliminationMethod::Hybrid) {
-        uint64_t maximalDepth = performHybridStateElimination(transitionMatrix, flexibleMatrix, flexibleBackwardTransitions, subsystem, initialStates,
+    } else if (env.solver().elimination().getMethod() == EliminationMethod::Hybrid) {
+        uint64_t maximalDepth = performHybridStateElimination(env, transitionMatrix, flexibleMatrix, flexibleBackwardTransitions, subsystem, initialStates,
                                                               computeResultsForInitialStatesOnly, values, distanceBasedPriorities);
         STORM_LOG_TRACE("Maximal depth of decomposition was " << maximalDepth << ".");
     }
@@ -966,7 +958,7 @@ SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeReachabilityValue
 
 template<typename SparseDtmcModelType>
 uint_fast64_t SparseDtmcEliminationModelChecker<SparseDtmcModelType>::treatScc(
-    storm::storage::FlexibleSparseMatrix<ValueType>& matrix, std::vector<ValueType>& values, storm::storage::BitVector const& entryStates,
+    Environment const& env, storm::storage::FlexibleSparseMatrix<ValueType>& matrix, std::vector<ValueType>& values, storm::storage::BitVector const& entryStates,
     storm::storage::BitVector const& scc, storm::storage::BitVector const& initialStates, storm::storage::SparseMatrix<ValueType> const& forwardTransitions,
     storm::storage::FlexibleSparseMatrix<ValueType>& backwardTransitions, bool eliminateEntryStates, uint_fast64_t level, uint_fast64_t maximalSccSize,
     std::vector<storm::storage::sparse::state_type>& entryStateQueue, bool computeResultsForInitialStatesOnly,
@@ -999,7 +991,7 @@ uint_fast64_t SparseDtmcEliminationModelChecker<SparseDtmcModelType>::treatScc(
         }
 
         std::shared_ptr<StatePriorityQueue> statePriorities =
-            createStatePriorityQueue(distanceBasedPriorities, matrix, backwardTransitions, values, statesInTrivialSccs);
+            createStatePriorityQueue(env.solver().elimination().getOrder(), distanceBasedPriorities, matrix, backwardTransitions, values, statesInTrivialSccs);
         STORM_LOG_TRACE("Eliminating " << statePriorities->size() << " trivial SCCs.");
         performPrioritizedStateElimination(statePriorities, matrix, backwardTransitions, values, initialStates, computeResultsForInitialStatesOnly);
         STORM_LOG_TRACE("Eliminated all trivial SCCs.");
@@ -1024,16 +1016,16 @@ uint_fast64_t SparseDtmcEliminationModelChecker<SparseDtmcModelType>::treatScc(
 
             // Recursively descend in SCC-hierarchy.
             uint_fast64_t depth =
-                treatScc(matrix, values, entryStates, newSccAsBitVector, initialStates, forwardTransitions, backwardTransitions,
-                         eliminateEntryStates || !storm::settings::getModule<storm::settings::modules::EliminationSettings>().isEliminateEntryStatesLastSet(),
-                         level + 1, maximalSccSize, entryStateQueue, computeResultsForInitialStatesOnly, distanceBasedPriorities);
+                treatScc(env, matrix, values, entryStates, newSccAsBitVector, initialStates, forwardTransitions, backwardTransitions,
+                         eliminateEntryStates || !env.solver().elimination().isEliminateEntryStatesLastSet(), level + 1, maximalSccSize, entryStateQueue,
+                         computeResultsForInitialStatesOnly, distanceBasedPriorities);
             maximalDepth = std::max(maximalDepth, depth);
         }
     } else {
         // In this case, we perform simple state elimination in the current SCC.
         STORM_LOG_TRACE("SCC of size " << scc.getNumberOfSetBits() << " is small enough to be eliminated directly.");
         std::shared_ptr<StatePriorityQueue> statePriorities =
-            createStatePriorityQueue(distanceBasedPriorities, matrix, backwardTransitions, values, scc & ~entryStates);
+            createStatePriorityQueue(env.solver().elimination().getOrder(), distanceBasedPriorities, matrix, backwardTransitions, values, scc & ~entryStates);
         performPrioritizedStateElimination(statePriorities, matrix, backwardTransitions, values, initialStates, computeResultsForInitialStatesOnly);
         STORM_LOG_TRACE("Eliminated all states of SCC.");
     }

--- a/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.cpp
+++ b/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.cpp
@@ -13,7 +13,7 @@
 #include "storm/modelchecker/results/ExplicitQualitativeCheckResult.h"
 #include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
 #include "storm/settings/SettingsManager.h"
-#include "storm/settings/modules/EliminationSettings.h"
+#include "storm/settings/modules/CoreSettings.h"
 #include "storm/solver/stateelimination/ConditionalStateEliminator.h"
 #include "storm/solver/stateelimination/DynamicStatePriorityQueue.h"
 #include "storm/solver/stateelimination/MultiValueStateEliminator.h"

--- a/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.cpp
+++ b/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.cpp
@@ -462,9 +462,9 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
 
 template<typename SparseDtmcModelType>
 std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeUntilProbabilities(
-    Environment const& env, storm::storage::SparseMatrix<ValueType> const& probabilityMatrix, storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-    storm::storage::BitVector const& initialStates, storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
-    bool computeForInitialStatesOnly) {
+    Environment const& env, storm::storage::SparseMatrix<ValueType> const& probabilityMatrix,
+    storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& initialStates,
+    storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates, bool computeForInitialStatesOnly) {
     // Then, compute the subset of states that has a probability of 0 or 1, respectively.
     std::pair<storm::storage::BitVector, storm::storage::BitVector> statesWithProbability01 =
         storm::utility::graph::performProb01(backwardTransitions, phiStates, psiStates);
@@ -550,9 +550,9 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
 
 template<typename SparseDtmcModelType>
 std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeReachabilityRewards(
-    Environment const& env, storm::storage::SparseMatrix<ValueType> const& probabilityMatrix, storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-    storm::storage::BitVector const& initialStates, storm::storage::BitVector const& targetStates, std::vector<ValueType>& stateRewardValues,
-    bool computeForInitialStatesOnly) {
+    Environment const& env, storm::storage::SparseMatrix<ValueType> const& probabilityMatrix,
+    storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& initialStates,
+    storm::storage::BitVector const& targetStates, std::vector<ValueType>& stateRewardValues, bool computeForInitialStatesOnly) {
     return computeReachabilityRewards(
         env, probabilityMatrix, backwardTransitions, initialStates, targetStates,
         [&](uint_fast64_t numberOfRows, storm::storage::SparseMatrix<ValueType> const&, storm::storage::BitVector const& maybeStates) {
@@ -565,8 +565,9 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
 
 template<typename SparseDtmcModelType>
 std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeReachabilityRewards(
-    Environment const& env, storm::storage::SparseMatrix<ValueType> const& probabilityMatrix, storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-    storm::storage::BitVector const& initialStates, storm::storage::BitVector const& targetStates,
+    Environment const& env, storm::storage::SparseMatrix<ValueType> const& probabilityMatrix,
+    storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& initialStates,
+    storm::storage::BitVector const& targetStates,
     std::function<std::vector<ValueType>(uint_fast64_t, storm::storage::SparseMatrix<ValueType> const&, storm::storage::BitVector const&)> const&
         totalStateRewardVectorGetter,
     bool computeForInitialStatesOnly) {
@@ -877,9 +878,10 @@ void SparseDtmcEliminationModelChecker<SparseDtmcModelType>::performPrioritizedS
 
 template<typename SparseDtmcModelType>
 void SparseDtmcEliminationModelChecker<SparseDtmcModelType>::performOrdinaryStateElimination(
-    Environment const& env, storm::storage::FlexibleSparseMatrix<ValueType>& transitionMatrix, storm::storage::FlexibleSparseMatrix<ValueType>& backwardTransitions,
-    storm::storage::BitVector const& subsystem, storm::storage::BitVector const& initialStates, bool computeResultsForInitialStatesOnly,
-    std::vector<ValueType>& values, boost::optional<std::vector<uint_fast64_t>> const& distanceBasedPriorities) {
+    Environment const& env, storm::storage::FlexibleSparseMatrix<ValueType>& transitionMatrix,
+    storm::storage::FlexibleSparseMatrix<ValueType>& backwardTransitions, storm::storage::BitVector const& subsystem,
+    storm::storage::BitVector const& initialStates, bool computeResultsForInitialStatesOnly, std::vector<ValueType>& values,
+    boost::optional<std::vector<uint_fast64_t>> const& distanceBasedPriorities) {
     std::shared_ptr<StatePriorityQueue> statePriorities =
         createStatePriorityQueue(env.solver().elimination().getOrder(), distanceBasedPriorities, transitionMatrix, backwardTransitions, values, subsystem);
 
@@ -891,16 +893,16 @@ void SparseDtmcEliminationModelChecker<SparseDtmcModelType>::performOrdinaryStat
 
 template<typename SparseDtmcModelType>
 uint_fast64_t SparseDtmcEliminationModelChecker<SparseDtmcModelType>::performHybridStateElimination(
-    Environment const& env, storm::storage::SparseMatrix<ValueType> const& forwardTransitions, storm::storage::FlexibleSparseMatrix<ValueType>& transitionMatrix,
-    storm::storage::FlexibleSparseMatrix<ValueType>& backwardTransitions, storm::storage::BitVector const& subsystem,
-    storm::storage::BitVector const& initialStates, bool computeResultsForInitialStatesOnly, std::vector<ValueType>& values,
-    boost::optional<std::vector<uint_fast64_t>> const& distanceBasedPriorities) {
+    Environment const& env, storm::storage::SparseMatrix<ValueType> const& forwardTransitions,
+    storm::storage::FlexibleSparseMatrix<ValueType>& transitionMatrix, storm::storage::FlexibleSparseMatrix<ValueType>& backwardTransitions,
+    storm::storage::BitVector const& subsystem, storm::storage::BitVector const& initialStates, bool computeResultsForInitialStatesOnly,
+    std::vector<ValueType>& values, boost::optional<std::vector<uint_fast64_t>> const& distanceBasedPriorities) {
     // When using the hybrid technique, we recursively treat the SCCs up to some size.
     std::vector<storm::storage::sparse::state_type> entryStateQueue;
     STORM_LOG_DEBUG("Eliminating " << subsystem.size() << " states using the hybrid elimination technique.\n");
-    uint_fast64_t maximalDepth = treatScc(env, transitionMatrix, values, initialStates, subsystem, initialStates, forwardTransitions, backwardTransitions,
-                                          false, 0, env.solver().elimination().getMaximalSccSize(), entryStateQueue, computeResultsForInitialStatesOnly,
-                                          distanceBasedPriorities);
+    uint_fast64_t maximalDepth =
+        treatScc(env, transitionMatrix, values, initialStates, subsystem, initialStates, forwardTransitions, backwardTransitions, false, 0,
+                 env.solver().elimination().getMaximalSccSize(), entryStateQueue, computeResultsForInitialStatesOnly, distanceBasedPriorities);
 
     // If the entry states were to be eliminated last, we need to do so now.
     if (env.solver().elimination().isEliminateEntryStatesLastSet()) {
@@ -915,13 +917,10 @@ uint_fast64_t SparseDtmcEliminationModelChecker<SparseDtmcModelType>::performHyb
 
 template<typename SparseDtmcModelType>
 std::vector<typename SparseDtmcEliminationModelChecker<SparseDtmcModelType>::ValueType>
-SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeReachabilityValues(Environment const& env,
-                                                                                  storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-                                                                                  std::vector<ValueType>& values,
-                                                                                  storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                                                  storm::storage::BitVector const& initialStates,
-                                                                                  bool computeResultsForInitialStatesOnly,
-                                                                                  std::vector<ValueType> const& oneStepProbabilitiesToTarget) {
+SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeReachabilityValues(
+    Environment const& env, storm::storage::SparseMatrix<ValueType> const& transitionMatrix, std::vector<ValueType>& values,
+    storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& initialStates, bool computeResultsForInitialStatesOnly,
+    std::vector<ValueType> const& oneStepProbabilitiesToTarget) {
     // Then, we convert the reduced matrix to a more flexible format to be able to perform state elimination more easily.
     storm::storage::FlexibleSparseMatrix<ValueType> flexibleMatrix(transitionMatrix);
     storm::storage::FlexibleSparseMatrix<ValueType> flexibleBackwardTransitions(backwardTransitions);
@@ -958,11 +957,11 @@ SparseDtmcEliminationModelChecker<SparseDtmcModelType>::computeReachabilityValue
 
 template<typename SparseDtmcModelType>
 uint_fast64_t SparseDtmcEliminationModelChecker<SparseDtmcModelType>::treatScc(
-    Environment const& env, storm::storage::FlexibleSparseMatrix<ValueType>& matrix, std::vector<ValueType>& values, storm::storage::BitVector const& entryStates,
-    storm::storage::BitVector const& scc, storm::storage::BitVector const& initialStates, storm::storage::SparseMatrix<ValueType> const& forwardTransitions,
-    storm::storage::FlexibleSparseMatrix<ValueType>& backwardTransitions, bool eliminateEntryStates, uint_fast64_t level, uint_fast64_t maximalSccSize,
-    std::vector<storm::storage::sparse::state_type>& entryStateQueue, bool computeResultsForInitialStatesOnly,
-    boost::optional<std::vector<uint_fast64_t>> const& distanceBasedPriorities) {
+    Environment const& env, storm::storage::FlexibleSparseMatrix<ValueType>& matrix, std::vector<ValueType>& values,
+    storm::storage::BitVector const& entryStates, storm::storage::BitVector const& scc, storm::storage::BitVector const& initialStates,
+    storm::storage::SparseMatrix<ValueType> const& forwardTransitions, storm::storage::FlexibleSparseMatrix<ValueType>& backwardTransitions,
+    bool eliminateEntryStates, uint_fast64_t level, uint_fast64_t maximalSccSize, std::vector<storm::storage::sparse::state_type>& entryStateQueue,
+    bool computeResultsForInitialStatesOnly, boost::optional<std::vector<uint_fast64_t>> const& distanceBasedPriorities) {
     uint_fast64_t maximalDepth = level;
 
     // If the SCCs are large enough, we try to split them further.
@@ -1015,10 +1014,9 @@ uint_fast64_t SparseDtmcEliminationModelChecker<SparseDtmcModelType>::treatScc(
             }
 
             // Recursively descend in SCC-hierarchy.
-            uint_fast64_t depth =
-                treatScc(env, matrix, values, entryStates, newSccAsBitVector, initialStates, forwardTransitions, backwardTransitions,
-                         eliminateEntryStates || !env.solver().elimination().isEliminateEntryStatesLastSet(), level + 1, maximalSccSize, entryStateQueue,
-                         computeResultsForInitialStatesOnly, distanceBasedPriorities);
+            uint_fast64_t depth = treatScc(env, matrix, values, entryStates, newSccAsBitVector, initialStates, forwardTransitions, backwardTransitions,
+                                           eliminateEntryStates || !env.solver().elimination().isEliminateEntryStatesLastSet(), level + 1, maximalSccSize,
+                                           entryStateQueue, computeResultsForInitialStatesOnly, distanceBasedPriorities);
             maximalDepth = std::max(maximalDepth, depth);
         }
     } else {

--- a/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.h
+++ b/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.h
@@ -53,8 +53,7 @@ class SparseDtmcEliminationModelChecker : public SparsePropositionalModelChecker
                                                                             CheckTask<storm::logic::StateFormula, SolutionType> const& checkTask) override;
 
     // Static helper methods
-    static std::unique_ptr<CheckResult> computeUntilProbabilities(Environment const& env,
-                                                                  storm::storage::SparseMatrix<ValueType> const& probabilityMatrix,
+    static std::unique_ptr<CheckResult> computeUntilProbabilities(Environment const& env, storm::storage::SparseMatrix<ValueType> const& probabilityMatrix,
                                                                   storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                   storm::storage::BitVector const& initialStates, storm::storage::BitVector const& phiStates,
                                                                   storm::storage::BitVector const& psiStates, bool computeForInitialStatesOnly);
@@ -80,8 +79,7 @@ class SparseDtmcEliminationModelChecker : public SparsePropositionalModelChecker
         bool computeForInitialStatesOnly);
 
     static std::vector<ValueType> computeReachabilityValues(Environment const& env, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-                                                            std::vector<ValueType>& values,
-                                                            storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
+                                                            std::vector<ValueType>& values, storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                             storm::storage::BitVector const& initialStates, bool computeResultsForInitialStatesOnly,
                                                             std::vector<ValueType> const& oneStepProbabilitiesToTarget);
 

--- a/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.h
+++ b/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.h
@@ -53,31 +53,34 @@ class SparseDtmcEliminationModelChecker : public SparsePropositionalModelChecker
                                                                             CheckTask<storm::logic::StateFormula, SolutionType> const& checkTask) override;
 
     // Static helper methods
-    static std::unique_ptr<CheckResult> computeUntilProbabilities(storm::storage::SparseMatrix<ValueType> const& probabilityMatrix,
+    static std::unique_ptr<CheckResult> computeUntilProbabilities(Environment const& env,
+                                                                  storm::storage::SparseMatrix<ValueType> const& probabilityMatrix,
                                                                   storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                   storm::storage::BitVector const& initialStates, storm::storage::BitVector const& phiStates,
                                                                   storm::storage::BitVector const& psiStates, bool computeForInitialStatesOnly);
 
-    static std::unique_ptr<CheckResult> computeReachabilityRewards(storm::storage::SparseMatrix<ValueType> const& probabilityMatrix,
+    static std::unique_ptr<CheckResult> computeReachabilityRewards(Environment const& env, storm::storage::SparseMatrix<ValueType> const& probabilityMatrix,
                                                                    storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                    storm::storage::BitVector const& initialStates,
                                                                    storm::storage::BitVector const& targetStates, std::vector<ValueType>& stateRewardValues,
                                                                    bool computeForInitialStatesOnly);
 
    private:
-    static std::vector<SolutionType> computeLongRunValues(storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+    static std::vector<SolutionType> computeLongRunValues(Environment const& env, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                           storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                           storm::storage::BitVector const& initialStates, storm::storage::BitVector const& maybeStates,
                                                           bool computeResultsForInitialStatesOnly, std::vector<ValueType>& stateValues);
 
     static std::unique_ptr<CheckResult> computeReachabilityRewards(
-        storm::storage::SparseMatrix<ValueType> const& probabilityMatrix, storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-        storm::storage::BitVector const& initialStates, storm::storage::BitVector const& targetStates,
+        Environment const& env, storm::storage::SparseMatrix<ValueType> const& probabilityMatrix,
+        storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& initialStates,
+        storm::storage::BitVector const& targetStates,
         std::function<std::vector<ValueType>(uint_fast64_t, storm::storage::SparseMatrix<ValueType> const&, storm::storage::BitVector const&)> const&
             totalStateRewardVectorGetter,
         bool computeForInitialStatesOnly);
 
-    static std::vector<ValueType> computeReachabilityValues(storm::storage::SparseMatrix<ValueType> const& transitionMatrix, std::vector<ValueType>& values,
+    static std::vector<ValueType> computeReachabilityValues(Environment const& env, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+                                                            std::vector<ValueType>& values,
                                                             storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                             storm::storage::BitVector const& initialStates, bool computeResultsForInitialStatesOnly,
                                                             std::vector<ValueType> const& oneStepProbabilitiesToTarget);
@@ -87,20 +90,20 @@ class SparseDtmcEliminationModelChecker : public SparsePropositionalModelChecker
                                                    storm::storage::FlexibleSparseMatrix<ValueType>& backwardTransitions, std::vector<ValueType>& values,
                                                    storm::storage::BitVector const& initialStates, bool computeResultsForInitialStatesOnly);
 
-    static void performOrdinaryStateElimination(storm::storage::FlexibleSparseMatrix<ValueType>& transitionMatrix,
+    static void performOrdinaryStateElimination(Environment const& env, storm::storage::FlexibleSparseMatrix<ValueType>& transitionMatrix,
                                                 storm::storage::FlexibleSparseMatrix<ValueType>& backwardTransitions,
                                                 storm::storage::BitVector const& subsystem, storm::storage::BitVector const& initialStates,
                                                 bool computeResultsForInitialStatesOnly, std::vector<ValueType>& values,
                                                 boost::optional<std::vector<uint_fast64_t>> const& distanceBasedPriorities);
 
-    static uint_fast64_t performHybridStateElimination(storm::storage::SparseMatrix<ValueType> const& forwardTransitions,
+    static uint_fast64_t performHybridStateElimination(Environment const& env, storm::storage::SparseMatrix<ValueType> const& forwardTransitions,
                                                        storm::storage::FlexibleSparseMatrix<ValueType>& transitionMatrix,
                                                        storm::storage::FlexibleSparseMatrix<ValueType>& backwardTransitions,
                                                        storm::storage::BitVector const& subsystem, storm::storage::BitVector const& initialStates,
                                                        bool computeResultsForInitialStatesOnly, std::vector<ValueType>& values,
                                                        boost::optional<std::vector<uint_fast64_t>> const& distanceBasedPriorities);
 
-    static uint_fast64_t treatScc(storm::storage::FlexibleSparseMatrix<ValueType>& matrix, std::vector<ValueType>& values,
+    static uint_fast64_t treatScc(Environment const& env, storm::storage::FlexibleSparseMatrix<ValueType>& matrix, std::vector<ValueType>& values,
                                   storm::storage::BitVector const& entryStates, storm::storage::BitVector const& scc,
                                   storm::storage::BitVector const& initialStates, storm::storage::SparseMatrix<ValueType> const& forwardTransitions,
                                   storm::storage::FlexibleSparseMatrix<ValueType>& backwardTransitions, bool eliminateEntryStates, uint_fast64_t level,

--- a/src/storm/settings/modules/EliminationSettings.cpp
+++ b/src/storm/settings/modules/EliminationSettings.cpp
@@ -56,35 +56,35 @@ EliminationSettings::EliminationSettings() : ModuleSettings(moduleName) {
                         .build());
 }
 
-EliminationSettings::EliminationMethod EliminationSettings::getEliminationMethod() const {
+storm::solver::stateelimination::EliminationMethod EliminationSettings::getEliminationMethod() const {
     std::string eliminationMethodAsString = this->getOption(eliminationMethodOptionName).getArgumentByName("name").getValueAsString();
     if (eliminationMethodAsString == "state") {
-        return EliminationMethod::State;
+        return storm::solver::stateelimination::EliminationMethod::State;
     } else if (eliminationMethodAsString == "hybrid") {
-        return EliminationMethod::Hybrid;
+        return storm::solver::stateelimination::EliminationMethod::Hybrid;
     } else {
         STORM_LOG_THROW(false, storm::exceptions::IllegalArgumentValueException, "Illegal elimination method selected.");
     }
 }
 
-EliminationSettings::EliminationOrder EliminationSettings::getEliminationOrder() const {
+storm::solver::stateelimination::EliminationOrder EliminationSettings::getEliminationOrder() const {
     std::string eliminationOrderAsString = this->getOption(eliminationOrderOptionName).getArgumentByName("name").getValueAsString();
     if (eliminationOrderAsString == "fw") {
-        return EliminationOrder::Forward;
+        return storm::solver::stateelimination::EliminationOrder::Forward;
     } else if (eliminationOrderAsString == "fwrev") {
-        return EliminationOrder::ForwardReversed;
+        return storm::solver::stateelimination::EliminationOrder::ForwardReversed;
     } else if (eliminationOrderAsString == "bw") {
-        return EliminationOrder::Backward;
+        return storm::solver::stateelimination::EliminationOrder::Backward;
     } else if (eliminationOrderAsString == "bwrev") {
-        return EliminationOrder::BackwardReversed;
+        return storm::solver::stateelimination::EliminationOrder::BackwardReversed;
     } else if (eliminationOrderAsString == "rand") {
-        return EliminationOrder::Random;
+        return storm::solver::stateelimination::EliminationOrder::Random;
     } else if (eliminationOrderAsString == "spen") {
-        return EliminationOrder::StaticPenalty;
+        return storm::solver::stateelimination::EliminationOrder::StaticPenalty;
     } else if (eliminationOrderAsString == "dpen") {
-        return EliminationOrder::DynamicPenalty;
+        return storm::solver::stateelimination::EliminationOrder::DynamicPenalty;
     } else if (eliminationOrderAsString == "regex") {
-        return EliminationOrder::RegularExpression;
+        return storm::solver::stateelimination::EliminationOrder::RegularExpression;
     } else {
         STORM_LOG_THROW(false, storm::exceptions::IllegalArgumentValueException, "Illegal elimination order selected.");
     }

--- a/src/storm/settings/modules/EliminationSettings.h
+++ b/src/storm/settings/modules/EliminationSettings.h
@@ -2,6 +2,9 @@
 
 #include "storm/settings/modules/ModuleSettings.h"
 
+#include "storm/solver/stateelimination/EliminationMethod.h"
+#include "storm/solver/stateelimination/EliminationOrder.h"
+
 namespace storm {
 namespace settings {
 namespace modules {
@@ -12,16 +15,6 @@ namespace modules {
 class EliminationSettings : public ModuleSettings {
    public:
     /*!
-     * An enum that contains all available state elimination orders.
-     */
-    enum class EliminationOrder { Forward, ForwardReversed, Backward, BackwardReversed, Random, StaticPenalty, DynamicPenalty, RegularExpression };
-
-    /*!
-     * An enum that contains all available elimination methods.
-     */
-    enum class EliminationMethod { State, Scc, Hybrid };
-
-    /*!
      * Creates a new set of parametric model checking settings.
      */
     EliminationSettings();
@@ -31,14 +24,14 @@ class EliminationSettings : public ModuleSettings {
      *
      * @return The selected elimination method.
      */
-    EliminationMethod getEliminationMethod() const;
+    storm::solver::stateelimination::EliminationMethod getEliminationMethod() const;
 
     /*!
      * Retrieves the selected elimination order.
      *
      * @return The selected elimination order.
      */
-    EliminationOrder getEliminationOrder() const;
+    storm::solver::stateelimination::EliminationOrder getEliminationOrder() const;
 
     /*!
      * Retrieves whether the option to eliminate entry states in the very end is set.

--- a/src/storm/solver/EliminationLinearEquationSolver.cpp
+++ b/src/storm/solver/EliminationLinearEquationSolver.cpp
@@ -3,20 +3,19 @@
 #include <numeric>
 
 #include "storm/adapters/RationalFunctionAdapter.h"
-#include "storm/settings/SettingsManager.h"
-#include "storm/settings/modules/EliminationSettings.h"
+#include "storm/environment/solver/EliminationSolverEnvironment.h"
+#include "storm/environment/solver/SolverEnvironment.h"
 #include "storm/solver/stateelimination/PrioritizedStateEliminator.h"
+#include "storm/solver/stateelimination/StateEliminationUtility.h"
 #include "storm/solver/stateelimination/StatePriorityQueue.h"
 #include "storm/utility/graph.h"
 #include "storm/utility/macros.h"
-#include "storm/utility/stateelimination.h"
 #include "storm/utility/vector.h"
 
 namespace storm {
 namespace solver {
 
 using namespace stateelimination;
-using namespace storm::utility::stateelimination;
 
 template<typename ValueType>
 EliminationLinearEquationSolver<ValueType>::EliminationLinearEquationSolver() {
@@ -68,21 +67,19 @@ bool EliminationLinearEquationSolver<ValueType>::internalSolveEquations(Environm
 
     boost::optional<std::vector<uint_fast64_t>> distanceBasedPriorities;
 
-    // TODO: get the order from the environment
-    storm::settings::modules::EliminationSettings::EliminationOrder order =
-        storm::settings::getModule<storm::settings::modules::EliminationSettings>().getEliminationOrder();
+    EliminationOrder order = env.solver().elimination().getOrder();
 
     if (eliminationOrderNeedsDistances(order)) {
         // Since we have no initial states at this point, we determine a representative of every BSCC regarding
         // the backward transitions, because this means that every row is reachable from this set of rows, which
         // we require to make sure we cover every row.
         storm::storage::BitVector initialRows = storm::utility::graph::getBsccCover(backwardTransitions);
-        distanceBasedPriorities = getDistanceBasedPriorities(transitionMatrix, backwardTransitions, initialRows, b,
+        distanceBasedPriorities = getDistanceBasedPriorities(order, transitionMatrix, backwardTransitions, initialRows, b,
                                                              eliminationOrderNeedsForwardDistances(order), eliminationOrderNeedsReversedDistances(order));
     }
 
-    std::shared_ptr<StatePriorityQueue> priorityQueue =
-        createStatePriorityQueue<ValueType>(distanceBasedPriorities, flexibleMatrix, flexibleBackwardTransitions, b, storm::storage::BitVector(x.size(), true));
+    std::shared_ptr<StatePriorityQueue> priorityQueue = createStatePriorityQueue<ValueType>(
+        order, distanceBasedPriorities, flexibleMatrix, flexibleBackwardTransitions, b, storm::storage::BitVector(x.size(), true));
 
     // Create a state eliminator to perform the actual elimination.
     PrioritizedStateEliminator<ValueType> eliminator(flexibleMatrix, flexibleBackwardTransitions, priorityQueue, x);

--- a/src/storm/solver/stateelimination/EliminationMethod.h
+++ b/src/storm/solver/stateelimination/EliminationMethod.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace storm {
+namespace solver {
+namespace stateelimination {
+
+/*!
+ * An enum that contains all available elimination methods.
+ */
+enum class EliminationMethod { State, Scc, Hybrid };
+
+}  // namespace stateelimination
+}  // namespace solver
+}  // namespace storm

--- a/src/storm/solver/stateelimination/EliminationOrder.h
+++ b/src/storm/solver/stateelimination/EliminationOrder.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace storm {
+namespace solver {
+namespace stateelimination {
+
+/*!
+ * An enum that contains all available state elimination orders.
+ */
+enum class EliminationOrder { Forward, ForwardReversed, Backward, BackwardReversed, Random, StaticPenalty, DynamicPenalty, RegularExpression };
+
+}  // namespace stateelimination
+}  // namespace solver
+}  // namespace storm

--- a/src/storm/solver/stateelimination/EliminatorBase.cpp
+++ b/src/storm/solver/stateelimination/EliminatorBase.cpp
@@ -2,15 +2,13 @@
 
 #include "storm/adapters/RationalFunctionAdapter.h"
 #include "storm/exceptions/InvalidStateException.h"
+#include "storm/solver/stateelimination/StateEliminationUtility.h"
 #include "storm/utility/constants.h"
 #include "storm/utility/macros.h"
-#include "storm/utility/stateelimination.h"
 
 namespace storm {
 namespace solver {
 namespace stateelimination {
-
-using namespace storm::utility::stateelimination;
 
 template<typename ValueType, ScalingMode Mode>
 EliminatorBase<ValueType, Mode>::EliminatorBase(storm::storage::FlexibleSparseMatrix<ValueType>& matrix,

--- a/src/storm/solver/stateelimination/StateEliminationUtility.cpp
+++ b/src/storm/solver/stateelimination/StateEliminationUtility.cpp
@@ -116,8 +116,7 @@ std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(EliminationOrder co
         } else if (eliminationOrderIsPenaltyBased(order)) {
             std::vector<std::pair<storm::storage::sparse::state_type, uint_fast64_t>> statePenalties(sortedStates.size());
             typename DynamicStatePriorityQueue<ValueType>::PenaltyFunctionType penaltyFunction =
-                order == EliminationOrder::RegularExpression ? computeStatePenaltyRegularExpression<ValueType>
-                                                                                                            : computeStatePenalty<ValueType>;
+                order == EliminationOrder::RegularExpression ? computeStatePenaltyRegularExpression<ValueType> : computeStatePenalty<ValueType>;
             for (uint_fast64_t index = 0; index < sortedStates.size(); ++index) {
                 statePenalties[index] =
                     std::make_pair(sortedStates[index], penaltyFunction(sortedStates[index], transitionMatrix, backwardTransitions, oneStepProbabilities));
@@ -164,9 +163,8 @@ std::vector<uint_fast64_t> getDistanceBasedPriorities(EliminationOrder const& or
         states[index] = index;
     }
 
-    std::vector<uint_fast64_t> distances =
-        getStateDistances(transitionMatrix, transitionMatrixTransposed, initialStates, oneStepProbabilities,
-                          order == EliminationOrder::Forward || order == EliminationOrder::ForwardReversed);
+    std::vector<uint_fast64_t> distances = getStateDistances(transitionMatrix, transitionMatrixTransposed, initialStates, oneStepProbabilities,
+                                                             order == EliminationOrder::Forward || order == EliminationOrder::ForwardReversed);
 
     // In case of the forward or backward ordering, we can sort the states according to the distances.
     if (forward ^ reverse) {

--- a/src/storm/solver/stateelimination/StateEliminationUtility.cpp
+++ b/src/storm/solver/stateelimination/StateEliminationUtility.cpp
@@ -1,11 +1,10 @@
-#include "storm/utility/stateelimination.h"
+#include "storm/solver/stateelimination/StateEliminationUtility.h"
 
 #include <random>
 
 #include "storm/adapters/RationalFunctionAdapter.h"
 #include "storm/exceptions/InvalidSettingsException.h"
 #include "storm/exceptions/InvalidStateException.h"
-#include "storm/settings/SettingsManager.h"
 #include "storm/solver/stateelimination/DynamicStatePriorityQueue.h"
 #include "storm/solver/stateelimination/StatePriorityQueue.h"
 #include "storm/solver/stateelimination/StaticStatePriorityQueue.h"
@@ -16,34 +15,28 @@
 #include "storm/utility/macros.h"
 
 namespace storm {
-namespace utility {
+namespace solver {
 namespace stateelimination {
 
-bool eliminationOrderNeedsDistances(storm::settings::modules::EliminationSettings::EliminationOrder const& order) {
-    return order == storm::settings::modules::EliminationSettings::EliminationOrder::Forward ||
-           order == storm::settings::modules::EliminationSettings::EliminationOrder::ForwardReversed ||
-           order == storm::settings::modules::EliminationSettings::EliminationOrder::Backward ||
-           order == storm::settings::modules::EliminationSettings::EliminationOrder::BackwardReversed;
+bool eliminationOrderNeedsDistances(EliminationOrder const& order) {
+    return order == EliminationOrder::Forward || order == EliminationOrder::ForwardReversed || order == EliminationOrder::Backward ||
+           order == EliminationOrder::BackwardReversed;
 }
 
-bool eliminationOrderNeedsForwardDistances(storm::settings::modules::EliminationSettings::EliminationOrder const& order) {
-    return order == storm::settings::modules::EliminationSettings::EliminationOrder::Forward ||
-           order == storm::settings::modules::EliminationSettings::EliminationOrder::ForwardReversed;
+bool eliminationOrderNeedsForwardDistances(EliminationOrder const& order) {
+    return order == EliminationOrder::Forward || order == EliminationOrder::ForwardReversed;
 }
 
-bool eliminationOrderNeedsReversedDistances(storm::settings::modules::EliminationSettings::EliminationOrder const& order) {
-    return order == storm::settings::modules::EliminationSettings::EliminationOrder::ForwardReversed ||
-           order == storm::settings::modules::EliminationSettings::EliminationOrder::BackwardReversed;
+bool eliminationOrderNeedsReversedDistances(EliminationOrder const& order) {
+    return order == EliminationOrder::ForwardReversed || order == EliminationOrder::BackwardReversed;
 }
 
-bool eliminationOrderIsPenaltyBased(storm::settings::modules::EliminationSettings::EliminationOrder const& order) {
-    return order == storm::settings::modules::EliminationSettings::EliminationOrder::StaticPenalty ||
-           order == storm::settings::modules::EliminationSettings::EliminationOrder::DynamicPenalty ||
-           order == storm::settings::modules::EliminationSettings::EliminationOrder::RegularExpression;
+bool eliminationOrderIsPenaltyBased(EliminationOrder const& order) {
+    return order == EliminationOrder::StaticPenalty || order == EliminationOrder::DynamicPenalty || order == EliminationOrder::RegularExpression;
 }
 
-bool eliminationOrderIsStatic(storm::settings::modules::EliminationSettings::EliminationOrder const& order) {
-    return eliminationOrderNeedsDistances(order) || order == storm::settings::modules::EliminationSettings::EliminationOrder::StaticPenalty;
+bool eliminationOrderIsStatic(EliminationOrder const& order) {
+    return eliminationOrderNeedsDistances(order) || order == EliminationOrder::StaticPenalty;
 }
 
 template<typename ValueType>
@@ -97,19 +90,16 @@ uint_fast64_t computeStatePenaltyRegularExpression(storm::storage::sparse::state
 }
 
 template<typename ValueType>
-std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(boost::optional<std::vector<uint_fast64_t>> const& distanceBasedStatePriorities,
+std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(EliminationOrder const& order,
+                                                             boost::optional<std::vector<uint_fast64_t>> const& distanceBasedStatePriorities,
                                                              storm::storage::FlexibleSparseMatrix<ValueType> const& transitionMatrix,
                                                              storm::storage::FlexibleSparseMatrix<ValueType> const& backwardTransitions,
                                                              std::vector<ValueType> const& oneStepProbabilities, storm::storage::BitVector const& states) {
     STORM_LOG_TRACE("Creating state priority queue for states " << states);
 
-    // Get the settings to customize the priority queue.
-    storm::settings::modules::EliminationSettings::EliminationOrder order =
-        storm::settings::getModule<storm::settings::modules::EliminationSettings>().getEliminationOrder();
-
     std::vector<storm::storage::sparse::state_type> sortedStates(states.begin(), states.end());
 
-    if (order == storm::settings::modules::EliminationSettings::EliminationOrder::Random) {
+    if (order == EliminationOrder::Random) {
         std::random_device randomDevice;
         std::mt19937 generator(randomDevice());
         std::shuffle(sortedStates.begin(), sortedStates.end(), generator);
@@ -126,7 +116,7 @@ std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(boost::optional<std
         } else if (eliminationOrderIsPenaltyBased(order)) {
             std::vector<std::pair<storm::storage::sparse::state_type, uint_fast64_t>> statePenalties(sortedStates.size());
             typename DynamicStatePriorityQueue<ValueType>::PenaltyFunctionType penaltyFunction =
-                order == storm::settings::modules::EliminationSettings::EliminationOrder::RegularExpression ? computeStatePenaltyRegularExpression<ValueType>
+                order == EliminationOrder::RegularExpression ? computeStatePenaltyRegularExpression<ValueType>
                                                                                                             : computeStatePenalty<ValueType>;
             for (uint_fast64_t index = 0; index < sortedStates.size(); ++index) {
                 statePenalties[index] =
@@ -164,7 +154,7 @@ std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(std::vector<storm::
 }
 
 template<typename ValueType>
-std::vector<uint_fast64_t> getDistanceBasedPriorities(storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+std::vector<uint_fast64_t> getDistanceBasedPriorities(EliminationOrder const& order, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                       storm::storage::SparseMatrix<ValueType> const& transitionMatrixTransposed,
                                                       storm::storage::BitVector const& initialStates, std::vector<ValueType> const& oneStepProbabilities,
                                                       bool forward, bool reverse) {
@@ -176,10 +166,7 @@ std::vector<uint_fast64_t> getDistanceBasedPriorities(storm::storage::SparseMatr
 
     std::vector<uint_fast64_t> distances =
         getStateDistances(transitionMatrix, transitionMatrixTransposed, initialStates, oneStepProbabilities,
-                          storm::settings::getModule<storm::settings::modules::EliminationSettings>().getEliminationOrder() ==
-                                  storm::settings::modules::EliminationSettings::EliminationOrder::Forward ||
-                              storm::settings::getModule<storm::settings::modules::EliminationSettings>().getEliminationOrder() ==
-                                  storm::settings::modules::EliminationSettings::EliminationOrder::ForwardReversed);
+                          order == EliminationOrder::Forward || order == EliminationOrder::ForwardReversed);
 
     // In case of the forward or backward ordering, we can sort the states according to the distances.
     if (forward ^ reverse) {
@@ -225,7 +212,8 @@ std::vector<uint_fast64_t> getStateDistances(storm::storage::SparseMatrix<ValueT
 }
 
 template uint_fast64_t estimateComplexity(double const& value);
-template std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(boost::optional<std::vector<uint_fast64_t>> const& distanceBasedStatePriorities,
+template std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(EliminationOrder const& order,
+                                                                      boost::optional<std::vector<uint_fast64_t>> const& distanceBasedStatePriorities,
                                                                       storm::storage::FlexibleSparseMatrix<double> const& transitionMatrix,
                                                                       storm::storage::FlexibleSparseMatrix<double> const& backwardTransitions,
                                                                       std::vector<double> const& oneStepProbabilities, storm::storage::BitVector const& states);
@@ -237,7 +225,7 @@ template uint_fast64_t computeStatePenaltyRegularExpression(storm::storage::spar
                                                             storm::storage::FlexibleSparseMatrix<double> const& transitionMatrix,
                                                             storm::storage::FlexibleSparseMatrix<double> const& backwardTransitions,
                                                             std::vector<double> const& oneStepProbabilities);
-template std::vector<uint_fast64_t> getDistanceBasedPriorities(storm::storage::SparseMatrix<double> const& transitionMatrix,
+template std::vector<uint_fast64_t> getDistanceBasedPriorities(EliminationOrder const& order, storm::storage::SparseMatrix<double> const& transitionMatrix,
                                                                storm::storage::SparseMatrix<double> const& transitionMatrixTransposed,
                                                                storm::storage::BitVector const& initialStates, std::vector<double> const& oneStepProbabilities,
                                                                bool forward, bool reverse);
@@ -247,7 +235,8 @@ template std::vector<uint_fast64_t> getStateDistances(storm::storage::SparseMatr
                                                       bool forward);
 
 template uint_fast64_t estimateComplexity(storm::RationalNumber const& value);
-template std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(boost::optional<std::vector<uint_fast64_t>> const& distanceBasedStatePriorities,
+template std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(EliminationOrder const& order,
+                                                                      boost::optional<std::vector<uint_fast64_t>> const& distanceBasedStatePriorities,
                                                                       storm::storage::FlexibleSparseMatrix<storm::RationalNumber> const& transitionMatrix,
                                                                       storm::storage::FlexibleSparseMatrix<storm::RationalNumber> const& backwardTransitions,
                                                                       std::vector<storm::RationalNumber> const& oneStepProbabilities,
@@ -260,7 +249,8 @@ template uint_fast64_t computeStatePenaltyRegularExpression(storm::storage::spar
                                                             storm::storage::FlexibleSparseMatrix<storm::RationalNumber> const& transitionMatrix,
                                                             storm::storage::FlexibleSparseMatrix<storm::RationalNumber> const& backwardTransitions,
                                                             std::vector<storm::RationalNumber> const& oneStepProbabilities);
-template std::vector<uint_fast64_t> getDistanceBasedPriorities(storm::storage::SparseMatrix<storm::RationalNumber> const& transitionMatrix,
+template std::vector<uint_fast64_t> getDistanceBasedPriorities(EliminationOrder const& order,
+                                                               storm::storage::SparseMatrix<storm::RationalNumber> const& transitionMatrix,
                                                                storm::storage::SparseMatrix<storm::RationalNumber> const& transitionMatrixTransposed,
                                                                storm::storage::BitVector const& initialStates,
                                                                std::vector<storm::RationalNumber> const& oneStepProbabilities, bool forward, bool reverse);
@@ -269,7 +259,8 @@ template std::vector<uint_fast64_t> getStateDistances(storm::storage::SparseMatr
                                                       storm::storage::BitVector const& initialStates,
                                                       std::vector<storm::RationalNumber> const& oneStepProbabilities, bool forward);
 
-template std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(boost::optional<std::vector<uint_fast64_t>> const& distanceBasedStatePriorities,
+template std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(EliminationOrder const& order,
+                                                                      boost::optional<std::vector<uint_fast64_t>> const& distanceBasedStatePriorities,
                                                                       storm::storage::FlexibleSparseMatrix<storm::RationalFunction> const& transitionMatrix,
                                                                       storm::storage::FlexibleSparseMatrix<storm::RationalFunction> const& backwardTransitions,
                                                                       std::vector<storm::RationalFunction> const& oneStepProbabilities,
@@ -282,7 +273,8 @@ template uint_fast64_t computeStatePenaltyRegularExpression(storm::storage::spar
                                                             storm::storage::FlexibleSparseMatrix<storm::RationalFunction> const& transitionMatrix,
                                                             storm::storage::FlexibleSparseMatrix<storm::RationalFunction> const& backwardTransitions,
                                                             std::vector<storm::RationalFunction> const& oneStepProbabilities);
-template std::vector<uint_fast64_t> getDistanceBasedPriorities(storm::storage::SparseMatrix<storm::RationalFunction> const& transitionMatrix,
+template std::vector<uint_fast64_t> getDistanceBasedPriorities(EliminationOrder const& order,
+                                                               storm::storage::SparseMatrix<storm::RationalFunction> const& transitionMatrix,
                                                                storm::storage::SparseMatrix<storm::RationalFunction> const& transitionMatrixTransposed,
                                                                storm::storage::BitVector const& initialStates,
                                                                std::vector<storm::RationalFunction> const& oneStepProbabilities, bool forward, bool reverse);
@@ -291,5 +283,5 @@ template std::vector<uint_fast64_t> getStateDistances(storm::storage::SparseMatr
                                                       storm::storage::BitVector const& initialStates,
                                                       std::vector<storm::RationalFunction> const& oneStepProbabilities, bool forward);
 }  // namespace stateelimination
-}  // namespace utility
+}  // namespace solver
 }  // namespace storm

--- a/src/storm/solver/stateelimination/StateEliminationUtility.h
+++ b/src/storm/solver/stateelimination/StateEliminationUtility.h
@@ -48,8 +48,7 @@ uint_fast64_t computeStatePenaltyRegularExpression(storm::storage::sparse::state
                                                    std::vector<ValueType> const& oneStepProbabilities);
 
 template<typename ValueType>
-std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(EliminationOrder const& order,
-                                                             boost::optional<std::vector<uint_fast64_t>> const& stateDistances,
+std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(EliminationOrder const& order, boost::optional<std::vector<uint_fast64_t>> const& stateDistances,
                                                              storm::storage::FlexibleSparseMatrix<ValueType> const& transitionMatrix,
                                                              storm::storage::FlexibleSparseMatrix<ValueType> const& backwardTransitions,
                                                              std::vector<ValueType> const& oneStepProbabilities, storm::storage::BitVector const& states);

--- a/src/storm/solver/stateelimination/StateEliminationUtility.h
+++ b/src/storm/solver/stateelimination/StateEliminationUtility.h
@@ -5,16 +5,10 @@
 #include <vector>
 
 #include "storm/adapters/RationalFunctionForward.h"
-#include "storm/settings/modules/EliminationSettings.h"
+#include "storm/solver/stateelimination/EliminationOrder.h"
 #include "storm/storage/sparse/StateType.h"
 
 namespace storm {
-namespace solver {
-namespace stateelimination {
-class StatePriorityQueue;
-}
-}  // namespace solver
-
 namespace storage {
 class BitVector;
 
@@ -25,16 +19,16 @@ template<typename ValueType>
 class SparseMatrix;
 }  // namespace storage
 
-namespace utility {
+namespace solver {
 namespace stateelimination {
 
-using namespace storm::solver::stateelimination;
+class StatePriorityQueue;
 
-bool eliminationOrderNeedsDistances(storm::settings::modules::EliminationSettings::EliminationOrder const& order);
-bool eliminationOrderNeedsForwardDistances(storm::settings::modules::EliminationSettings::EliminationOrder const& order);
-bool eliminationOrderNeedsReversedDistances(storm::settings::modules::EliminationSettings::EliminationOrder const& order);
-bool eliminationOrderIsPenaltyBased(storm::settings::modules::EliminationSettings::EliminationOrder const& order);
-bool eliminationOrderIsStatic(storm::settings::modules::EliminationSettings::EliminationOrder const& order);
+bool eliminationOrderNeedsDistances(EliminationOrder const& order);
+bool eliminationOrderNeedsForwardDistances(EliminationOrder const& order);
+bool eliminationOrderNeedsReversedDistances(EliminationOrder const& order);
+bool eliminationOrderIsPenaltyBased(EliminationOrder const& order);
+bool eliminationOrderIsStatic(EliminationOrder const& order);
 
 template<typename ValueType>
 uint_fast64_t estimateComplexity(ValueType const& value);
@@ -54,7 +48,8 @@ uint_fast64_t computeStatePenaltyRegularExpression(storm::storage::sparse::state
                                                    std::vector<ValueType> const& oneStepProbabilities);
 
 template<typename ValueType>
-std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(boost::optional<std::vector<uint_fast64_t>> const& stateDistances,
+std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(EliminationOrder const& order,
+                                                             boost::optional<std::vector<uint_fast64_t>> const& stateDistances,
                                                              storm::storage::FlexibleSparseMatrix<ValueType> const& transitionMatrix,
                                                              storm::storage::FlexibleSparseMatrix<ValueType> const& backwardTransitions,
                                                              std::vector<ValueType> const& oneStepProbabilities, storm::storage::BitVector const& states);
@@ -63,7 +58,7 @@ std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(storm::storage::Bit
 std::shared_ptr<StatePriorityQueue> createStatePriorityQueue(std::vector<storm::storage::sparse::state_type> const& states);
 
 template<typename ValueType>
-std::vector<uint_fast64_t> getDistanceBasedPriorities(storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+std::vector<uint_fast64_t> getDistanceBasedPriorities(EliminationOrder const& order, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                       storm::storage::SparseMatrix<ValueType> const& transitionMatrixTransposed,
                                                       storm::storage::BitVector const& initialStates, std::vector<ValueType> const& oneStepProbabilities,
                                                       bool forward, bool reverse);
@@ -74,5 +69,5 @@ std::vector<uint_fast64_t> getStateDistances(storm::storage::SparseMatrix<ValueT
                                              storm::storage::BitVector const& initialStates, std::vector<ValueType> const& oneStepProbabilities, bool forward);
 
 }  // namespace stateelimination
-}  // namespace utility
+}  // namespace solver
 }  // namespace storm

--- a/src/storm/solver/stateelimination/StateEliminator.cpp
+++ b/src/storm/solver/stateelimination/StateEliminator.cpp
@@ -2,14 +2,12 @@
 
 #include "storm/adapters/RationalFunctionAdapter.h"
 #include "storm/exceptions/IllegalArgumentException.h"
+#include "storm/solver/stateelimination/StateEliminationUtility.h"
 #include "storm/utility/macros.h"
-#include "storm/utility/stateelimination.h"
 
 namespace storm {
 namespace solver {
 namespace stateelimination {
-
-using namespace storm::utility::stateelimination;
 
 template<typename ValueType>
 StateEliminator<ValueType>::StateEliminator(storm::storage::FlexibleSparseMatrix<ValueType>& transitionMatrix,


### PR DESCRIPTION
Moving settings out of the deeper state elim code in favour of an environment. Moved from utility/stateelim to solver/statelim/...

Note that the replacement to an environment is mechanical and could be improved by a more thorough refactoring. 

